### PR TITLE
fix: correct module name

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -17,7 +17,7 @@ managed:
   override:
     - file_option: go_package
       path: a2a.proto
-      value: github.com/a2aproject/a2a/grpc
+      value: github.com/a2aproject/a2a-go/grpc
 
 plugins:
   - remote: buf.build/protocolbuffers/go

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/a2aproject/a2a
+module github.com/a2aproject/a2a-go
 
 go 1.24.4
 

--- a/grpc/a2a.pb.go
+++ b/grpc/a2a.pb.go
@@ -3579,9 +3579,9 @@ const file_a2a_proto_rawDesc = "" +
 	"\x1eListTaskPushNotificationConfig\x12-.a2a.v1.ListTaskPushNotificationConfigRequest\x1a..a2a.v1.ListTaskPushNotificationConfigResponse\"=\xdaA\x06parent\x82\xd3\xe4\x93\x02.\x12,/v1/{parent=tasks/*}/pushNotificationConfigs\x12P\n" +
 	"\fGetAgentCard\x12\x1b.a2a.v1.GetAgentCardRequest\x1a\x11.a2a.v1.AgentCard\"\x10\x82\xd3\xe4\x93\x02\n" +
 	"\x12\b/v1/card\x12\xa8\x01\n" +
-	" DeleteTaskPushNotificationConfig\x12/.a2a.v1.DeleteTaskPushNotificationConfigRequest\x1a\x16.google.protobuf.Empty\";\xdaA\x04name\x82\xd3\xe4\x93\x02.*,/v1/{name=tasks/*/pushNotificationConfigs/*}Bo\n" +
+	" DeleteTaskPushNotificationConfig\x12/.a2a.v1.DeleteTaskPushNotificationConfigRequest\x1a\x16.google.protobuf.Empty\";\xdaA\x04name\x82\xd3\xe4\x93\x02.*,/v1/{name=tasks/*/pushNotificationConfigs/*}Br\n" +
 	"\n" +
-	"com.a2a.v1B\bA2aProtoP\x01Z\x1egithub.com/a2aproject/a2a/grpc\xa2\x02\x03AXX\xaa\x02\x06A2a.V1\xca\x02\x06A2a\\V1\xe2\x02\x12A2a\\V1\\GPBMetadata\xea\x02\aA2a::V1b\x06proto3"
+	"com.a2a.v1B\bA2aProtoP\x01Z!github.com/a2aproject/a2a-go/grpc\xa2\x02\x03AXX\xaa\x02\x06A2a.V1\xca\x02\x06A2a\\V1\xe2\x02\x12A2a\\V1\\GPBMetadata\xea\x02\aA2a::V1b\x06proto3"
 
 var (
 	file_a2a_proto_rawDescOnce sync.Once


### PR DESCRIPTION
Currently, the following error occurs:

```log
go: github.com/a2aproject/a2a-go@v0.0.0-20250723091033-2993b9830c07 found: parsing go.mod:
	module declares its path as: github.com/a2aproject/a2a
	        but was required as: github.com/a2aproject/a2a-go
go: github.com/a2aproject/a2a-go@2993b98 (v0.0.0-20250723091033-2993b9830c07) requires github.com/a2aproject/a2a-go@v0.0.0-20250723091033-2993b9830c07: parsing go.mod:
	module declares its path as: github.com/a2aproject/a2a
	        but was required as: github.com/a2aproject/a2a-go
```

The `github.com/a2aproject/a2a` is actually https://github.com/a2aproject/A2A. Fix to correct module name.