### PR TITLE
chore: ci cleanup and minor improvements

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,6 +14,10 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,13 +28,10 @@ jobs:
       uses: ./.github/actions/setup
 
     - name: Tidy
-      run: |
-        go mod tidy
-        git diff --exit-code go.mod
-        git diff --exit-code go.sum
+      run: go mod tidy -diff
       
     - name: Build
-      run:  go build -mod=readonly -v -trimpath ./...
+      run: go build -mod=readonly -v ./...
 
     - name: Test
       run: go test -mod=readonly -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,8 @@ linters:
       values:
         const:
           COMPANY: The A2A Authors
+        regexp:
+          YEAR: 20\d\d
       template: |-
         Copyright {{ YEAR }} {{ COMPANY }}
         


### PR DESCRIPTION
### Details

* Don't require license year to be 2025
* Remove -trimpath because github actions runner fs path is stable meaning it won't affect build artifact cacheability
* Simplify go mod tidy step
* Introduce pipeline concurrency control policy to cacnel CI runs if commits are pushed in rapid succession