### PR TITLE
feat: result aggregation part 3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.4
 
 require (
 	github.com/google/uuid v1.6.0
+	golang.org/x/sync v0.15.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250715232539-7130f93afb79
 	google.golang.org/grpc v1.73.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ go.opentelemetry.io/otel/trace v1.35.0 h1:dPpEfJu1sDIqruz7BHFG3c7528f6ddfSWfFDVt
 go.opentelemetry.io/otel/trace v1.35.0/go.mod h1:WUk7DtFp1Aw2MkvqGdwiXYDZZNvA/1J8o6xRXLrIkyc=
 golang.org/x/net v0.41.0 h1:vBTly1HeNPEn3wtREYfy4GZ/NECgw2Cnl+nK6Nz3uvw=
 golang.org/x/net v0.41.0/go.mod h1:B/K4NNqkfmg07DQYrbwvSluqCJOOXwUjeb/5lOisjbA=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=

--- a/internal/taskexec/cancelation.go
+++ b/internal/taskexec/cancelation.go
@@ -1,0 +1,83 @@
+// Copyright 2025 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskexec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+)
+
+type cancelation struct {
+	tid      a2a.TaskID
+	canceler Canceler
+	result   *promise
+}
+
+func newCancelation(tid a2a.TaskID, controller Canceler) *cancelation {
+	return &cancelation{
+		tid:      tid,
+		canceler: controller,
+		result:   newPromise(),
+	}
+}
+
+func (c *cancelation) wait(ctx context.Context) (*a2a.Task, error) {
+	result, err := c.result.wait(ctx)
+
+	if err != nil {
+		return nil, fmt.Errorf("cancelation failed: %w", err)
+	}
+
+	task, ok := result.(*a2a.Task)
+	if !ok { // a2a.Message was the result of the execution
+		return nil, a2a.ErrTaskNotCancelable
+	}
+
+	if task.Status.State != a2a.TaskStateCanceled {
+		return nil, a2a.ErrTaskNotCancelable
+	}
+
+	return task, nil
+}
+
+func (c *cancelation) processEvents(ctx context.Context, queue eventqueue.Queue) (a2a.SendMessageResult, error) {
+	eventChan := make(chan a2a.Event)
+	errorChan := make(chan error)
+	go readQueueToChannels(ctx, queue, eventChan, errorChan)
+
+	for {
+		select {
+		case event := <-eventChan:
+			res, err := c.canceler.Process(ctx, event)
+
+			if err != nil {
+				return nil, err
+			}
+
+			if res != nil {
+				return *res, nil
+			}
+
+		case <-ctx.Done():
+			return nil, ctx.Err()
+
+		case err := <-errorChan:
+			return nil, err
+		}
+	}
+}

--- a/internal/taskexec/controller.go
+++ b/internal/taskexec/controller.go
@@ -1,0 +1,43 @@
+// Copyright 2025 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskexec
+
+import (
+	"context"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+)
+
+type Processor interface {
+	// Process is called for each event produced by the started Execution.
+	// Execution finishes when either a non-nil result or a non-nil error is returned.
+	// the terminal value becomes the result of the execution.
+	// Called in a separate goroutine.
+	Process(context.Context, a2a.Event) (*a2a.SendMessageResult, error)
+}
+
+type Executor interface {
+	Processor
+	// Start starts publishing events to the queue. Called in a separate goroutine.
+	Execute(context.Context, eventqueue.Queue) error
+}
+
+type Canceler interface {
+	Processor
+	// Cancel attempts to cancel a Task.
+	// Expected to produce a Task update event with canceled state.
+	Cancel(context.Context, eventqueue.Queue) error
+}

--- a/internal/taskexec/execution.go
+++ b/internal/taskexec/execution.go
@@ -1,0 +1,162 @@
+// Copyright 2025 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskexec
+
+import (
+	"context"
+	"fmt"
+	"iter"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+)
+
+type Execution struct {
+	tid        a2a.TaskID
+	controller Executor
+
+	subscribeChan   chan chan a2a.Event
+	unsubscribeChan chan chan a2a.Event
+
+	result *promise
+}
+
+// Not exported, because Executions are created by Executor.
+func newExecution(tid a2a.TaskID, controller Executor) *Execution {
+	return &Execution{
+		tid:        tid,
+		controller: controller,
+
+		subscribeChan:   make(chan chan a2a.Event),
+		unsubscribeChan: make(chan chan a2a.Event),
+
+		result: newPromise(),
+	}
+}
+
+func (e *Execution) GetEvents(ctx context.Context) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {
+		eventChan, err := e.Subscribe(ctx)
+		if err != nil {
+			yield(nil, fmt.Errorf("failed to subscribe to execution events: %w", err))
+			return
+		}
+
+		stopped := false
+		defer func() {
+			err := e.Unsubscribe(ctx, eventChan)
+			// TODO(yarolegovich): else log
+			if !stopped {
+				yield(nil, err)
+			}
+		}()
+
+		for {
+			select {
+			case <-ctx.Done():
+				stopped = true
+				yield(nil, err)
+				return
+
+			case event, ok := <-eventChan:
+				if !ok {
+					return
+				}
+				if !yield(event, nil) {
+					stopped = true
+					return
+				}
+			}
+		}
+	}
+}
+
+func (e *Execution) Result(ctx context.Context) (a2a.SendMessageResult, error) {
+	return e.result.wait(ctx)
+}
+
+func (e *Execution) Subscribe(ctx context.Context) (chan a2a.Event, error) {
+	ch := make(chan a2a.Event)
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+
+	case e.subscribeChan <- ch:
+		return ch, nil
+
+	case <-e.result.done:
+		close(ch)
+		return ch, nil
+	}
+}
+
+func (e *Execution) Unsubscribe(ctx context.Context, ch chan a2a.Event) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+
+	case e.unsubscribeChan <- ch:
+		return nil
+
+	case <-e.result.done:
+		return nil
+	}
+}
+
+func (e *Execution) processEvents(ctx context.Context, queue eventqueue.Queue) (a2a.SendMessageResult, error) {
+	subscribers := make(map[chan a2a.Event]any)
+
+	defer func() {
+		for sub := range subscribers {
+			close(sub)
+		}
+	}()
+
+	eventChan := make(chan a2a.Event)
+	errorChan := make(chan error)
+	go readQueueToChannels(ctx, queue, eventChan, errorChan)
+
+	for {
+		select {
+		case event := <-eventChan:
+			res, err := e.controller.Process(ctx, event)
+
+			if err != nil {
+				return nil, err
+			}
+
+			for subscriber := range subscribers {
+				subscriber <- event
+			}
+
+			if res != nil {
+				return *res, nil
+			}
+
+		case <-ctx.Done():
+			return nil, ctx.Err()
+
+		case err := <-errorChan:
+			return nil, err
+
+		case s := <-e.subscribeChan:
+			subscribers[s] = struct{}{}
+
+		case s := <-e.unsubscribeChan:
+			delete(subscribers, s)
+		}
+	}
+}

--- a/internal/taskexec/manager.go
+++ b/internal/taskexec/manager.go
@@ -1,0 +1,265 @@
+// Copyright 2025 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskexec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	ErrExecutionInProgress   = errors.New("task execution is already in progress")
+	ErrCancelationInProgress = errors.New("task cancelation is in progress")
+)
+
+// Manager provides an API for executing and canceling tasks in a way that ensures
+// concurrent calls don't interfere with one another in unexpected ways.
+// The following guarantees are provided:
+//   - If a Task is being canceled, a concurrent Execution can't be started.
+//   - If a Task is being canceled, a concurrent cancelation will await the existing cancelation.
+//   - If a Task is being executed, a concurrent cancelation will have the same result as the execution.
+//   - If a Task is being executed, a concurrent execution will be rejected.
+//
+// Both cancelations and executions are started in detached context and run until completion.
+type Manager struct {
+	queueManager eventqueue.Manager
+
+	mu           sync.Mutex
+	executions   map[a2a.TaskID]*Execution
+	cancelations map[a2a.TaskID]*cancelation
+}
+
+func NewManager(queueManager eventqueue.Manager) *Manager {
+	return &Manager{
+		queueManager: queueManager,
+		executions:   make(map[a2a.TaskID]*Execution),
+		cancelations: make(map[a2a.TaskID]*cancelation),
+	}
+}
+
+// GetExecution can be used to resubscribe to events which are being produced by agentExecution.
+func (m *Manager) GetExecution(taskID a2a.TaskID) (*Execution, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	execution, ok := m.executions[taskID]
+	return execution, ok
+}
+
+// Execute starts an AgentExecutor in a separate goroutine with a detached context.
+// There can only be a single active execution per TaskID.
+func (m *Manager) Execute(ctx context.Context, tid a2a.TaskID, executor Executor) (*Execution, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// TODO(yarolegovich): handle idempotency once spec establishes the key. We can return
+	// an execution in progress here and decide whether to tap it or not on the caller side.
+	if _, ok := m.executions[tid]; ok {
+		return nil, ErrExecutionInProgress
+	}
+
+	if _, ok := m.cancelations[tid]; ok {
+		return nil, ErrCancelationInProgress
+	}
+
+	execution := newExecution(tid, executor)
+	m.executions[tid] = execution
+
+	detachedCtx := context.WithoutCancel(ctx)
+
+	go m.handleExecution(detachedCtx, execution)
+
+	return execution, nil
+}
+
+// Cancel uses Canceler to finish execution and waits for it to finish.
+// If there's a cancelation in progress we wait for its result instead of starting a new attempt.
+// If there's an active Execution Canceler will be writing to the same result queue. Consumers
+// subscribed to the Execution will receive a Task cancelation Event.
+// If there's no active Execution Canceler is responsible for processing Task events.
+func (m *Manager) Cancel(ctx context.Context, tid a2a.TaskID, canceler Canceler) (*a2a.Task, error) {
+	m.mu.Lock()
+	execution := m.executions[tid]
+	cancel, cancelInProgress := m.cancelations[tid]
+
+	if cancel == nil {
+		cancel = newCancelation(tid, canceler)
+		m.cancelations[tid] = cancel
+	}
+	m.mu.Unlock()
+
+	if cancelInProgress {
+		return cancel.wait(ctx)
+	}
+
+	detachedCtx := context.WithoutCancel(ctx)
+
+	if execution != nil {
+		go m.handleCancelWithConcurrentRun(detachedCtx, cancel, execution)
+	} else {
+		go m.handleCancel(detachedCtx, cancel)
+	}
+
+	return cancel.wait(ctx)
+}
+
+// Uses an errogroup to start two goroutines.
+// Execution is started in on of them. Another is processing events until a result or error
+// is returned.
+// The returned value is set as Execution result.
+func (m *Manager) handleExecution(ctx context.Context, execution *Execution) {
+	defer func() {
+		m.mu.Lock()
+		delete(m.executions, execution.tid)
+		m.mu.Unlock()
+	}()
+
+	queue, err := m.queueManager.GetOrCreate(ctx, execution.tid)
+	if err != nil {
+		execution.result.reject(fmt.Errorf("queue creation failed: %w", err))
+		return
+	}
+	defer m.destroyQueue(ctx, execution.tid)
+
+	group, ctx := errgroup.WithContext(ctx)
+
+	group.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("task execution panic: %v", r)
+			}
+		}()
+		err = execution.controller.Execute(ctx, queue)
+		return
+	})
+
+	handleEvents(ctx, group, execution.result, func(context.Context) (a2a.SendMessageResult, error) {
+		return execution.processEvents(ctx, queue)
+	})
+}
+
+// Uses an errogroup to start two goroutines.
+// Cancelation is started in on of them. Another is processing events until a result or error
+// is returned.
+// The returned value is set as Cancelation result.
+func (m *Manager) handleCancel(ctx context.Context, cancel *cancelation) {
+	defer func() {
+		m.mu.Lock()
+		delete(m.cancelations, cancel.tid)
+		m.mu.Unlock()
+	}()
+
+	queue, err := m.queueManager.GetOrCreate(ctx, cancel.tid)
+	if err != nil {
+		cancel.result.reject(fmt.Errorf("queue creation failed: %w", err))
+		return
+	}
+	defer m.destroyQueue(ctx, cancel.tid)
+
+	group, ctx := errgroup.WithContext(ctx)
+
+	group.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("task cancelation panic: %v", r)
+			}
+		}()
+		err = cancel.canceler.Cancel(ctx, queue)
+		return
+	})
+
+	handleEvents(ctx, group, cancel.result, func(context.Context) (a2a.SendMessageResult, error) {
+		return cancel.processEvents(ctx, queue)
+	})
+}
+
+// Sends a cancelation request on the queue which is being used by an active execution.
+// Then waits for the execution to complete and resolves cancelation to the same result.
+func (m *Manager) handleCancelWithConcurrentRun(ctx context.Context, cancel *cancelation, run *Execution) {
+	defer func() {
+		if r := recover(); r != nil {
+			cancel.result.reject(fmt.Errorf("task cancelation panic: %v", r))
+		}
+	}()
+
+	defer func() {
+		m.mu.Lock()
+		delete(m.cancelations, cancel.tid)
+		m.mu.Unlock()
+	}()
+
+	queue, err := m.queueManager.GetOrCreate(ctx, cancel.tid)
+	if err != nil {
+		cancel.result.reject(fmt.Errorf("queue creation failed: %w", err))
+		return
+	}
+	defer m.destroyQueue(ctx, cancel.tid)
+
+	if err := cancel.canceler.Cancel(ctx, queue); err != nil {
+		cancel.result.reject(err)
+		return
+	}
+
+	result, err := run.Result(ctx)
+	if err != nil {
+		cancel.result.reject(err)
+		return
+	}
+
+	cancel.result.resolve(result)
+}
+
+type eventHandlerFn func(context.Context) (a2a.SendMessageResult, error)
+
+// Event producer is supposed to be started by the caller.
+// Starts an event-processor goroutine in the provided error group and consumes events
+// until a result is returned.
+// The result is on the provided promise once group.Wait() returns.
+func handleEvents(ctx context.Context, group *errgroup.Group, r *promise, handler eventHandlerFn) {
+	var result *a2a.SendMessageResult
+	group.Go(func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("task event consumer panic: %v", r)
+			}
+		}()
+		localResult, err := handler(ctx)
+		result = &localResult
+		return
+	})
+
+	if err := group.Wait(); err != nil {
+		r.reject(err)
+		return
+	}
+
+	if result == nil {
+		r.reject(fmt.Errorf("bug: no error returned, but result unset"))
+		return
+	}
+
+	r.resolve(*result)
+}
+
+func (m *Manager) destroyQueue(ctx context.Context, tid a2a.TaskID) {
+	// TODO(yarolegovich): log if destroy fails
+	// TODO(yarolegovich): consider not destroying queues until a Task reaches terminal state
+	_ = m.queueManager.Destroy(ctx, tid)
+}

--- a/internal/taskexec/manager_test.go
+++ b/internal/taskexec/manager_test.go
@@ -1,0 +1,528 @@
+// Copyright 2025 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskexec
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+)
+
+func newManager() *Manager {
+	qm := eventqueue.NewInMemoryManager()
+	return NewManager(qm)
+}
+
+type testProcessor struct {
+	callCount         atomic.Int32
+	nextEventTerminal bool
+	processErr        error
+
+	contextCanceled bool
+	block           chan struct{}
+}
+
+func (e *testProcessor) Process(ctx context.Context, event a2a.Event) (*a2a.SendMessageResult, error) {
+	e.callCount.Add(1)
+
+	if e.block != nil {
+		select {
+		case <-e.block:
+		case <-ctx.Done():
+			e.contextCanceled = true
+			return nil, ctx.Err()
+		}
+	}
+
+	if e.processErr != nil {
+		return nil, e.processErr
+	}
+
+	if e.nextEventTerminal {
+		result := event.(a2a.SendMessageResult)
+		return &result, nil
+	}
+
+	return nil, nil
+}
+
+type testExecutor struct {
+	*testProcessor
+
+	executeCalled   chan struct{}
+	executeErr      error
+	queue           eventqueue.Queue
+	contextCanceled bool
+	block           chan struct{}
+}
+
+func newExecutor() *testExecutor {
+	return &testExecutor{executeCalled: make(chan struct{}), testProcessor: &testProcessor{}}
+}
+
+func (e *testExecutor) Execute(ctx context.Context, queue eventqueue.Queue) error {
+	e.queue = queue
+	close(e.executeCalled)
+
+	if e.block != nil {
+		select {
+		case <-e.block:
+		case <-ctx.Done():
+			e.contextCanceled = true
+			return ctx.Err()
+		}
+	}
+
+	return e.executeErr
+}
+
+type testCanceler struct {
+	*testProcessor
+
+	cancelCalled    chan struct{}
+	cancelErr       error
+	queue           eventqueue.Queue
+	contextCanceled bool
+	block           chan struct{}
+}
+
+func newCanceler() *testCanceler {
+	return &testCanceler{cancelCalled: make(chan struct{}), testProcessor: &testProcessor{}}
+}
+
+func (c *testCanceler) Cancel(ctx context.Context, queue eventqueue.Queue) error {
+	c.queue = queue
+	close(c.cancelCalled)
+
+	if c.block != nil {
+		select {
+		case <-c.block:
+		case <-ctx.Done():
+			c.contextCanceled = true
+			return ctx.Err()
+		}
+	}
+
+	return c.cancelErr
+}
+
+func (e *testExecutor) mustWrite(t *testing.T, event a2a.Event) {
+	if err := e.queue.Write(t.Context(), event); err != nil {
+		t.Fatalf("queue Write() failed with: %v", err)
+	}
+}
+
+func (e *testCanceler) mustWrite(t *testing.T, event a2a.Event) {
+	if err := e.queue.Write(t.Context(), event); err != nil {
+		t.Fatalf("queue Write() failed with: %v", err)
+	}
+}
+
+func TestManager_Execute(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	executor := newExecutor()
+	executor.nextEventTerminal = true
+	execution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+
+	<-executor.executeCalled
+	want := &a2a.Task{ID: tid}
+	executor.mustWrite(t, want)
+
+	if got, err := execution.Result(ctx); err != nil || got != want {
+		t.Fatalf("expected Result() to return %v, got %v, %v", want, got, err)
+	}
+}
+
+func TestManager_EventProcessingFailureFailsExecution(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	executor := newExecutor()
+	executor.processErr = errors.New("test error")
+	execution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+
+	<-executor.executeCalled
+	executor.mustWrite(t, &a2a.Task{ID: tid})
+
+	if _, err = execution.Result(ctx); !errors.Is(err, executor.processErr) {
+		t.Fatalf("expected Result() to return %v, got %v", executor.processErr, err)
+	}
+}
+
+func TestManager_ExecuteFailureFailsExecution(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	executor := newExecutor()
+	executor.executeErr = errors.New("test error")
+	execution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+
+	if _, err = execution.Result(ctx); !errors.Is(err, executor.executeErr) {
+		t.Fatalf("expected Result() to return %v, got %v", executor.executeErr, err)
+	}
+}
+
+func TestManager_ExecuteFailureCancelsProcessingContext(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	executor := newExecutor()
+	executor.executeErr = errors.New("test error")
+	executor.block = make(chan struct{})
+	executor.testProcessor.block = make(chan struct{})
+	execution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+
+	<-executor.executeCalled
+	executor.mustWrite(t, &a2a.Task{ID: tid})
+	for executor.testProcessor.callCount.Load() == 0 {
+		time.Sleep(1 * time.Millisecond)
+	}
+	close(executor.block)
+	_, _ = execution.Result(ctx)
+
+	if !executor.testProcessor.contextCanceled {
+		t.Fatalf("expected processing context to be canceled")
+	}
+}
+
+func TestManager_ProcessingFailureCancelsExecuteContext(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	executor := newExecutor()
+	executor.block = make(chan struct{})
+	executor.processErr = errors.New("test error")
+	execution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+
+	<-executor.executeCalled
+	executor.mustWrite(t, &a2a.Task{ID: tid})
+	_, _ = execution.Result(ctx)
+
+	if !executor.contextCanceled {
+		t.Fatalf("expected processing context to be canceled")
+	}
+}
+
+func TestManager_FanOutExecutionEvents(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	executor := newExecutor()
+	execution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+	<-executor.executeCalled
+
+	// subscribe ${consumerCount} consumers to execution events
+	consumerCount := 3
+	var waitSubscribed sync.WaitGroup
+	var waitConsumed sync.WaitGroup
+	var mu sync.Mutex
+	consumed := map[int][]a2a.Event{}
+	for consumerI := range consumerCount {
+		waitSubscribed.Add(1)
+		go func() {
+			sub, _ := execution.Subscribe(t.Context())
+			waitSubscribed.Done()
+			defer func() {
+				if err := execution.Unsubscribe(t.Context(), sub); err != nil {
+					t.Errorf("Unsubscribe() failed with %v", err)
+				}
+			}()
+
+			for event := range sub {
+				mu.Lock()
+				consumed[consumerI] = append(consumed[consumerI], event)
+				mu.Unlock()
+				waitConsumed.Done()
+			}
+		}()
+	}
+	waitSubscribed.Wait()
+
+	// for each produced event wait for all consumers to consume it
+	states := []a2a.TaskState{a2a.TaskStateSubmitted, a2a.TaskStateWorking, a2a.TaskStateCompleted}
+	for i, state := range states {
+		waitConsumed.Add(consumerCount)
+		executor.nextEventTerminal = i == len(states)-1
+		executor.mustWrite(t, &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: state}})
+		waitConsumed.Wait()
+	}
+
+	for i, list := range consumed {
+		if len(list) != len(states) {
+			t.Fatalf("expected %d events, got %d for consumer %d", len(states), len(list), i)
+		}
+		for eventI, event := range list {
+			state := event.(*a2a.Task).Status.State
+			if state != states[eventI] {
+				t.Fatalf("expected event state for consumer %d to be %v, got %v", i, states[eventI], state)
+			}
+		}
+	}
+}
+
+func TestManager_CancelActiveExecution(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	executor := newExecutor()
+	executor.nextEventTerminal = true
+	execution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+	<-executor.executeCalled
+
+	canceler := newCanceler()
+	want := &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCanceled}}
+	go func() {
+		<-canceler.cancelCalled
+		canceler.mustWrite(t, want)
+	}()
+
+	task, err := manager.Cancel(ctx, tid, canceler)
+	if err != nil || task != want {
+		t.Fatalf("expected Cancel() to return %v, got %v, %v", want, task, err)
+	}
+
+	execResult, err := execution.Result(ctx)
+	if err != nil || execResult != want {
+		t.Fatalf("expected execution result to be %v, got %v, %v", want, execResult, err)
+	}
+}
+
+func TestManager_CancelWithoutActiveExecution(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	canceler := newCanceler()
+	canceler.nextEventTerminal = true
+	want := &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCanceled}}
+	go func() {
+		<-canceler.cancelCalled
+		canceler.mustWrite(t, want)
+	}()
+
+	task, err := manager.Cancel(ctx, tid, canceler)
+	if err != nil || task != want {
+		t.Fatalf("expected Cancel() to return %v, got %v, %v", want, task, err)
+	}
+}
+
+func TestManager_ConcurrentExecutionCompletesBeforeCancel(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	executor := newExecutor()
+	executor.nextEventTerminal = true
+	execution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+	<-executor.executeCalled
+
+	canceler := newCanceler()
+	canceler.block = make(chan struct{})
+	cancelErr := make(chan error)
+	go func() {
+		task, err := manager.Cancel(ctx, tid, canceler)
+		if task != nil || err == nil {
+			t.Errorf("expected Cancel() to fail, got %v, %v", task, err)
+		}
+		cancelErr <- err
+	}()
+	<-canceler.cancelCalled
+
+	executor.mustWrite(t, &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}})
+	_, _ = execution.Result(ctx)
+	close(canceler.block)
+
+	if got := <-cancelErr; !errors.Is(got, a2a.ErrTaskNotCancelable) {
+		t.Fatalf("expected Cancel() to fail with %v, got %v", a2a.ErrTaskNotCancelable, got)
+	}
+}
+
+func TestManager_ConcurrentCancelationsResolveToTheSameResult(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	results := make(chan *a2a.Task, 2)
+
+	canceler1 := newCanceler()
+	canceler1.nextEventTerminal = true
+	canceler1.block = make(chan struct{})
+	go func() {
+		task, err := manager.Cancel(ctx, tid, canceler1)
+		if err != nil {
+			t.Errorf("Cancel() failed: %v", err)
+		}
+		results <- task
+		wg.Done()
+	}()
+	<-canceler1.cancelCalled
+
+	canceler2 := newCanceler()
+	canceler2.cancelErr = errors.New("test error") // this should never be returned
+	ready := make(chan struct{})
+	go func() {
+		close(ready)
+		task, err := manager.Cancel(ctx, tid, canceler2)
+		if err != nil {
+			t.Errorf("Cancel() failed: %v", err)
+		}
+		results <- task
+		wg.Done()
+	}()
+	<-ready
+
+	close(canceler1.block)
+	want := &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCanceled}}
+	canceler1.mustWrite(t, want)
+	wg.Wait()
+
+	t1, t2 := <-results, <-results
+	if t1 != want || t2 != want {
+		t.Fatalf("expected task to be %v, got [%v, %v]", want, t1, t2)
+	}
+}
+
+func TestManager_NotAllowedToExecuteWhileCanceling(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	canceler := newCanceler()
+	canceler.block = make(chan struct{})
+	canceler.cancelErr = errors.New("test error")
+	done := make(chan struct{})
+	go func() {
+		_, _ = manager.Cancel(ctx, tid, canceler)
+		close(done)
+	}()
+	<-canceler.cancelCalled
+
+	execution, err := manager.Execute(ctx, tid, newExecutor())
+	if execution != nil || !errors.Is(err, ErrCancelationInProgress) {
+		t.Fatalf("expected Execute() to fail with %v, got %v, %v", ErrCancelationInProgress, execution, err)
+	}
+
+	close(canceler.block)
+	<-done
+}
+
+func TestManager_CanExecuteAfterCancelFailed(t *testing.T) {
+	t.Parallel()
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	// First cancelation fails
+	canceler := newCanceler()
+	canceler.cancelErr = errors.New("test error")
+	if _, err := manager.Cancel(ctx, tid, canceler); err == nil {
+		t.Fatalf("expected Cancel() to fail, got %v", err)
+	}
+
+	executor := newExecutor()
+	executor.nextEventTerminal = true
+	execution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+
+	<-executor.executeCalled
+	executor.mustWrite(t, &a2a.Task{ID: tid})
+
+	if _, err := execution.Result(ctx); err != nil {
+		t.Fatalf("Result() failed: %v", err)
+	}
+}
+
+func TestManager_CanCancelAfterCancelFailed(t *testing.T) {
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	// First cancelation fails
+	canceler := newCanceler()
+	canceler.cancelErr = errors.New("test error")
+	if task, err := manager.Cancel(ctx, tid, canceler); err == nil {
+		t.Fatalf("expected Cancel() to fail, got %v", task)
+	}
+
+	// Second cancelation succeeds
+	canceler = newCanceler()
+	canceler.nextEventTerminal = true
+	go func() {
+		<-canceler.cancelCalled
+		canceler.mustWrite(t, &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCanceled}})
+	}()
+
+	if _, err := manager.Cancel(ctx, tid, canceler); err != nil {
+		t.Errorf("expected Cancel() to succeed, got %v", err)
+	}
+}
+
+func TestManager_GetExecution(t *testing.T) {
+	ctx, tid, manager := t.Context(), a2a.NewTaskID(), newManager()
+
+	executor := newExecutor()
+	executor.nextEventTerminal = true
+	startedExecution, err := manager.Execute(ctx, tid, executor)
+	if err != nil {
+		t.Fatalf("Execute() failed: %v", err)
+	}
+
+	execution, ok := manager.GetExecution(tid)
+	if !ok || execution != startedExecution {
+		t.Fatalf("expected active execution, got %v, %v", ok, execution)
+	}
+
+	execution, ok = manager.GetExecution(tid + "-2")
+	if ok || execution != nil {
+		t.Fatalf("expected no execution for fake id, got %v, %v", ok, execution)
+	}
+
+	<-executor.executeCalled
+	executor.mustWrite(t, &a2a.Task{ID: tid})
+	_, _ = startedExecution.Result(ctx)
+
+	execution, ok = manager.GetExecution(tid)
+	if ok || execution != nil {
+		t.Fatalf("expected finished execution to be removed, got %v, %v", ok, execution)
+	}
+}

--- a/internal/taskexec/promise.go
+++ b/internal/taskexec/promise.go
@@ -1,0 +1,51 @@
+// Copyright 2025 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskexec
+
+import (
+	"context"
+
+	"github.com/a2aproject/a2a-go/a2a"
+)
+
+type promise struct {
+	// done channel gets closed once value or err field is set
+	done  chan struct{}
+	value a2a.SendMessageResult
+	err   error
+}
+
+func newPromise() *promise {
+	return &promise{done: make(chan struct{})}
+}
+
+func (p *promise) resolve(value a2a.SendMessageResult) {
+	p.value = value
+	close(p.done)
+}
+
+func (p *promise) reject(err error) {
+	p.err = err
+	close(p.done)
+}
+
+func (r *promise) wait(ctx context.Context) (a2a.SendMessageResult, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-r.done:
+		return r.value, r.err
+	}
+}

--- a/internal/taskexec/util.go
+++ b/internal/taskexec/util.go
@@ -1,0 +1,41 @@
+// Copyright 2025 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskexec
+
+import (
+	"context"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+)
+
+func readQueueToChannels(ctx context.Context, queue eventqueue.Reader, eventChan chan a2a.Event, errorChan chan error) {
+	for {
+		event, err := queue.Read(ctx)
+		if err != nil {
+			select {
+			case errorChan <- err:
+			case <-ctx.Done():
+			}
+			return
+		}
+
+		select {
+		case eventChan <- event:
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/internal/taskexec/util_test.go
+++ b/internal/taskexec/util_test.go
@@ -1,0 +1,131 @@
+// Copyright 2025 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package taskexec
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/a2a"
+)
+
+type testQueue struct {
+	events chan a2a.Event
+	err    chan error
+}
+
+func (q *testQueue) Read(ctx context.Context) (a2a.Event, error) {
+	select {
+	case e := <-q.events:
+		return e, nil
+	case err := <-q.err:
+		return nil, err
+	}
+}
+
+func newTestQueue() *testQueue {
+	return &testQueue{events: make(chan a2a.Event), err: make(chan error)}
+}
+
+func makeUnbufferedChannels() (chan a2a.Event, chan error) {
+	eventChan := make(chan a2a.Event)
+	errorChan := make(chan error)
+	return eventChan, errorChan
+}
+
+func TestReadQueueToChannels_WriteMultipleEvents(t *testing.T) {
+	eventChan, errChan := makeUnbufferedChannels()
+	queue := newTestQueue()
+
+	ctx, cancelCtx := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		readQueueToChannels(ctx, queue, eventChan, errChan)
+		close(done)
+	}()
+	read := []*a2a.Task{}
+	send := []*a2a.Task{{ID: "1"}, {ID: "2"}, {ID: "3"}}
+	for _, event := range send {
+		queue.events <- event
+		read = append(read, (<-eventChan).(*a2a.Task))
+	}
+	queue.err <- fmt.Errorf("failed")
+	cancelCtx()
+	<-done
+
+	for i, sent := range send {
+		if sent.ID != read[i].ID {
+			t.Fatalf("expected ID at %d to be %s, got %s", i, sent.ID, read[i].ID)
+		}
+	}
+}
+
+func TestReadQueueToChannels_StopsWhenReadFails(t *testing.T) {
+	eventChan, errChan := makeUnbufferedChannels()
+	queue := newTestQueue()
+
+	done := make(chan struct{})
+	go func() {
+		readQueueToChannels(t.Context(), queue, eventChan, errChan)
+		close(done)
+	}()
+
+	wantErr := errors.New("read failure")
+	queue.err <- wantErr
+	gotErr := <-errChan
+	<-done
+
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("expected read to fail with %v, got %v", wantErr, gotErr)
+	}
+}
+
+func TestReadQueueToChannels_StopsEventWriteWhenContextCanceled(t *testing.T) {
+	eventChan, errChan := makeUnbufferedChannels()
+	queue := newTestQueue()
+
+	ctx, cancelCtx := context.WithCancel(t.Context())
+
+	done := make(chan struct{})
+	go func() {
+		readQueueToChannels(ctx, queue, eventChan, errChan)
+		close(done)
+	}()
+	queue.events <- &a2a.Task{}
+	cancelCtx()
+	<-done
+
+	// Expect readQueueToChannels exits without eventChan reader
+}
+
+func TestReadQueueToChannels_StopsErrorWriteWhenContextCanceled(t *testing.T) {
+	eventChan, errChan := makeUnbufferedChannels()
+	queue := newTestQueue()
+
+	ctx, cancelCtx := context.WithCancel(t.Context())
+
+	done := make(chan struct{})
+	go func() {
+		readQueueToChannels(ctx, queue, eventChan, errChan)
+		close(done)
+	}()
+	queue.err <- errors.New("failed")
+	cancelCtx()
+	<-done
+
+	// Expect readQueueToChannels exist without errChan reader
+}


### PR DESCRIPTION
[Main PR](https://github.com/a2aproject/a2a-go/pull/36)

#### `internal/taskexec` package

Exports `taskexec.Manager` and `taskexec.Execution`. 

`taskexec.Execution` allows package users to subscribe to `Execution` events and await the `Execution` result.

`taskexec.Manager` exports `GetExecution`, `Execute` and `Cancel` methods and ensures predictable behavior in case of task-level-concurrent executions and cancellations.

The package is only concerned with concurrency management and delegate Execution event handling to `Executor` and `Canceler` interfaces.

Methods have the following semantics:
* Concurrent executions are not allowed. Once idempotency key proposal gets accepted we'll be able to handle it gracefully.
* If there's an execution in progress, cancelation is best-effort. It sends a cancelation signal and taps into the active execution event processing. It resolves to an ErrTaskNotCancelable if the execution completes before.
* If there's a cancelation in progress, new executions fail.
* If there's a cancelation in progress, another cancel call will tap into the same result.

Implementation details:
* `Manager` maintains a map from taskID to executions and cancellations guarded with a mutex.
* `Execution` has a `done` channel which gets closed once either result or error field is set.
* `Execution` has two channels for subscriber channels which allows new request scopes to subscribe to active execution events. 
* `cancelation` is similar to `Execution` but is not exported and doesn't provide event subscriptions.
* Both `Execution` and `cancelation` run in separate goroutines with detached context.
* For `Execution` in `Manager` two goroutines are started in an `errgroup`. One calls `Execute` which starts producing event and writing them to the queue. Another one reads events in a loop, passes them through `Processor` which is responsible for deciding when to stop, and notifies subscribers. 
* For `cancelation` in `Manager` the handling is different depending on whether there's a concurrent `Execution` or not.
* If there's a concurrent `Execution` we only call `Cancel` passing in the same queue that `Execution` uses and await the execution result where event processing go-routine is reading from the queue.
* If there's no concurrent `Execution` during `cancelation` then the mechanism is the same as for `Execution`: two goroutines in `errgroup`. 

#### `a2asrv` changes

Ties all the internal packages together.

`DefaultRequestHandler` uses `taskexec.Manager` for handling new messages, task cancellations and client re-subscriptions.

`executor` implements `taskexec.Executor` by delegating `Execute()` to `AgentExecutor` and event processing to `taskupdate.Manager`. 
`executor` contains the logic used to determine when we should stop consuming the event stream. 
When push notification functionality is implemented it will sit there as well.

`canceler` implements `taskexec.Executor` by delegating `Cancel()` to `AgentExecutor` and shares event processing implementation with `executor` through `processor` embedding.

#### Goroutine interactions

<img width="976" height="584" alt="image" src="https://github.com/user-attachments/assets/c741d425-4b43-4a07-a1e0-ea5f072ccbfd" />

<details>

https://www.mermaidflow.app/editor

```
sequenceDiagram
    participant C as Client
    participant EM as taskexec.Manager
    participant EG as ExecutionGoroutine
    participant AEG as AgentExecuteGoroutine
    participant EQ as EventQueue
    participant EHG as EventHandlerGoroutine
    participant P as Processor

    C->>+EM: Execute(Processor)
    EM->>+EG: start in detached ctx
    EM-->>-C: return execution

    EG->>AEG: start in errgroup
    EG->>EHG: start in errgroup

    C-->>EHG: join with execution.subscribe()

    loop Event Processing
        AEG->>EQ: Write
        EHG->>EQ: Read
        EHG->>P: Invoke
        EHG-->>C: Notify through subscribed channel
    end

    EHG->>EG: complete
    EG-->>-EM: unregister self
    EHG-->>C: result delivered through agentExecution.wait()
```
</details>
