### PR TITLE
chore: improve value vs pointer type consistency

### DIFF
--- a/a2a/core.go
+++ b/a2a/core.go
@@ -95,7 +95,7 @@ func NewMessage(role MessageRole, parts ...Part) *Message {
 }
 
 // NewMessageForTask creates a new message with a random identifier that references the provided Task.
-func NewMessageForTask(role MessageRole, task Task, parts ...Part) *Message {
+func NewMessageForTask(role MessageRole, task *Task, parts ...Part) *Message {
 	return &Message{
 		ID:        NewMessageID(),
 		Role:      role,
@@ -229,7 +229,7 @@ type TaskArtifactUpdateEvent struct {
 }
 
 // NewArtifactEvent create a TaskArtifactUpdateEvent for an Artifact with a random ID.
-func NewArtifactEvent(task Task, parts ...Part) *TaskArtifactUpdateEvent {
+func NewArtifactEvent(task *Task, parts ...Part) *TaskArtifactUpdateEvent {
 	return &TaskArtifactUpdateEvent{
 		ContextID: task.ContextID,
 		TaskID:    task.ID,
@@ -241,7 +241,7 @@ func NewArtifactEvent(task Task, parts ...Part) *TaskArtifactUpdateEvent {
 }
 
 // NewArtifactUpdateEvent creates a TaskArtifactUpdateEvent that represents an update of the artifact with the provided ID.
-func NewArtifactUpdateEvent(task Task, id ArtifactID, parts ...Part) *TaskArtifactUpdateEvent {
+func NewArtifactUpdateEvent(task *Task, id ArtifactID, parts ...Part) *TaskArtifactUpdateEvent {
 	return &TaskArtifactUpdateEvent{
 		ContextID: task.ContextID,
 		TaskID:    task.ID,
@@ -531,7 +531,7 @@ type MessageSendParams struct {
 	Config *MessageSendConfig `json:"configuration,omitempty" yaml:"configuration,omitempty" mapstructure:"configuration,omitempty"`
 
 	// Message is the message object being sent to the agent.
-	Message Message `json:"message" yaml:"message" mapstructure:"message"`
+	Message *Message `json:"message" yaml:"message" mapstructure:"message"`
 
 	// Metadata is an optional metadata for extensions.
 	Metadata map[string]any `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata,omitempty"`

--- a/a2aclient/grpc.go
+++ b/a2aclient/grpc.go
@@ -55,43 +55,42 @@ type grpcTransport struct {
 
 // A2A protocol methods
 
-func (c *grpcTransport) GetTask(ctx context.Context, query a2a.TaskQueryParams) (*a2a.Task, error) {
+func (c *grpcTransport) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error) {
 	return &a2a.Task{}, ErrNotImplemented
 }
 
-func (c *grpcTransport) CancelTask(ctx context.Context, id a2a.TaskIDParams) (*a2a.Task, error) {
+func (c *grpcTransport) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
 	return &a2a.Task{}, ErrNotImplemented
 }
 
-func (c *grpcTransport) SendMessage(ctx context.Context, message a2a.MessageSendParams) (a2a.SendMessageResult, error) {
+func (c *grpcTransport) SendMessage(ctx context.Context, message *a2a.MessageSendParams) (a2a.SendMessageResult, error) {
 	return &a2a.Task{}, ErrNotImplemented
 }
 
-func (c *grpcTransport) ResubscribeToTask(ctx context.Context, id a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
+func (c *grpcTransport) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
 		yield(&a2a.Message{}, ErrNotImplemented)
 	}
 }
 
-func (c *grpcTransport) SendStreamingMessage(ctx context.Context, message a2a.MessageSendParams) iter.Seq2[a2a.Event, error] {
+func (c *grpcTransport) SendStreamingMessage(ctx context.Context, message *a2a.MessageSendParams) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
-		yield(&a2a.Message{}, ErrNotImplemented)
 	}
 }
 
-func (c *grpcTransport) GetTaskPushConfig(ctx context.Context, params a2a.GetTaskPushConfigParams) (a2a.TaskPushConfig, error) {
-	return a2a.TaskPushConfig{}, ErrNotImplemented
+func (c *grpcTransport) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushConfigParams) (*a2a.TaskPushConfig, error) {
+	return &a2a.TaskPushConfig{}, ErrNotImplemented
 }
 
-func (c *grpcTransport) ListTaskPushConfig(ctx context.Context, params a2a.ListTaskPushConfigParams) ([]a2a.TaskPushConfig, error) {
-	return []a2a.TaskPushConfig{}, ErrNotImplemented
+func (c *grpcTransport) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error) {
+	return []*a2a.TaskPushConfig{}, ErrNotImplemented
 }
 
-func (c *grpcTransport) SetTaskPushConfig(ctx context.Context, params a2a.TaskPushConfig) (a2a.TaskPushConfig, error) {
-	return a2a.TaskPushConfig{}, ErrNotImplemented
+func (c *grpcTransport) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error) {
+	return &a2a.TaskPushConfig{}, ErrNotImplemented
 }
 
-func (c *grpcTransport) DeleteTaskPushConfig(ctx context.Context, params a2a.DeleteTaskPushConfigParams) error {
+func (c *grpcTransport) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error {
 	return ErrNotImplemented
 }
 

--- a/a2aclient/transport.go
+++ b/a2aclient/transport.go
@@ -24,31 +24,31 @@ import (
 // A2AClient defines a transport-agnostic interface for making A2A requests.
 type Transport interface {
 	// GetTask calls the 'tasks/get' protocol method.
-	GetTask(ctx context.Context, query a2a.TaskQueryParams) (*a2a.Task, error)
+	GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error)
 
 	// CancelTask calls the 'tasks/cancel' protocol method.
-	CancelTask(ctx context.Context, id a2a.TaskIDParams) (*a2a.Task, error)
+	CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error)
 
 	// SendMessage calls the 'message/send' protocol method (non-streaming).
-	SendMessage(ctx context.Context, message a2a.MessageSendParams) (a2a.SendMessageResult, error)
+	SendMessage(ctx context.Context, message *a2a.MessageSendParams) (a2a.SendMessageResult, error)
 
 	// ResubscribeToTask calls the `tasks/resubscribe` protocol method.
-	ResubscribeToTask(ctx context.Context, id a2a.TaskIDParams) iter.Seq2[a2a.Event, error]
+	ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) iter.Seq2[a2a.Event, error]
 
 	// SendStreamingMessage calls the 'message/stream' protocol method (streaming).
-	SendStreamingMessage(ctx context.Context, message a2a.MessageSendParams) iter.Seq2[a2a.Event, error]
+	SendStreamingMessage(ctx context.Context, message *a2a.MessageSendParams) iter.Seq2[a2a.Event, error]
 
 	// GetTaskPushNotificationConfig calls the `tasks/pushNotificationConfig/get` protocol method.
-	GetTaskPushConfig(ctx context.Context, params a2a.GetTaskPushConfigParams) (a2a.TaskPushConfig, error)
+	GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushConfigParams) (*a2a.TaskPushConfig, error)
 
 	// ListTaskPushNotificationConfig calls the `tasks/pushNotificationConfig/list` protocol method.
-	ListTaskPushConfig(ctx context.Context, params a2a.ListTaskPushConfigParams) ([]a2a.TaskPushConfig, error)
+	ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error)
 
 	// SetTaskPushConfig calls the `tasks/pushNotificationConfig/set` protocol method.
-	SetTaskPushConfig(ctx context.Context, params a2a.TaskPushConfig) (a2a.TaskPushConfig, error)
+	SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error)
 
 	// DeleteTaskPushNotificationConfig calls the `tasks/pushNotificationConfig/delete` protocol method.
-	DeleteTaskPushConfig(ctx context.Context, params a2a.DeleteTaskPushConfigParams) error
+	DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error
 
 	// GetAgentCard resolves the AgentCard.
 	// If extended card is supported calls the 'agent/getAuthenticatedExtendedCard' protocol method.
@@ -68,4 +68,54 @@ type TransportFactoryFn func(ctx context.Context, url string, card *a2a.AgentCar
 
 func (fn TransportFactoryFn) Create(ctx context.Context, url string, card *a2a.AgentCard) (Transport, error) {
 	return fn(ctx, url, card)
+}
+
+type UnimplementedTransport struct{}
+
+func (UnimplementedTransport) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error) {
+	return nil, ErrNotImplemented
+}
+
+func (UnimplementedTransport) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
+	return nil, ErrNotImplemented
+}
+
+func (UnimplementedTransport) SendMessage(ctx context.Context, message *a2a.MessageSendParams) (a2a.SendMessageResult, error) {
+	return nil, ErrNotImplemented
+}
+
+func (UnimplementedTransport) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {
+		yield(nil, ErrNotImplemented)
+	}
+}
+
+func (UnimplementedTransport) SendStreamingMessage(ctx context.Context, message *a2a.MessageSendParams) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {
+		yield(nil, ErrNotImplemented)
+	}
+}
+
+func (UnimplementedTransport) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushConfigParams) (*a2a.TaskPushConfig, error) {
+	return nil, ErrNotImplemented
+}
+
+func (UnimplementedTransport) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error) {
+	return nil, ErrNotImplemented
+}
+
+func (UnimplementedTransport) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error) {
+	return nil, ErrNotImplemented
+}
+
+func (UnimplementedTransport) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error {
+	return ErrNotImplemented
+}
+
+func (UnimplementedTransport) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
+	return nil, ErrNotImplemented
+}
+
+func (UnimplementedTransport) Destroy() error {
+	return nil
 }

--- a/a2agrpc/handler.go
+++ b/a2agrpc/handler.go
@@ -102,7 +102,7 @@ func (h *GRPCHandler) GetTask(ctx context.Context, req *a2apb.GetTaskRequest) (*
 	if err != nil {
 		return nil, toGRPCError(err)
 	}
-	result, err := pbconv.ToProtoTask(&task)
+	result, err := pbconv.ToProtoTask(task)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to convert task: %v", err)
 	}
@@ -114,11 +114,11 @@ func (h *GRPCHandler) CancelTask(ctx context.Context, req *a2apb.CancelTaskReque
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to extract task id: %v", err)
 	}
-	task, err := h.handler.OnCancelTask(ctx, a2a.TaskIDParams{ID: taskID})
+	task, err := h.handler.OnCancelTask(ctx, &a2a.TaskIDParams{ID: taskID})
 	if err != nil {
 		return nil, toGRPCError(err)
 	}
-	result, err := pbconv.ToProtoTask(&task)
+	result, err := pbconv.ToProtoTask(task)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to convert task: %v", err)
 	}
@@ -130,7 +130,7 @@ func (h *GRPCHandler) TaskSubscription(req *a2apb.TaskSubscriptionRequest, strea
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "failed to extract task id: %v", err)
 	}
-	for event, err := range h.handler.OnResubscribeToTask(stream.Context(), a2a.TaskIDParams{ID: taskID}) {
+	for event, err := range h.handler.OnResubscribeToTask(stream.Context(), &a2a.TaskIDParams{ID: taskID}) {
 		if err != nil {
 			return toGRPCError(err)
 		}
@@ -155,7 +155,7 @@ func (h *GRPCHandler) CreateTaskPushNotificationConfig(ctx context.Context, req 
 	if err != nil {
 		return nil, toGRPCError(err)
 	}
-	result, err := pbconv.ToProtoTaskPushConfig(&config)
+	result, err := pbconv.ToProtoTaskPushConfig(config)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to convert push config: %v", err)
 	}
@@ -171,7 +171,7 @@ func (h *GRPCHandler) GetTaskPushNotificationConfig(ctx context.Context, req *a2
 	if err != nil {
 		return nil, toGRPCError(err)
 	}
-	result, err := pbconv.ToProtoTaskPushConfig(&config)
+	result, err := pbconv.ToProtoTaskPushConfig(config)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to convert push config: %v", err)
 	}
@@ -184,7 +184,7 @@ func (h *GRPCHandler) ListTaskPushNotificationConfig(ctx context.Context, req *a
 		return nil, status.Errorf(codes.InvalidArgument, "failed to extract task id: %v", err)
 	}
 	// todo: handling pagination
-	configs, err := h.handler.OnListTaskPushConfig(ctx, a2a.ListTaskPushConfigParams{TaskID: taskID})
+	configs, err := h.handler.OnListTaskPushConfig(ctx, &a2a.ListTaskPushConfigParams{TaskID: taskID})
 	if err != nil {
 		return nil, toGRPCError(err)
 	}

--- a/a2apb/pbconv/convert.go
+++ b/a2apb/pbconv/convert.go
@@ -48,11 +48,11 @@ func extractConfigID(name string) (string, error) {
 func FromProtoSendMessageRequest(req *a2apb.SendMessageRequest) (*a2a.MessageSendParams, error) {
 	msg, err := fromProtoMessage(req.GetRequest())
 	if err != nil {
-		return &a2a.MessageSendParams{}, err
+		return nil, err
 	}
 	config, err := fromProtoSendMessageConfig(req.GetConfiguration())
 	if err != nil {
-		return &a2a.MessageSendParams{}, err
+		return nil, err
 	}
 	params := &a2a.MessageSendParams{
 		Message: msg,

--- a/a2apb/pbconv/convert.go
+++ b/a2apb/pbconv/convert.go
@@ -45,16 +45,16 @@ func extractConfigID(name string) (string, error) {
 	return matches[1], nil
 }
 
-func FromProtoSendMessageRequest(req *a2apb.SendMessageRequest) (a2a.MessageSendParams, error) {
+func FromProtoSendMessageRequest(req *a2apb.SendMessageRequest) (*a2a.MessageSendParams, error) {
 	msg, err := fromProtoMessage(req.GetRequest())
 	if err != nil {
-		return a2a.MessageSendParams{}, err
+		return &a2a.MessageSendParams{}, err
 	}
 	config, err := fromProtoSendMessageConfig(req.GetConfiguration())
 	if err != nil {
-		return a2a.MessageSendParams{}, err
+		return &a2a.MessageSendParams{}, err
 	}
-	params := a2a.MessageSendParams{
+	params := &a2a.MessageSendParams{
 		Message: msg,
 		Config:  config,
 	}
@@ -64,19 +64,19 @@ func FromProtoSendMessageRequest(req *a2apb.SendMessageRequest) (a2a.MessageSend
 	return params, nil
 }
 
-func fromProtoMessage(pMsg *a2apb.Message) (a2a.Message, error) {
+func fromProtoMessage(pMsg *a2apb.Message) (*a2a.Message, error) {
 	if pMsg == nil {
-		return a2a.Message{}, fmt.Errorf("proto message is nil")
+		return nil, fmt.Errorf("proto message is nil")
 	}
 	parts := make([]a2a.Part, len(pMsg.GetContent()))
 	for i, p := range pMsg.GetContent() {
 		part, err := fromProtoPart(p)
 		if err != nil {
-			return a2a.Message{}, fmt.Errorf("failed to convert part: %w", err)
+			return nil, fmt.Errorf("failed to convert part: %w", err)
 		}
 		parts[i] = part
 	}
-	msg := a2a.Message{
+	msg := &a2a.Message{
 		ID:         pMsg.GetMessageId(),
 		ContextID:  pMsg.GetContextId(),
 		Extensions: pMsg.GetExtensions(),
@@ -182,13 +182,13 @@ func fromProtoSendMessageConfig(conf *a2apb.SendMessageConfiguration) (*a2a.Mess
 	return result, nil
 }
 
-func FromProtoGetTaskRequest(req *a2apb.GetTaskRequest) (a2a.TaskQueryParams, error) {
+func FromProtoGetTaskRequest(req *a2apb.GetTaskRequest) (*a2a.TaskQueryParams, error) {
 	// TODO: consider throwing an error when the path - req.GetName() is unexpected, e.g. tasks/taskID/someExtraText
 	taskID, err := ExtractTaskID(req.GetName())
 	if err != nil {
-		return a2a.TaskQueryParams{}, fmt.Errorf("failed to extract task id: %w", err)
+		return nil, fmt.Errorf("failed to extract task id: %w", err)
 	}
-	params := a2a.TaskQueryParams{
+	params := &a2a.TaskQueryParams{
 		ID: taskID,
 	}
 	if req.GetHistoryLength() > 0 {
@@ -198,51 +198,51 @@ func FromProtoGetTaskRequest(req *a2apb.GetTaskRequest) (a2a.TaskQueryParams, er
 	return params, nil
 }
 
-func FromProtoCreateTaskPushConfigRequest(req *a2apb.CreateTaskPushNotificationConfigRequest) (a2a.TaskPushConfig, error) {
+func FromProtoCreateTaskPushConfigRequest(req *a2apb.CreateTaskPushNotificationConfigRequest) (*a2a.TaskPushConfig, error) {
 	config := req.GetConfig()
 	if config == nil || config.GetPushNotificationConfig() == nil {
-		return a2a.TaskPushConfig{}, fmt.Errorf("invalid config")
+		return nil, fmt.Errorf("invalid config")
 	}
 	pConf, err := fromProtoPushConfig(config.GetPushNotificationConfig())
 	if err != nil {
-		return a2a.TaskPushConfig{}, fmt.Errorf("failed to convert push config: %w", err)
+		return nil, fmt.Errorf("failed to convert push config: %w", err)
 	}
 	taskID, err := ExtractTaskID(req.GetParent())
 	if err != nil {
-		return a2a.TaskPushConfig{}, fmt.Errorf("failed to extract task id: %w", err)
+		return nil, fmt.Errorf("failed to extract task id: %w", err)
 	}
 
-	return a2a.TaskPushConfig{
+	return &a2a.TaskPushConfig{
 		TaskID: taskID,
 		Config: *pConf,
 	}, nil
 }
 
-func FromProtoGetTaskPushConfigRequest(req *a2apb.GetTaskPushNotificationConfigRequest) (a2a.GetTaskPushConfigParams, error) {
+func FromProtoGetTaskPushConfigRequest(req *a2apb.GetTaskPushNotificationConfigRequest) (*a2a.GetTaskPushConfigParams, error) {
 	taskID, err := ExtractTaskID(req.GetName())
 	if err != nil {
-		return a2a.GetTaskPushConfigParams{}, fmt.Errorf("failed to extract task id: %w", err)
+		return nil, fmt.Errorf("failed to extract task id: %w", err)
 	}
 	configID, err := extractConfigID(req.GetName())
 	if err != nil {
-		return a2a.GetTaskPushConfigParams{}, fmt.Errorf("failed to extract config id: %w", err)
+		return nil, fmt.Errorf("failed to extract config id: %w", err)
 	}
-	return a2a.GetTaskPushConfigParams{
+	return &a2a.GetTaskPushConfigParams{
 		TaskID:   taskID,
 		ConfigID: configID,
 	}, nil
 }
 
-func FromProtoDeleteTaskPushConfigRequest(req *a2apb.DeleteTaskPushNotificationConfigRequest) (a2a.DeleteTaskPushConfigParams, error) {
+func FromProtoDeleteTaskPushConfigRequest(req *a2apb.DeleteTaskPushNotificationConfigRequest) (*a2a.DeleteTaskPushConfigParams, error) {
 	taskID, err := ExtractTaskID(req.GetName())
 	if err != nil {
-		return a2a.DeleteTaskPushConfigParams{}, fmt.Errorf("failed to extract task id: %w", err)
+		return nil, fmt.Errorf("failed to extract task id: %w", err)
 	}
 	configID, err := extractConfigID(req.GetName())
 	if err != nil {
-		return a2a.DeleteTaskPushConfigParams{}, fmt.Errorf("failed to extract config id: %w", err)
+		return nil, fmt.Errorf("failed to extract config id: %w", err)
 	}
-	return a2a.DeleteTaskPushConfigParams{
+	return &a2a.DeleteTaskPushConfigParams{
 		TaskID:   taskID,
 		ConfigID: configID,
 	}, nil
@@ -592,10 +592,10 @@ func ToProtoTaskPushConfig(config *a2a.TaskPushConfig) (*a2apb.TaskPushNotificat
 	}, nil
 }
 
-func ToProtoListTaskPushConfig(configs []a2a.TaskPushConfig) (*a2apb.ListTaskPushNotificationConfigResponse, error) {
+func ToProtoListTaskPushConfig(configs []*a2a.TaskPushConfig) (*a2apb.ListTaskPushNotificationConfigResponse, error) {
 	pConfigs := make([]*a2apb.TaskPushNotificationConfig, len(configs))
 	for i, config := range configs {
-		pConfig, err := ToProtoTaskPushConfig(&config)
+		pConfig, err := ToProtoTaskPushConfig(config)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert config: %w", err)
 		}

--- a/a2apb/pbconv/convert_test.go
+++ b/a2apb/pbconv/convert_test.go
@@ -350,7 +350,7 @@ func TestFromProtoRequests(t *testing.T) {
 		tests := []struct {
 			name    string
 			req     *a2apb.SendMessageRequest
-			want    a2a.MessageSendParams
+			want    *a2a.MessageSendParams
 			wantErr bool
 		}{
 			{
@@ -360,8 +360,8 @@ func TestFromProtoRequests(t *testing.T) {
 					Configuration: pConf,
 					Metadata:      pMeta,
 				},
-				want: a2a.MessageSendParams{
-					Message:  a2aMsg,
+				want: &a2a.MessageSendParams{
+					Message:  &a2aMsg,
 					Config:   a2aConf,
 					Metadata: a2aMeta,
 				},
@@ -372,8 +372,8 @@ func TestFromProtoRequests(t *testing.T) {
 					Request:       pMsg,
 					Configuration: pConf,
 				},
-				want: a2a.MessageSendParams{
-					Message: a2aMsg,
+				want: &a2a.MessageSendParams{
+					Message: &a2aMsg,
 					Config:  a2aConf,
 				},
 			},
@@ -383,8 +383,8 @@ func TestFromProtoRequests(t *testing.T) {
 					Request:  pMsg,
 					Metadata: pMeta,
 				},
-				want: a2a.MessageSendParams{
-					Message:  a2aMsg,
+				want: &a2a.MessageSendParams{
+					Message:  &a2aMsg,
 					Metadata: a2aMeta,
 				},
 			},
@@ -435,7 +435,7 @@ func TestFromProtoRequests(t *testing.T) {
 		tests := []struct {
 			name    string
 			req     *a2apb.GetTaskRequest
-			want    a2a.TaskQueryParams
+			want    *a2a.TaskQueryParams
 			wantErr bool
 		}{
 			{
@@ -444,7 +444,7 @@ func TestFromProtoRequests(t *testing.T) {
 					Name:          "tasks/test",
 					HistoryLength: 10,
 				},
-				want: a2a.TaskQueryParams{
+				want: &a2a.TaskQueryParams{
 					ID:            "test",
 					HistoryLength: &historyLen,
 				},
@@ -454,7 +454,7 @@ func TestFromProtoRequests(t *testing.T) {
 				req: &a2apb.GetTaskRequest{
 					Name: "tasks/test",
 				},
-				want: a2a.TaskQueryParams{
+				want: &a2a.TaskQueryParams{
 					ID: "test",
 				},
 			},
@@ -484,7 +484,7 @@ func TestFromProtoRequests(t *testing.T) {
 		tests := []struct {
 			name    string
 			req     *a2apb.CreateTaskPushNotificationConfigRequest
-			want    a2a.TaskPushConfig
+			want    *a2a.TaskPushConfig
 			wantErr bool
 		}{
 			{
@@ -493,7 +493,7 @@ func TestFromProtoRequests(t *testing.T) {
 					Parent: "tasks/test",
 					Config: &a2apb.TaskPushNotificationConfig{PushNotificationConfig: &a2apb.PushNotificationConfig{Id: "test-config"}},
 				},
-				want: a2a.TaskPushConfig{TaskID: "test", Config: a2a.PushConfig{ID: "test-config"}},
+				want: &a2a.TaskPushConfig{TaskID: "test", Config: a2a.PushConfig{ID: "test-config"}},
 			},
 			{
 				name: "nil config",
@@ -544,7 +544,7 @@ func TestFromProtoRequests(t *testing.T) {
 		tests := []struct {
 			name    string
 			req     *a2apb.GetTaskPushNotificationConfigRequest
-			want    a2a.GetTaskPushConfigParams
+			want    *a2a.GetTaskPushConfigParams
 			wantErr bool
 		}{
 			{
@@ -552,7 +552,7 @@ func TestFromProtoRequests(t *testing.T) {
 				req: &a2apb.GetTaskPushNotificationConfigRequest{
 					Name: "tasks/test-task/pushConfigs/test-config",
 				},
-				want: a2a.GetTaskPushConfigParams{
+				want: &a2a.GetTaskPushConfigParams{
 					TaskID:   "test-task",
 					ConfigID: "test-config",
 				},
@@ -590,7 +590,7 @@ func TestFromProtoRequests(t *testing.T) {
 		tests := []struct {
 			name    string
 			req     *a2apb.DeleteTaskPushNotificationConfigRequest
-			want    a2a.DeleteTaskPushConfigParams
+			want    *a2a.DeleteTaskPushConfigParams
 			wantErr bool
 		}{
 			{
@@ -598,7 +598,7 @@ func TestFromProtoRequests(t *testing.T) {
 				req: &a2apb.DeleteTaskPushNotificationConfigRequest{
 					Name: "tasks/test-task/pushConfigs/test-config",
 				},
-				want: a2a.DeleteTaskPushConfigParams{
+				want: &a2a.DeleteTaskPushConfigParams{
 					TaskID:   "test-task",
 					ConfigID: "test-config",
 				},
@@ -1077,16 +1077,16 @@ func TestToProtoConversion(t *testing.T) {
 	})
 
 	t.Run("toProtoListTaskPushConfig", func(t *testing.T) {
-		configs := []a2a.TaskPushConfig{
-			{TaskID: "test-task", Config: a2a.PushConfig{ID: "test-config1"}},
-			{TaskID: "test-task", Config: a2a.PushConfig{ID: "test-config2"}},
+		configs := []*a2a.TaskPushConfig{
+			&a2a.TaskPushConfig{TaskID: "test-task", Config: a2a.PushConfig{ID: "test-config1"}},
+			&a2a.TaskPushConfig{TaskID: "test-task", Config: a2a.PushConfig{ID: "test-config2"}},
 		}
-		pConf1, _ := ToProtoTaskPushConfig(&configs[0])
-		pConf2, _ := ToProtoTaskPushConfig(&configs[1])
+		pConf1, _ := ToProtoTaskPushConfig(configs[0])
+		pConf2, _ := ToProtoTaskPushConfig(configs[1])
 
 		tests := []struct {
 			name    string
-			configs []a2a.TaskPushConfig
+			configs []*a2a.TaskPushConfig
 			want    *a2apb.ListTaskPushNotificationConfigResponse
 			wantErr bool
 		}{
@@ -1099,15 +1099,15 @@ func TestToProtoConversion(t *testing.T) {
 			},
 			{
 				name:    "empty slice",
-				configs: []a2a.TaskPushConfig{},
+				configs: []*a2a.TaskPushConfig{},
 				want: &a2apb.ListTaskPushNotificationConfigResponse{
 					Configs: []*a2apb.TaskPushNotificationConfig{},
 				},
 			},
 			{
 				name: "conversion error",
-				configs: []a2a.TaskPushConfig{
-					{TaskID: "test-task", Config: a2a.PushConfig{}},
+				configs: []*a2a.TaskPushConfig{
+					&a2a.TaskPushConfig{TaskID: "test-task", Config: a2a.PushConfig{}},
 				},
 				wantErr: true,
 			},

--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -29,31 +29,31 @@ var ErrUnimplemented = errors.New("unimplemented")
 // RequestHandler defines a transport-agnostic interface for handling incoming A2A requests.
 type RequestHandler interface {
 	// OnGetTask handles the 'tasks/get' protocol method.
-	OnGetTask(ctx context.Context, query a2a.TaskQueryParams) (a2a.Task, error)
+	OnGetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error)
 
 	// OnCancelTask handles the 'tasks/cancel' protocol method.
-	OnCancelTask(ctx context.Context, id a2a.TaskIDParams) (a2a.Task, error)
+	OnCancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error)
 
 	// OnSendMessage handles the 'message/send' protocol method (non-streaming).
-	OnSendMessage(ctx context.Context, message a2a.MessageSendParams) (a2a.SendMessageResult, error)
+	OnSendMessage(ctx context.Context, message *a2a.MessageSendParams) (a2a.SendMessageResult, error)
 
 	// OnResubscribeToTask handles the `tasks/resubscribe` protocol method.
-	OnResubscribeToTask(ctx context.Context, id a2a.TaskIDParams) iter.Seq2[a2a.Event, error]
+	OnResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) iter.Seq2[a2a.Event, error]
 
 	// OnMessageSendStream handles the 'message/stream' protocol method (streaming).
-	OnSendMessageStream(ctx context.Context, message a2a.MessageSendParams) iter.Seq2[a2a.Event, error]
+	OnSendMessageStream(ctx context.Context, message *a2a.MessageSendParams) iter.Seq2[a2a.Event, error]
 
 	// OnGetTaskPushNotificationConfig handles the `tasks/pushNotificationConfig/get` protocol method.
-	OnGetTaskPushConfig(ctx context.Context, params a2a.GetTaskPushConfigParams) (a2a.TaskPushConfig, error)
+	OnGetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushConfigParams) (*a2a.TaskPushConfig, error)
 
 	// OnListTaskPushNotificationConfig handles the `tasks/pushNotificationConfig/list` protocol method.
-	OnListTaskPushConfig(ctx context.Context, params a2a.ListTaskPushConfigParams) ([]a2a.TaskPushConfig, error)
+	OnListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error)
 
 	// OnSetTaskPushConfig handles the `tasks/pushNotificationConfig/set` protocol method.
-	OnSetTaskPushConfig(ctx context.Context, params a2a.TaskPushConfig) (a2a.TaskPushConfig, error)
+	OnSetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error)
 
 	// OnDeleteTaskPushNotificationConfig handles the `tasks/pushNotificationConfig/delete` protocol method.
-	OnDeleteTaskPushConfig(ctx context.Context, params a2a.DeleteTaskPushConfigParams) error
+	OnDeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error
 }
 
 // Implements a2asrv.RequestHandler
@@ -107,15 +107,15 @@ func NewHandler(executor AgentExecutor, options ...RequestHandlerOption) Request
 	return h
 }
 
-func (h *defaultRequestHandler) OnGetTask(ctx context.Context, query a2a.TaskQueryParams) (a2a.Task, error) {
-	return a2a.Task{}, ErrUnimplemented
+func (h *defaultRequestHandler) OnGetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error) {
+	return &a2a.Task{}, ErrUnimplemented
 }
 
-func (h *defaultRequestHandler) OnCancelTask(ctx context.Context, id a2a.TaskIDParams) (a2a.Task, error) {
-	return a2a.Task{}, ErrUnimplemented
+func (h *defaultRequestHandler) OnCancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
+	return &a2a.Task{}, ErrUnimplemented
 }
 
-func (h *defaultRequestHandler) OnSendMessage(ctx context.Context, message a2a.MessageSendParams) (a2a.SendMessageResult, error) {
+func (h *defaultRequestHandler) OnSendMessage(ctx context.Context, message *a2a.MessageSendParams) (a2a.SendMessageResult, error) {
 	taskID := message.Message.TaskID
 	if taskID == "" {
 		// todo: generate task id - https://github.com/a2aproject/a2a-go/issues/18
@@ -144,26 +144,26 @@ func (h *defaultRequestHandler) OnSendMessage(ctx context.Context, message a2a.M
 	return event.(a2a.SendMessageResult), nil
 }
 
-func (h *defaultRequestHandler) OnResubscribeToTask(ctx context.Context, id a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
+func (h *defaultRequestHandler) OnResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
 	return nil
 }
 
-func (h *defaultRequestHandler) OnSendMessageStream(ctx context.Context, message a2a.MessageSendParams) iter.Seq2[a2a.Event, error] {
+func (h *defaultRequestHandler) OnSendMessageStream(ctx context.Context, message *a2a.MessageSendParams) iter.Seq2[a2a.Event, error] {
 	return nil
 }
 
-func (h *defaultRequestHandler) OnGetTaskPushConfig(ctx context.Context, params a2a.GetTaskPushConfigParams) (a2a.TaskPushConfig, error) {
-	return a2a.TaskPushConfig{}, ErrUnimplemented
+func (h *defaultRequestHandler) OnGetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushConfigParams) (*a2a.TaskPushConfig, error) {
+	return &a2a.TaskPushConfig{}, ErrUnimplemented
 }
 
-func (h *defaultRequestHandler) OnListTaskPushConfig(ctx context.Context, params a2a.ListTaskPushConfigParams) ([]a2a.TaskPushConfig, error) {
+func (h *defaultRequestHandler) OnListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error) {
 	return nil, ErrUnimplemented
 }
 
-func (h *defaultRequestHandler) OnSetTaskPushConfig(ctx context.Context, params a2a.TaskPushConfig) (a2a.TaskPushConfig, error) {
-	return a2a.TaskPushConfig{}, ErrUnimplemented
+func (h *defaultRequestHandler) OnSetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error) {
+	return &a2a.TaskPushConfig{}, ErrUnimplemented
 }
 
-func (h *defaultRequestHandler) OnDeleteTaskPushConfig(ctx context.Context, params a2a.DeleteTaskPushConfigParams) error {
+func (h *defaultRequestHandler) OnDeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error {
 	return ErrUnimplemented
 }

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -136,50 +136,50 @@ func newTestHandler(opts ...RequestHandlerOption) RequestHandler {
 func TestDefaultRequestHandler_OnSendMessage(t *testing.T) {
 	tests := []struct {
 		name      string
-		message   a2a.MessageSendParams
+		message   *a2a.MessageSendParams
 		wantEvent a2a.Event
 		wantErr   error
 	}{
 		{
 			name: "success with TaskID",
-			message: a2a.MessageSendParams{
-				Message: a2a.Message{TaskID: taskID, ID: "test-message"},
+			message: &a2a.MessageSendParams{
+				Message: &a2a.Message{TaskID: taskID, ID: "test-message"},
 			},
 			wantEvent: &a2a.Message{TaskID: taskID, ID: "test-message"},
 		},
 		{
 			name: "missing TaskID",
-			message: a2a.MessageSendParams{
-				Message: a2a.Message{ID: "test-message"},
+			message: &a2a.MessageSendParams{
+				Message: &a2a.Message{ID: "test-message"},
 			},
 			wantErr: errors.New("message is missing TaskID"),
 		},
 		{
 			name: "type assertion fails",
-			message: a2a.MessageSendParams{
-				Message: a2a.Message{TaskID: taskID, ID: "test-message"},
+			message: &a2a.MessageSendParams{
+				Message: &a2a.Message{TaskID: taskID, ID: "test-message"},
 			},
 			wantEvent: &a2a.TaskStatusUpdateEvent{TaskID: taskID},
 			wantErr:   errors.New("unexpected event type: *a2a.TaskStatusUpdateEvent"),
 		},
 		{
 			name: "GetOrCreate() fails",
-			message: a2a.MessageSendParams{
-				Message: a2a.Message{TaskID: getOrCreateFailTaskID, ID: "test-message"},
+			message: &a2a.MessageSendParams{
+				Message: &a2a.Message{TaskID: getOrCreateFailTaskID, ID: "test-message"},
 			},
 			wantErr: errors.New("failed to retrieve queue: get or create failed"),
 		},
 		{
 			name: "executor Execute() fails",
-			message: a2a.MessageSendParams{
-				Message: a2a.Message{TaskID: executeFailTaskID, ID: "test-message"},
+			message: &a2a.MessageSendParams{
+				Message: &a2a.Message{TaskID: executeFailTaskID, ID: "test-message"},
 			},
 			wantErr: errors.New("execute failed"),
 		},
 		{
 			name: "queue Read() fails",
-			message: a2a.MessageSendParams{
-				Message: a2a.Message{TaskID: taskID, ID: "test-message"},
+			message: &a2a.MessageSendParams{
+				Message: &a2a.Message{TaskID: taskID, ID: "test-message"},
 			},
 			wantErr: errors.New("failed to read event from queue: The number of ReadFunc exceeded the number of events: 0"),
 		},
@@ -220,28 +220,28 @@ func TestDefaultRequestHandler_Unimplemented(t *testing.T) {
 	handler := NewHandler(&mockAgentExecutor{})
 	ctx := t.Context()
 
-	if _, err := handler.OnGetTask(ctx, a2a.TaskQueryParams{}); !errors.Is(err, ErrUnimplemented) {
+	if _, err := handler.OnGetTask(ctx, &a2a.TaskQueryParams{}); !errors.Is(err, ErrUnimplemented) {
 		t.Errorf("OnGetTask: expected unimplemented error, got %v", err)
 	}
-	if _, err := handler.OnCancelTask(ctx, a2a.TaskIDParams{}); !errors.Is(err, ErrUnimplemented) {
+	if _, err := handler.OnCancelTask(ctx, &a2a.TaskIDParams{}); !errors.Is(err, ErrUnimplemented) {
 		t.Errorf("OnCancelTask: expected unimplemented error, got %v", err)
 	}
-	if seq := handler.OnResubscribeToTask(ctx, a2a.TaskIDParams{}); seq != nil {
+	if seq := handler.OnResubscribeToTask(ctx, &a2a.TaskIDParams{}); seq != nil {
 		t.Error("OnResubscribeToTask: expected nil iterator, got non-nil")
 	}
-	if seq := handler.OnSendMessageStream(ctx, a2a.MessageSendParams{}); seq != nil {
+	if seq := handler.OnSendMessageStream(ctx, &a2a.MessageSendParams{}); seq != nil {
 		t.Error("OnSendMessageStream: expected nil iterator, got non-nil")
 	}
-	if _, err := handler.OnGetTaskPushConfig(ctx, a2a.GetTaskPushConfigParams{}); !errors.Is(err, ErrUnimplemented) {
+	if _, err := handler.OnGetTaskPushConfig(ctx, &a2a.GetTaskPushConfigParams{}); !errors.Is(err, ErrUnimplemented) {
 		t.Errorf("OnGetTaskPushConfig: expected unimplemented error, got %v", err)
 	}
-	if _, err := handler.OnListTaskPushConfig(ctx, a2a.ListTaskPushConfigParams{}); !errors.Is(err, ErrUnimplemented) {
+	if _, err := handler.OnListTaskPushConfig(ctx, &a2a.ListTaskPushConfigParams{}); !errors.Is(err, ErrUnimplemented) {
 		t.Errorf("OnListTaskPushConfig: expected unimplemented error, got %v", err)
 	}
-	if _, err := handler.OnSetTaskPushConfig(ctx, a2a.TaskPushConfig{}); !errors.Is(err, ErrUnimplemented) {
+	if _, err := handler.OnSetTaskPushConfig(ctx, &a2a.TaskPushConfig{}); !errors.Is(err, ErrUnimplemented) {
 		t.Errorf("OnSetTaskPushConfig: expected unimplemented error, got %v", err)
 	}
-	if err := handler.OnDeleteTaskPushConfig(ctx, a2a.DeleteTaskPushConfigParams{}); !errors.Is(err, ErrUnimplemented) {
+	if err := handler.OnDeleteTaskPushConfig(ctx, &a2a.DeleteTaskPushConfigParams{}); !errors.Is(err, ErrUnimplemented) {
 		t.Errorf("OnDeleteTaskPushConfig: expected unimplemented error, got %v", err)
 	}
 }

--- a/a2asrv/reqctx.go
+++ b/a2asrv/reqctx.go
@@ -24,19 +24,19 @@ import (
 // that contain the information needed by AgentExecutor implementations to process incoming requests.
 type RequestContextBuilder interface {
 	// Build constructs a RequestContext from the provided parameters.
-	Build(ctx context.Context, p a2a.MessageSendParams, t *a2a.Task) RequestContext
+	Build(ctx context.Context, p *a2a.MessageSendParams, t *a2a.Task) *RequestContext
 }
 
 // RequestContext provides information about an incoming A2A request to AgentExecutor.
 type RequestContext struct {
 	// Request which triggered the execution.
-	Request a2a.MessageSendParams
+	Request *a2a.MessageSendParams
 	// TaskID is an ID of the task or a newly generated UUIDv4 in case Message did not reference any Task.
 	TaskID a2a.TaskID
 	// Task is present if request message specified a TaskID.
 	Task *a2a.Task
 	// RelatedTasks can be present when Message includes Task references and RequestContextBuilder is configured to load them.
-	RelatedTasks []a2a.Task
+	RelatedTasks []*a2a.Task
 	// ContextID is a server-generated identifier for maintaining context across multiple related tasks or interactions. Matches the Task ContextID.
 	ContextID string
 }

--- a/a2asrv/tasks.go
+++ b/a2asrv/tasks.go
@@ -31,10 +31,10 @@ type PushNotifier interface {
 type PushConfigStore interface {
 	// Save creates or updates a push notification configuration for a task.
 	// PushConfig has an ID and a Task can have multiple associated configurations.
-	Save(ctx context.Context, taskId a2a.TaskID, config *a2a.PushConfig) error
+	Save(ctx context.Context, taskID a2a.TaskID, config *a2a.PushConfig) error
 
 	// Get retrieves all registered push configurations for a Task.
-	Get(ctx context.Context, taskId a2a.TaskID) ([]*a2a.PushConfig, error)
+	Get(ctx context.Context, taskID a2a.TaskID) ([]*a2a.PushConfig, error)
 
 	// Delete removes a push configuration registered for a Task with the given configID.
 	Delete(ctx context.Context, taskID a2a.TaskID, configID string) error
@@ -49,5 +49,5 @@ type TaskStore interface {
 	Save(ctx context.Context, task *a2a.Task) error
 
 	// Get retrieves a task by ID.
-	Get(ctx context.Context, taskId a2a.TaskID) (*a2a.Task, error)
+	Get(ctx context.Context, taskID a2a.TaskID) (*a2a.Task, error)
 }

--- a/a2asrv/tasks.go
+++ b/a2asrv/tasks.go
@@ -24,17 +24,17 @@ import (
 // about task state changes to external endpoints.
 type PushNotifier interface {
 	// SendPush sends a push notification containing the latest task state.
-	SendPush(ctx context.Context, task a2a.Task) error
+	SendPush(ctx context.Context, task *a2a.Task) error
 }
 
 // PushConfigStore manages push notification configurations for tasks.
 type PushConfigStore interface {
 	// Save creates or updates a push notification configuration for a task.
 	// PushConfig has an ID and a Task can have multiple associated configurations.
-	Save(ctx context.Context, taskID a2a.TaskID, config a2a.PushConfig) error
+	Save(ctx context.Context, taskId a2a.TaskID, config *a2a.PushConfig) error
 
 	// Get retrieves all registered push configurations for a Task.
-	Get(ctx context.Context, taskID a2a.TaskID) ([]a2a.PushConfig, error)
+	Get(ctx context.Context, taskId a2a.TaskID) ([]*a2a.PushConfig, error)
 
 	// Delete removes a push configuration registered for a Task with the given configID.
 	Delete(ctx context.Context, taskID a2a.TaskID, configID string) error
@@ -46,8 +46,8 @@ type PushConfigStore interface {
 // TaskStore provides storage for A2A tasks.
 type TaskStore interface {
 	// Save stores a task.
-	Save(ctx context.Context, task a2a.Task) error
+	Save(ctx context.Context, task *a2a.Task) error
 
 	// Get retrieves a task by ID.
-	Get(ctx context.Context, taskID a2a.TaskID) (a2a.Task, error)
+	Get(ctx context.Context, taskId a2a.TaskID) (*a2a.Task, error)
 }

--- a/internal/taskstore/store.go
+++ b/internal/taskstore/store.go
@@ -58,9 +58,9 @@ func (s *Mem) Save(ctx context.Context, task *a2a.Task) error {
 	return nil
 }
 
-func (s *Mem) Get(ctx context.Context, taskId a2a.TaskID) (*a2a.Task, error) {
+func (s *Mem) Get(ctx context.Context, taskID a2a.TaskID) (*a2a.Task, error) {
 	s.mu.RLock()
-	task, ok := s.tasks[taskId]
+	task, ok := s.tasks[taskID]
 	s.mu.RUnlock()
 
 	if !ok {


### PR DESCRIPTION
### Details

The PR tries to make value vs pointer usages more consistent for core types, more specifically:
* Make methods and fields of type Message and Task use pointers.
* Make types used to represent request or response payloads use pointers. This makes it consistent with methods that take Task or Message as an argument, and return a2a.SendMessageResult or a2a.Event which are interfaces.
