### PR TITLE
feat: client interceptor invocations

### DIFF
--- a/a2a/errors.go
+++ b/a2a/errors.go
@@ -16,7 +16,26 @@ package a2a
 
 import "errors"
 
+// https://a2a-protocol.org/latest/specification/#8-error-handling
 var (
+	// ErrParseError indicates that server received payload that was not well-formed.
+	ErrParseError = errors.New("parse error")
+
+	// ErrInvalidRequest indicates that server received a well-formed payload which was not a valid request.
+	ErrInvalidRequest = errors.New("invalid request")
+
+	// ErrMethodNotFound indicates that a method does not exist or is not supported.
+	ErrMethodNotFound = errors.New("method not found")
+
+	// ErrInvalidParams indicates that params provided for the method were invalid (e.g., wrong type, missing required field).
+	ErrInvalidParams = errors.New("invalid params")
+
+	// ErrInternalError indicates an unexpected error occurred on the server during processing.
+	ErrInternalError = errors.New("internal error")
+
+	// ErrServerError reserved for implementation-defined server-errors.
+	ErrServerError = errors.New("server error")
+
 	// ErrTaskNotFound indicates that a task with the provided ID was not found.
 	ErrTaskNotFound = errors.New("task not found")
 
@@ -36,9 +55,6 @@ var (
 	// ErrInvalidAgentResponse indicates that the agent returned a response that
 	// does not conform to the specification for the current method.
 	ErrInvalidAgentResponse = errors.New("invalid agent response")
-
-	// ErrInvalidRequest indicates that the received request was invalid.
-	ErrInvalidRequest = errors.New("invalid request")
 
 	// ErrAuthenticatedExtendedCardNotConfigured indicates that the agent does not have an Authenticated
 	// Extended Card configured.

--- a/a2aclient/auth.go
+++ b/a2aclient/auth.go
@@ -29,6 +29,21 @@ var ErrCredentialNotFound = errors.New("credential not found")
 // SessionID is a client-generated identifier used for scoping auth credentials.
 type SessionID string
 
+// Used to store a SessionID in context.Context.
+type sessionIDKey struct{}
+
+// WithSessionID allows callers to attach a session identifier to the request.
+// CallInterceptor can access this identifier through CallContext.
+func WithSessionID(ctx context.Context, sid SessionID) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, sid)
+}
+
+// SessionIDFrom allows to get a previously attached session identifier from Context.
+func SessionIDFrom(ctx context.Context) (SessionID, bool) {
+	sid, ok := ctx.Value(sessionIDKey{}).(SessionID)
+	return sid, ok
+}
+
 // AuthCredential represents a security-scheme specific credential (eg. a JWT token).
 type AuthCredential string
 
@@ -46,6 +61,7 @@ type CredentialsService interface {
 	Get(ctx context.Context, sid SessionID, scheme a2a.SecuritySchemeName) (AuthCredential, error)
 }
 
+// SessionCredentials is a map of auth credentials by scheme name.
 type SessionCredentials map[a2a.SecuritySchemeName]AuthCredential
 
 // InMemoryCredentialsStore implements CredentialsService.

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -64,7 +64,6 @@ func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.
 	}
 
 	resp, err := c.transport.GetTask(ctx, query)
-
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
@@ -81,7 +80,6 @@ func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Tas
 	}
 
 	resp, err := c.transport.CancelTask(ctx, id)
-
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
@@ -98,7 +96,6 @@ func (c *Client) SendMessage(ctx context.Context, message *a2a.MessageSendParams
 	}
 
 	resp, err := c.transport.SendMessage(ctx, message)
-
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
@@ -171,7 +168,6 @@ func (c *Client) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushC
 	}
 
 	resp, err := c.transport.GetTaskPushConfig(ctx, params)
-
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
@@ -188,7 +184,6 @@ func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPus
 	}
 
 	resp, err := c.transport.ListTaskPushConfig(ctx, params)
-
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
@@ -205,7 +200,6 @@ func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConf
 	}
 
 	resp, err := c.transport.SetTaskPushConfig(ctx, params)
-
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
@@ -222,7 +216,6 @@ func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTas
 	}
 
 	err = c.transport.DeleteTaskPushConfig(ctx, params)
-
 	if errOverride := c.interceptAfter(ctx, method, nil, err); errOverride != nil {
 		return err
 	}

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -58,14 +58,14 @@ func (c *Client) AddCallInterceptor(ci CallInterceptor) {
 func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error) {
 	method := "GetTask"
 
-	ctx, err := interceptBefore(ctx, method, c.interceptors, query)
+	ctx, err := c.interceptBefore(ctx, method, query)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.GetTask(ctx, query)
 
-	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
+	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -75,14 +75,14 @@ func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.
 func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
 	method := "CancelTask"
 
-	ctx, err := interceptBefore(ctx, method, c.interceptors, id)
+	ctx, err := c.interceptBefore(ctx, method, id)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.CancelTask(ctx, id)
 
-	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
+	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -92,14 +92,14 @@ func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Tas
 func (c *Client) SendMessage(ctx context.Context, message *a2a.MessageSendParams) (a2a.SendMessageResult, error) {
 	method := "SendMessage"
 
-	ctx, err := interceptBefore(ctx, method, c.interceptors, message)
+	ctx, err := c.interceptBefore(ctx, method, message)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.SendMessage(ctx, message)
 
-	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
+	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -110,14 +110,14 @@ func (c *Client) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) it
 	return func(yield func(a2a.Event, error) bool) {
 		method := "ResubscribeToTask"
 
-		ctx, err := interceptBefore(ctx, method, c.interceptors, id)
+		ctx, err := c.interceptBefore(ctx, method, id)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 
 		for resp, err := range c.transport.ResubscribeToTask(ctx, id) {
-			if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
+			if err := c.interceptAfter(ctx, method, resp, err); err != nil {
 				yield(nil, err)
 				return
 			}
@@ -138,14 +138,14 @@ func (c *Client) SendStreamingMessage(ctx context.Context, message *a2a.MessageS
 	return func(yield func(a2a.Event, error) bool) {
 		method := "SendStreamingMessage"
 
-		ctx, err := interceptBefore(ctx, method, c.interceptors, message)
+		ctx, err := c.interceptBefore(ctx, method, message)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 
 		for resp, err := range c.transport.SendStreamingMessage(ctx, message) {
-			if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
+			if err := c.interceptAfter(ctx, method, resp, err); err != nil {
 				yield(nil, err)
 				return
 			}
@@ -165,14 +165,14 @@ func (c *Client) SendStreamingMessage(ctx context.Context, message *a2a.MessageS
 func (c *Client) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushConfigParams) (*a2a.TaskPushConfig, error) {
 	method := "GetTaskPushConfig"
 
-	ctx, err := interceptBefore(ctx, method, c.interceptors, params)
+	ctx, err := c.interceptBefore(ctx, method, params)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.GetTaskPushConfig(ctx, params)
 
-	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
+	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -182,14 +182,14 @@ func (c *Client) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushC
 func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error) {
 	method := "ListTaskPushConfig"
 
-	ctx, err := interceptBefore(ctx, method, c.interceptors, params)
+	ctx, err := c.interceptBefore(ctx, method, params)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.ListTaskPushConfig(ctx, params)
 
-	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
+	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -199,14 +199,14 @@ func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPus
 func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error) {
 	method := "SetTaskPushConfig"
 
-	ctx, err := interceptBefore(ctx, method, c.interceptors, params)
+	ctx, err := c.interceptBefore(ctx, method, params)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.SetTaskPushConfig(ctx, params)
 
-	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
+	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -216,14 +216,14 @@ func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConf
 func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error {
 	method := "DeleteTaskPushConfig"
 
-	ctx, err := interceptBefore(ctx, method, c.interceptors, params)
+	ctx, err := c.interceptBefore(ctx, method, params)
 	if err != nil {
 		return err
 	}
 
 	err = c.transport.DeleteTaskPushConfig(ctx, params)
 
-	if err := interceptAfter(ctx, method, c.interceptors, nil, err); err != nil {
+	if err := c.interceptAfter(ctx, method, nil, err); err != nil {
 		return err
 	}
 
@@ -233,13 +233,13 @@ func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTas
 func (c *Client) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
 	method := "GetAgentCard"
 
-	ctx, err := interceptBefore(ctx, method, c.interceptors, nil)
+	ctx, err := c.interceptBefore(ctx, method, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.GetAgentCard(ctx)
-	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
+	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -250,7 +250,7 @@ func (c *Client) Destroy() error {
 	return c.transport.Destroy()
 }
 
-func interceptBefore(ctx context.Context, method string, interceptors []CallInterceptor, payload any) (context.Context, error) {
+func (c *Client) interceptBefore(ctx context.Context, method string, payload any) (context.Context, error) {
 	req := Request{
 		method:  method,
 		Meta:    CallMeta{},
@@ -261,7 +261,7 @@ func interceptBefore(ctx context.Context, method string, interceptors []CallInte
 		req.Payload = nil
 	}
 
-	for _, interceptor := range interceptors {
+	for _, interceptor := range c.interceptors {
 		localCtx, err := interceptor.Before(ctx, &req)
 		if err != nil {
 			return ctx, err
@@ -272,7 +272,7 @@ func interceptBefore(ctx context.Context, method string, interceptors []CallInte
 	return withCallMeta(ctx, req.Meta), nil
 }
 
-func interceptAfter(ctx context.Context, method string, interceptors []CallInterceptor, payload any, err error) error {
+func (c *Client) interceptAfter(ctx context.Context, method string, payload any, err error) error {
 	meta, ok := CallMetaFrom(ctx)
 	if !ok {
 		meta = CallMeta{}
@@ -288,7 +288,7 @@ func interceptAfter(ctx context.Context, method string, interceptors []CallInter
 		resp.Payload = nil
 	}
 
-	for _, interceptor := range interceptors {
+	for _, interceptor := range c.interceptors {
 		if err := interceptor.After(ctx, &resp); err != nil {
 			return err
 		}

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -122,6 +122,11 @@ func (c *Client) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) it
 				return
 			}
 
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
 			if !yield(resp, nil) {
 				return
 			}
@@ -141,6 +146,11 @@ func (c *Client) SendStreamingMessage(ctx context.Context, message *a2a.MessageS
 
 		for resp, err := range c.transport.SendStreamingMessage(ctx, message) {
 			if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if err != nil {
 				yield(nil, err)
 				return
 			}

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -65,7 +65,7 @@ func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.
 
 	resp, err := c.transport.GetTask(ctx, query)
 
-	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
+	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
 
@@ -82,7 +82,7 @@ func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Tas
 
 	resp, err := c.transport.CancelTask(ctx, id)
 
-	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
+	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
 
@@ -99,7 +99,7 @@ func (c *Client) SendMessage(ctx context.Context, message *a2a.MessageSendParams
 
 	resp, err := c.transport.SendMessage(ctx, message)
 
-	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
+	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
 
@@ -117,7 +117,7 @@ func (c *Client) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) it
 		}
 
 		for resp, err := range c.transport.ResubscribeToTask(ctx, id) {
-			if err := c.interceptAfter(ctx, method, resp, err); err != nil {
+			if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 				yield(nil, err)
 				return
 			}
@@ -145,7 +145,7 @@ func (c *Client) SendStreamingMessage(ctx context.Context, message *a2a.MessageS
 		}
 
 		for resp, err := range c.transport.SendStreamingMessage(ctx, message) {
-			if err := c.interceptAfter(ctx, method, resp, err); err != nil {
+			if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 				yield(nil, err)
 				return
 			}
@@ -172,7 +172,7 @@ func (c *Client) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushC
 
 	resp, err := c.transport.GetTaskPushConfig(ctx, params)
 
-	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
+	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
 
@@ -189,7 +189,7 @@ func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPus
 
 	resp, err := c.transport.ListTaskPushConfig(ctx, params)
 
-	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
+	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
 
@@ -206,7 +206,7 @@ func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConf
 
 	resp, err := c.transport.SetTaskPushConfig(ctx, params)
 
-	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
+	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
 
@@ -223,7 +223,7 @@ func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTas
 
 	err = c.transport.DeleteTaskPushConfig(ctx, params)
 
-	if err := c.interceptAfter(ctx, method, nil, err); err != nil {
+	if errOverride := c.interceptAfter(ctx, method, nil, err); errOverride != nil {
 		return err
 	}
 
@@ -239,7 +239,7 @@ func (c *Client) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
 	}
 
 	resp, err := c.transport.GetAgentCard(ctx)
-	if err := c.interceptAfter(ctx, method, resp, err); err != nil {
+	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
 		return nil, err
 	}
 

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -55,50 +55,224 @@ func (c *Client) AddCallInterceptor(ci CallInterceptor) {
 
 // A2A protocol methods
 
-func (c *Client) GetTask(ctx context.Context, query a2a.TaskQueryParams) (*a2a.Task, error) {
-	return &a2a.Task{}, ErrNotImplemented
+func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error) {
+	ctx = withMethod(ctx, "GetTask")
+
+	ctx, err := interceptBefore(ctx, c.interceptors, query)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.transport.GetTask(ctx, query)
+
+	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
-func (c *Client) CancelTask(ctx context.Context, id a2a.TaskIDParams) (*a2a.Task, error) {
-	return &a2a.Task{}, ErrNotImplemented
+func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
+	ctx = withMethod(ctx, "CancelTask")
+
+	ctx, err := interceptBefore(ctx, c.interceptors, id)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.transport.CancelTask(ctx, id)
+
+	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
-func (c *Client) SendMessage(ctx context.Context, message a2a.MessageSendParams) (a2a.SendMessageResult, error) {
-	return &a2a.Task{}, ErrNotImplemented
+func (c *Client) SendMessage(ctx context.Context, message *a2a.MessageSendParams) (a2a.SendMessageResult, error) {
+	ctx = withMethod(ctx, "SendMessage")
+
+	ctx, err := interceptBefore(ctx, c.interceptors, message)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.transport.SendMessage(ctx, message)
+
+	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
-func (c *Client) ResubscribeToTask(ctx context.Context, id a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
+func (c *Client) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
-		yield(&a2a.Message{}, ErrNotImplemented)
+		ctx = withMethod(ctx, "ResubscribeToTask")
+
+		ctx, err := interceptBefore(ctx, c.interceptors, id)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		for resp, err := range c.transport.ResubscribeToTask(ctx, id) {
+			if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(resp, nil) {
+				return
+			}
+		}
 	}
 }
 
-func (c *Client) SendStreamingMessage(ctx context.Context, message a2a.MessageSendParams) iter.Seq2[a2a.Event, error] {
+func (c *Client) SendStreamingMessage(ctx context.Context, message *a2a.MessageSendParams) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
-		yield(&a2a.Message{}, ErrNotImplemented)
+		ctx = withMethod(ctx, "SendStreamingMessage")
+
+		ctx, err := interceptBefore(ctx, c.interceptors, message)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+
+		for resp, err := range c.transport.SendStreamingMessage(ctx, message) {
+			if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+				yield(nil, err)
+				return
+			}
+
+			if !yield(resp, nil) {
+				return
+			}
+		}
 	}
 }
 
-func (c *Client) GetTaskPushConfig(ctx context.Context, params a2a.GetTaskPushConfigParams) (a2a.TaskPushConfig, error) {
-	return a2a.TaskPushConfig{}, ErrNotImplemented
+func (c *Client) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushConfigParams) (*a2a.TaskPushConfig, error) {
+	ctx = withMethod(ctx, "GetTaskPushConfig")
+
+	ctx, err := interceptBefore(ctx, c.interceptors, params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.transport.GetTaskPushConfig(ctx, params)
+
+	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
-func (c *Client) ListTaskPushConfig(ctx context.Context, params a2a.ListTaskPushConfigParams) ([]a2a.TaskPushConfig, error) {
-	return []a2a.TaskPushConfig{}, ErrNotImplemented
+func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error) {
+	ctx = withMethod(ctx, "ListTaskPushConfig")
+
+	ctx, err := interceptBefore(ctx, c.interceptors, params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.transport.ListTaskPushConfig(ctx, params)
+
+	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
-func (c *Client) SetTaskPushConfig(ctx context.Context, params a2a.TaskPushConfig) (a2a.TaskPushConfig, error) {
-	return a2a.TaskPushConfig{}, ErrNotImplemented
+func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error) {
+	ctx = withMethod(ctx, "SetTaskPushConfig")
+
+	ctx, err := interceptBefore(ctx, c.interceptors, params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.transport.SetTaskPushConfig(ctx, params)
+
+	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
-func (c *Client) DeleteTaskPushConfig(ctx context.Context, params a2a.DeleteTaskPushConfigParams) error {
-	return ErrNotImplemented
+func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error {
+	ctx = withMethod(ctx, "DeleteTaskPushConfig")
+
+	ctx, err := interceptBefore(ctx, c.interceptors, params)
+	if err != nil {
+		return err
+	}
+
+	err = c.transport.DeleteTaskPushConfig(ctx, params)
+
+	if err := interceptAfter(ctx, c.interceptors, nil, err); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *Client) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
-	return &a2a.AgentCard{}, ErrNotImplemented
+	ctx = withMethod(ctx, "GetAgentCard")
+
+	ctx, err := interceptBefore(ctx, c.interceptors, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.transport.GetAgentCard(ctx)
+	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 func (c *Client) Destroy() error {
 	return c.transport.Destroy()
+}
+
+func interceptBefore(ctx context.Context, interceptors []CallInterceptor, payload any) (context.Context, error) {
+	req := Request{Meta: CallMeta{}, Payload: payload}
+	if payload == nil { // set interface to nil if method does not take any parameters
+		req.Payload = nil
+	}
+
+	for _, interceptor := range interceptors {
+		localCtx, err := interceptor.Before(ctx, &req)
+		if err != nil {
+			return ctx, err
+		}
+		ctx = localCtx
+	}
+
+	return WithCallMeta(ctx, req.Meta), nil
+}
+
+func interceptAfter(ctx context.Context, interceptors []CallInterceptor, payload any, err error) error {
+	meta, ok := CallMetaFrom(ctx)
+	if !ok {
+		meta = CallMeta{}
+	}
+
+	resp := Response{Meta: meta, Payload: payload, Err: err}
+	if payload == nil { // set interface to nil if method does not return any value
+		resp.Payload = nil
+	}
+
+	for _, interceptor := range interceptors {
+		if err := interceptor.After(ctx, &resp); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -56,16 +56,16 @@ func (c *Client) AddCallInterceptor(ci CallInterceptor) {
 // A2A protocol methods
 
 func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error) {
-	ctx = withMethod(ctx, "GetTask")
+	method := "GetTask"
 
-	ctx, err := interceptBefore(ctx, c.interceptors, query)
+	ctx, err := interceptBefore(ctx, method, c.interceptors, query)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.GetTask(ctx, query)
 
-	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -73,16 +73,16 @@ func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.
 }
 
 func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
-	ctx = withMethod(ctx, "CancelTask")
+	method := "CancelTask"
 
-	ctx, err := interceptBefore(ctx, c.interceptors, id)
+	ctx, err := interceptBefore(ctx, method, c.interceptors, id)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.CancelTask(ctx, id)
 
-	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -90,16 +90,16 @@ func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Tas
 }
 
 func (c *Client) SendMessage(ctx context.Context, message *a2a.MessageSendParams) (a2a.SendMessageResult, error) {
-	ctx = withMethod(ctx, "SendMessage")
+	method := "SendMessage"
 
-	ctx, err := interceptBefore(ctx, c.interceptors, message)
+	ctx, err := interceptBefore(ctx, method, c.interceptors, message)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.SendMessage(ctx, message)
 
-	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -108,16 +108,16 @@ func (c *Client) SendMessage(ctx context.Context, message *a2a.MessageSendParams
 
 func (c *Client) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
-		ctx = withMethod(ctx, "ResubscribeToTask")
+		method := "ResubscribeToTask"
 
-		ctx, err := interceptBefore(ctx, c.interceptors, id)
+		ctx, err := interceptBefore(ctx, method, c.interceptors, id)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 
 		for resp, err := range c.transport.ResubscribeToTask(ctx, id) {
-			if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+			if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
 				yield(nil, err)
 				return
 			}
@@ -136,16 +136,16 @@ func (c *Client) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) it
 
 func (c *Client) SendStreamingMessage(ctx context.Context, message *a2a.MessageSendParams) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
-		ctx = withMethod(ctx, "SendStreamingMessage")
+		method := "SendStreamingMessage"
 
-		ctx, err := interceptBefore(ctx, c.interceptors, message)
+		ctx, err := interceptBefore(ctx, method, c.interceptors, message)
 		if err != nil {
 			yield(nil, err)
 			return
 		}
 
 		for resp, err := range c.transport.SendStreamingMessage(ctx, message) {
-			if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+			if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
 				yield(nil, err)
 				return
 			}
@@ -163,16 +163,16 @@ func (c *Client) SendStreamingMessage(ctx context.Context, message *a2a.MessageS
 }
 
 func (c *Client) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushConfigParams) (*a2a.TaskPushConfig, error) {
-	ctx = withMethod(ctx, "GetTaskPushConfig")
+	method := "GetTaskPushConfig"
 
-	ctx, err := interceptBefore(ctx, c.interceptors, params)
+	ctx, err := interceptBefore(ctx, method, c.interceptors, params)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.GetTaskPushConfig(ctx, params)
 
-	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -180,16 +180,16 @@ func (c *Client) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushC
 }
 
 func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error) {
-	ctx = withMethod(ctx, "ListTaskPushConfig")
+	method := "ListTaskPushConfig"
 
-	ctx, err := interceptBefore(ctx, c.interceptors, params)
+	ctx, err := interceptBefore(ctx, method, c.interceptors, params)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.ListTaskPushConfig(ctx, params)
 
-	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -197,16 +197,16 @@ func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPus
 }
 
 func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error) {
-	ctx = withMethod(ctx, "SetTaskPushConfig")
+	method := "SetTaskPushConfig"
 
-	ctx, err := interceptBefore(ctx, c.interceptors, params)
+	ctx, err := interceptBefore(ctx, method, c.interceptors, params)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.SetTaskPushConfig(ctx, params)
 
-	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -214,16 +214,16 @@ func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConf
 }
 
 func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error {
-	ctx = withMethod(ctx, "DeleteTaskPushConfig")
+	method := "DeleteTaskPushConfig"
 
-	ctx, err := interceptBefore(ctx, c.interceptors, params)
+	ctx, err := interceptBefore(ctx, method, c.interceptors, params)
 	if err != nil {
 		return err
 	}
 
 	err = c.transport.DeleteTaskPushConfig(ctx, params)
 
-	if err := interceptAfter(ctx, c.interceptors, nil, err); err != nil {
+	if err := interceptAfter(ctx, method, c.interceptors, nil, err); err != nil {
 		return err
 	}
 
@@ -231,15 +231,15 @@ func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTas
 }
 
 func (c *Client) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
-	ctx = withMethod(ctx, "GetAgentCard")
+	method := "GetAgentCard"
 
-	ctx, err := interceptBefore(ctx, c.interceptors, nil)
+	ctx, err := interceptBefore(ctx, method, c.interceptors, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := c.transport.GetAgentCard(ctx)
-	if err := interceptAfter(ctx, c.interceptors, resp, err); err != nil {
+	if err := interceptAfter(ctx, method, c.interceptors, resp, err); err != nil {
 		return nil, err
 	}
 
@@ -250,8 +250,13 @@ func (c *Client) Destroy() error {
 	return c.transport.Destroy()
 }
 
-func interceptBefore(ctx context.Context, interceptors []CallInterceptor, payload any) (context.Context, error) {
-	req := Request{Meta: CallMeta{}, Payload: payload}
+func interceptBefore(ctx context.Context, method string, interceptors []CallInterceptor, payload any) (context.Context, error) {
+	req := Request{
+		method:  method,
+		Meta:    CallMeta{},
+		Payload: payload,
+	}
+
 	if payload == nil { // set interface to nil if method does not take any parameters
 		req.Payload = nil
 	}
@@ -267,13 +272,18 @@ func interceptBefore(ctx context.Context, interceptors []CallInterceptor, payloa
 	return withCallMeta(ctx, req.Meta), nil
 }
 
-func interceptAfter(ctx context.Context, interceptors []CallInterceptor, payload any, err error) error {
+func interceptAfter(ctx context.Context, method string, interceptors []CallInterceptor, payload any, err error) error {
 	meta, ok := CallMetaFrom(ctx)
 	if !ok {
 		meta = CallMeta{}
 	}
 
-	resp := Response{Meta: meta, Payload: payload, Err: err}
+	resp := Response{
+		method:  method,
+		Meta:    meta,
+		Payload: payload,
+		Err:     err,
+	}
 	if payload == nil { // set interface to nil if method does not return any value
 		resp.Payload = nil
 	}

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -65,7 +65,7 @@ func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.
 
 	resp, err := c.transport.GetTask(ctx, query)
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
-		return nil, err
+		return nil, errOverride
 	}
 
 	return resp, err
@@ -81,7 +81,7 @@ func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Tas
 
 	resp, err := c.transport.CancelTask(ctx, id)
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
-		return nil, err
+		return nil, errOverride
 	}
 
 	return resp, err
@@ -97,7 +97,7 @@ func (c *Client) SendMessage(ctx context.Context, message *a2a.MessageSendParams
 
 	resp, err := c.transport.SendMessage(ctx, message)
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
-		return nil, err
+		return nil, errOverride
 	}
 
 	return resp, err
@@ -115,7 +115,7 @@ func (c *Client) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) it
 
 		for resp, err := range c.transport.ResubscribeToTask(ctx, id) {
 			if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
-				yield(nil, err)
+				yield(nil, errOverride)
 				return
 			}
 
@@ -143,7 +143,7 @@ func (c *Client) SendStreamingMessage(ctx context.Context, message *a2a.MessageS
 
 		for resp, err := range c.transport.SendStreamingMessage(ctx, message) {
 			if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
-				yield(nil, err)
+				yield(nil, errOverride)
 				return
 			}
 
@@ -169,7 +169,7 @@ func (c *Client) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushC
 
 	resp, err := c.transport.GetTaskPushConfig(ctx, params)
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
-		return nil, err
+		return nil, errOverride
 	}
 
 	return resp, err
@@ -185,7 +185,7 @@ func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPus
 
 	resp, err := c.transport.ListTaskPushConfig(ctx, params)
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
-		return nil, err
+		return nil, errOverride
 	}
 
 	return resp, err
@@ -201,7 +201,7 @@ func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConf
 
 	resp, err := c.transport.SetTaskPushConfig(ctx, params)
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
-		return nil, err
+		return nil, errOverride
 	}
 
 	return resp, err
@@ -217,7 +217,7 @@ func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTas
 
 	err = c.transport.DeleteTaskPushConfig(ctx, params)
 	if errOverride := c.interceptAfter(ctx, method, nil, err); errOverride != nil {
-		return err
+		return errOverride
 	}
 
 	return err
@@ -233,7 +233,7 @@ func (c *Client) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
 
 	resp, err := c.transport.GetAgentCard(ctx)
 	if errOverride := c.interceptAfter(ctx, method, resp, err); errOverride != nil {
-		return nil, err
+		return nil, errOverride
 	}
 
 	return resp, err

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -274,5 +274,5 @@ func interceptAfter(ctx context.Context, interceptors []CallInterceptor, payload
 		}
 	}
 
-	return nil
+	return resp.Err
 }

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -69,7 +69,7 @@ func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.
 		return nil, err
 	}
 
-	return resp, nil
+	return resp, err
 }
 
 func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
@@ -86,7 +86,7 @@ func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Tas
 		return nil, err
 	}
 
-	return resp, nil
+	return resp, err
 }
 
 func (c *Client) SendMessage(ctx context.Context, message *a2a.MessageSendParams) (a2a.SendMessageResult, error) {
@@ -103,7 +103,7 @@ func (c *Client) SendMessage(ctx context.Context, message *a2a.MessageSendParams
 		return nil, err
 	}
 
-	return resp, nil
+	return resp, err
 }
 
 func (c *Client) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) iter.Seq2[a2a.Event, error] {
@@ -166,7 +166,7 @@ func (c *Client) GetTaskPushConfig(ctx context.Context, params *a2a.GetTaskPushC
 		return nil, err
 	}
 
-	return resp, nil
+	return resp, err
 }
 
 func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPushConfigParams) ([]*a2a.TaskPushConfig, error) {
@@ -183,7 +183,7 @@ func (c *Client) ListTaskPushConfig(ctx context.Context, params *a2a.ListTaskPus
 		return nil, err
 	}
 
-	return resp, nil
+	return resp, err
 }
 
 func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConfig) (*a2a.TaskPushConfig, error) {
@@ -200,7 +200,7 @@ func (c *Client) SetTaskPushConfig(ctx context.Context, params *a2a.TaskPushConf
 		return nil, err
 	}
 
-	return resp, nil
+	return resp, err
 }
 
 func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTaskPushConfigParams) error {
@@ -217,7 +217,7 @@ func (c *Client) DeleteTaskPushConfig(ctx context.Context, params *a2a.DeleteTas
 		return err
 	}
 
-	return nil
+	return err
 }
 
 func (c *Client) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
@@ -233,7 +233,7 @@ func (c *Client) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
 		return nil, err
 	}
 
-	return resp, nil
+	return resp, err
 }
 
 func (c *Client) Destroy() error {

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -254,7 +254,7 @@ func interceptBefore(ctx context.Context, interceptors []CallInterceptor, payloa
 		ctx = localCtx
 	}
 
-	return WithCallMeta(ctx, req.Meta), nil
+	return withCallMeta(ctx, req.Meta), nil
 }
 
 func interceptAfter(ctx context.Context, interceptors []CallInterceptor, payload any, err error) error {

--- a/a2aclient/client_test.go
+++ b/a2aclient/client_test.go
@@ -92,19 +92,13 @@ func makeEventSeq2(events []a2a.Event) iter.Seq2[a2a.Event, error] {
 }
 
 type testInterceptor struct {
-	lastCallCtx *CallContext
-	lastReq     *Request
-	lastResp    *Response
-	BeforeFn    func(context.Context, *Request) (context.Context, error)
-	AfterFn     func(context.Context, *Response) error
+	lastReq  *Request
+	lastResp *Response
+	BeforeFn func(context.Context, *Request) (context.Context, error)
+	AfterFn  func(context.Context, *Response) error
 }
 
 func (ti *testInterceptor) Before(ctx context.Context, req *Request) (context.Context, error) {
-	if callCtx, ok := CallContextFrom(ctx); ok {
-		ti.lastCallCtx = &callCtx
-	} else {
-		ti.lastCallCtx = nil
-	}
 	ti.lastReq = req
 	if ti.BeforeFn != nil {
 		return ti.BeforeFn(ctx, req)
@@ -322,8 +316,8 @@ func TestClient_InterceptGetTask(t *testing.T) {
 	client := newTestClient(transport, interceptor)
 	req := &a2a.TaskQueryParams{}
 	resp, err := client.GetTask(ctx, req)
-	if interceptor.lastCallCtx.Method != "GetTask" {
-		t.Fatalf("expected method to be GetTask, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "GetTask" {
+		t.Fatalf("expected method to be GetTask, got %v", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != task {
 		t.Fatalf("expected %v, got %v, %v", task, resp, err)
@@ -348,8 +342,8 @@ func TestClient_InterceptCancelTask(t *testing.T) {
 	client := newTestClient(transport, interceptor)
 	req := &a2a.TaskIDParams{}
 	resp, err := client.CancelTask(ctx, req)
-	if interceptor.lastCallCtx.Method != "CancelTask" {
-		t.Fatalf("expected method to be CancelTask, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "CancelTask" {
+		t.Fatalf("expected method to be CancelTask, got %v", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != task {
 		t.Fatalf("expected %v, got %v, %v", task, resp, err)
@@ -374,8 +368,8 @@ func TestClient_InterceptSendMessage(t *testing.T) {
 	client := newTestClient(transport, interceptor)
 	req := &a2a.MessageSendParams{}
 	resp, err := client.SendMessage(ctx, req)
-	if interceptor.lastCallCtx.Method != "SendMessage" {
-		t.Fatalf("expected method to be SendMessage, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "SendMessage" {
+		t.Fatalf("expected method to be SendMessage, got %v", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != task {
 		t.Fatalf("expected %v, got %v, %v", task, resp, err)
@@ -413,8 +407,8 @@ func TestClient_InterceptResubscribeToTask(t *testing.T) {
 		}
 		eventI += 1
 	}
-	if interceptor.lastCallCtx.Method != "ResubscribeToTask" {
-		t.Fatalf("expected method to be ResubscribeToTask, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "ResubscribeToTask" {
+		t.Fatalf("expected method to be ResubscribeToTask, got %v", interceptor.lastReq.Method())
 	}
 	if interceptor.lastReq.Payload != req {
 		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
@@ -446,8 +440,8 @@ func TestClient_InterceptSendStreamingMessage(t *testing.T) {
 		}
 		eventI += 1
 	}
-	if interceptor.lastCallCtx.Method != "SendStreamingMessage" {
-		t.Fatalf("expected method to be SendStreamingMessage, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "SendStreamingMessage" {
+		t.Fatalf("expected method to be SendStreamingMessage, got %v", interceptor.lastReq.Method())
 	}
 	if interceptor.lastReq.Payload != req {
 		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
@@ -466,8 +460,8 @@ func TestClient_InterceptGetTaskPushConfig(t *testing.T) {
 	client := newTestClient(transport, interceptor)
 	req := &a2a.GetTaskPushConfigParams{}
 	resp, err := client.GetTaskPushConfig(ctx, req)
-	if interceptor.lastCallCtx.Method != "GetTaskPushConfig" {
-		t.Fatalf("expected method to be GetTaskPushConfig, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "GetTaskPushConfig" {
+		t.Fatalf("expected method to be GetTaskPushConfig, got %v", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != config {
 		t.Fatalf("expected %v, got %v, %v", config, resp, err)
@@ -492,8 +486,8 @@ func TestClient_InterceptListTaskPushConfig(t *testing.T) {
 	client := newTestClient(transport, interceptor)
 	req := &a2a.ListTaskPushConfigParams{}
 	resp, err := client.ListTaskPushConfig(ctx, req)
-	if interceptor.lastCallCtx.Method != "ListTaskPushConfig" {
-		t.Fatalf("expected method to be ListTaskPushConfig, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "ListTaskPushConfig" {
+		t.Fatalf("expected method to be ListTaskPushConfig, got %v", interceptor.lastReq.Method())
 	}
 	if err != nil || len(resp) != 1 || resp[0] != config {
 		t.Fatalf("expected %v, got %v, %v", config, resp, err)
@@ -518,8 +512,8 @@ func TestClient_InterceptSetTaskPushConfig(t *testing.T) {
 	client := newTestClient(transport, interceptor)
 	req := &a2a.TaskPushConfig{}
 	resp, err := client.SetTaskPushConfig(ctx, req)
-	if interceptor.lastCallCtx.Method != "SetTaskPushConfig" {
-		t.Fatalf("expected method to be SetTaskPushConfig, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "SetTaskPushConfig" {
+		t.Fatalf("expected method to be SetTaskPushConfig, got %v", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != config {
 		t.Fatalf("expected %v, got %v, %v", config, resp, err)
@@ -543,8 +537,8 @@ func TestClient_InterceptDeleteTaskPushConfig(t *testing.T) {
 	client := newTestClient(transport, interceptor)
 	req := &a2a.DeleteTaskPushConfigParams{}
 	err := client.DeleteTaskPushConfig(ctx, req)
-	if interceptor.lastCallCtx.Method != "DeleteTaskPushConfig" {
-		t.Fatalf("expected method to be DeleteTaskPushConfig, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "DeleteTaskPushConfig" {
+		t.Fatalf("expected method to be DeleteTaskPushConfig, got %v", interceptor.lastReq.Method())
 	}
 	if err != nil {
 		t.Fatalf("expected delete to succeed, got %v", err)
@@ -568,8 +562,8 @@ func TestClient_InterceptGetAgentCard(t *testing.T) {
 	interceptor := &testInterceptor{}
 	client := newTestClient(transport, interceptor)
 	resp, err := client.GetAgentCard(ctx)
-	if interceptor.lastCallCtx.Method != "GetAgentCard" {
-		t.Fatalf("expected method to be GetAgentCard, got %v", interceptor.lastCallCtx)
+	if interceptor.lastReq.Method() != "GetAgentCard" {
+		t.Fatalf("expected method to be GetAgentCard, got %v", interceptor.lastReq.Method())
 	}
 	if err != nil {
 		t.Fatalf("expected delete to succeed, got %v", err)

--- a/a2aclient/client_test.go
+++ b/a2aclient/client_test.go
@@ -176,13 +176,13 @@ func TestClient_InterceptorsAttachCallMeta(t *testing.T) {
 	k1, v1, k2, v2 := "Authorization", "Basic ABCD", "X-Custom", "test"
 	interceptor1 := &testInterceptor{
 		BeforeFn: func(ctx context.Context, r *Request) (context.Context, error) {
-			r.Meta[k1] = v1
+			r.Meta[k1] = []string{v1}
 			return ctx, nil
 		},
 	}
 	interceptor2 := &testInterceptor{
 		BeforeFn: func(ctx context.Context, r *Request) (context.Context, error) {
-			r.Meta[k2] = v2
+			r.Meta[k2] = []string{v2}
 			return ctx, nil
 		},
 	}
@@ -191,7 +191,7 @@ func TestClient_InterceptorsAttachCallMeta(t *testing.T) {
 	if _, err := client.GetTask(ctx, &a2a.TaskQueryParams{}); err != nil {
 		t.Fatalf("expected call to succeed, got %v", err)
 	}
-	wantCallMeta := CallMeta{k1: v1, k2: v2}
+	wantCallMeta := CallMeta{k1: []string{v1}, k2: []string{v2}}
 	if !reflect.DeepEqual(receivedCallMeta, wantCallMeta) {
 		t.Fatalf("expected meta to be %v, got %v", wantCallMeta, receivedCallMeta)
 	}

--- a/a2aclient/client_test.go
+++ b/a2aclient/client_test.go
@@ -124,6 +124,22 @@ func newTestClient(transport Transport, interceptors ...CallInterceptor) *Client
 	return &Client{transport: transport, interceptors: interceptors}
 }
 
+func TestClient_CallFails(t *testing.T) {
+	ctx := t.Context()
+	wantErr := errors.New("call failed")
+
+	transport := &testTransport{
+		GetTaskFn: func(ctx context.Context, tqp *a2a.TaskQueryParams) (*a2a.Task, error) {
+			return nil, wantErr
+		},
+	}
+	client := newTestClient(transport)
+
+	if _, err := client.GetTask(ctx, &a2a.TaskQueryParams{}); !errors.Is(err, wantErr) {
+		t.Fatalf("expected call to fail with %v, got %v", wantErr, err)
+	}
+}
+
 func TestClient_InterceptorModifiesRequest(t *testing.T) {
 	ctx := t.Context()
 	task := &a2a.Task{}

--- a/a2aclient/client_test.go
+++ b/a2aclient/client_test.go
@@ -130,7 +130,7 @@ func TestClient_CallFails(t *testing.T) {
 	client := newTestClient(transport)
 
 	if _, err := client.GetTask(ctx, &a2a.TaskQueryParams{}); !errors.Is(err, wantErr) {
-		t.Fatalf("expected call to fail with %v, got %v", wantErr, err)
+		t.Fatalf("client.GetTask() error = %v, want %v", err, wantErr)
 	}
 }
 
@@ -155,10 +155,10 @@ func TestClient_InterceptorModifiesRequest(t *testing.T) {
 
 	client := newTestClient(transport, interceptor)
 	if _, err := client.GetTask(ctx, &a2a.TaskQueryParams{}); err != nil {
-		t.Fatalf("expected call to succeed, got %v", err)
+		t.Fatalf("client.GetTask() error = %v, want nil", err)
 	}
 	if receivedMeta[metaKey] != metaVal {
-		t.Fatalf("expected meta[%s]=%d, got %v", metaKey, metaVal, receivedMeta[metaKey])
+		t.Fatalf("client.GetTask() meta[%s]=%v, want %v", metaKey, receivedMeta[metaKey], metaVal)
 	}
 }
 
@@ -189,11 +189,11 @@ func TestClient_InterceptorsAttachCallMeta(t *testing.T) {
 
 	client := newTestClient(transport, interceptor1, interceptor2)
 	if _, err := client.GetTask(ctx, &a2a.TaskQueryParams{}); err != nil {
-		t.Fatalf("expected call to succeed, got %v", err)
+		t.Fatalf("client.GetTask() error = %v, want nil", err)
 	}
 	wantCallMeta := CallMeta{k1: []string{v1}, k2: []string{v2}}
 	if !reflect.DeepEqual(receivedCallMeta, wantCallMeta) {
-		t.Fatalf("expected meta to be %v, got %v", wantCallMeta, receivedCallMeta)
+		t.Fatalf("client.GetTask() meta = %v, want %v", receivedCallMeta, wantCallMeta)
 	}
 }
 
@@ -217,10 +217,10 @@ func TestClient_InterceptorModifiesResponse(t *testing.T) {
 	client := newTestClient(transport, interceptor)
 	task, err := client.GetTask(ctx, &a2a.TaskQueryParams{})
 	if err != nil {
-		t.Fatalf("expected call to succeed, got %v", err)
+		t.Fatalf("client.GetTask() error = %v, want nil", err)
 	}
 	if task.Metadata[metaKey] != metaVal {
-		t.Fatalf("expected meta[%s]=%d, got %v", metaKey, metaVal, task.Metadata[metaKey])
+		t.Fatalf("client.GetTask() meta[%s]=%v, want %v", metaKey, task.Metadata[metaKey], metaVal)
 	}
 }
 
@@ -242,10 +242,10 @@ func TestClient_InterceptorRejectsRequest(t *testing.T) {
 
 	client := newTestClient(transport, interceptor)
 	if task, err := client.GetTask(ctx, &a2a.TaskQueryParams{}); !errors.Is(err, wantErr) {
-		t.Fatalf("expected call to fail with %v, got %v, %v", wantErr, task, err)
+		t.Fatalf("client.GetTask() = (%v, %v), want error %v", task, err, wantErr)
 	}
 	if called {
-		t.Fatalf("expected transport to not be called")
+		t.Fatal("expected transport to not be called")
 	}
 }
 
@@ -267,10 +267,10 @@ func TestClient_InterceptorRejectsResponse(t *testing.T) {
 
 	client := newTestClient(transport, interceptor)
 	if task, err := client.GetTask(ctx, &a2a.TaskQueryParams{}); !errors.Is(err, wantErr) {
-		t.Fatalf("expected call to fail with %v, got %v, %v", wantErr, task, err)
+		t.Fatalf("client.GetTask() = (%v, %v), want error %v", task, err, wantErr)
 	}
 	if !called {
-		t.Fatalf("expected transport to be called")
+		t.Fatal("expected transport to be called")
 	}
 }
 
@@ -296,11 +296,11 @@ func TestClient_InterceptorMethodsDataSharing(t *testing.T) {
 
 	client := newTestClient(transport, interceptor)
 	if _, err := client.GetTask(ctx, &a2a.TaskQueryParams{}); err != nil {
-		t.Fatalf("expected call to succeed, got %v", err)
+		t.Fatalf("client.GetTask() error = %v, want nil", err)
 	}
 
 	if receivedVal != val {
-		t.Fatalf("expected transport to not be called")
+		t.Fatal("expected transport to not be called")
 	}
 }
 
@@ -317,16 +317,16 @@ func TestClient_InterceptGetTask(t *testing.T) {
 	req := &a2a.TaskQueryParams{}
 	resp, err := client.GetTask(ctx, req)
 	if interceptor.lastReq.Method() != "GetTask" {
-		t.Fatalf("expected method to be GetTask, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got = %v, want GetTask", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != task {
-		t.Fatalf("expected %v, got %v, %v", task, resp, err)
+		t.Fatalf("client.GetTask() = (%v, %v), want %v", resp, err, task)
 	}
 	if interceptor.lastReq.Payload != req {
-		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before() payload = %v, want %v", interceptor.lastReq.Payload, req)
 	}
 	if interceptor.lastResp.Payload != task {
-		t.Fatalf("expected interceptor.After to intercept %v, got %v", task, interceptor.lastResp.Payload)
+		t.Fatalf("interceptor.After() payload = %v, want %v", interceptor.lastResp.Payload, task)
 	}
 }
 
@@ -343,16 +343,16 @@ func TestClient_InterceptCancelTask(t *testing.T) {
 	req := &a2a.TaskIDParams{}
 	resp, err := client.CancelTask(ctx, req)
 	if interceptor.lastReq.Method() != "CancelTask" {
-		t.Fatalf("expected method to be CancelTask, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got = %v, want CancelTask", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != task {
-		t.Fatalf("expected %v, got %v, %v", task, resp, err)
+		t.Fatalf("client.CancelTask() = (%v, %v), want %v", resp, err, task)
 	}
 	if interceptor.lastReq.Payload != req {
-		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before() payload = %v, want %v", interceptor.lastReq.Payload, req)
 	}
 	if interceptor.lastResp.Payload != task {
-		t.Fatalf("expected interceptor.After to intercept %v, got %v", task, interceptor.lastResp.Payload)
+		t.Fatalf("interceptor.After() payload = %v, want %v", interceptor.lastResp.Payload, task)
 	}
 }
 
@@ -369,16 +369,16 @@ func TestClient_InterceptSendMessage(t *testing.T) {
 	req := &a2a.MessageSendParams{}
 	resp, err := client.SendMessage(ctx, req)
 	if interceptor.lastReq.Method() != "SendMessage" {
-		t.Fatalf("expected method to be SendMessage, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got %v, want SendMessage", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != task {
-		t.Fatalf("expected %v, got %v, %v", task, resp, err)
+		t.Fatalf("client.SendMessage() = (%v, %v), want %v", resp, err, task)
 	}
 	if interceptor.lastReq.Payload != req {
-		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before payload = %v, got %v", interceptor.lastReq.Payload, req)
 	}
 	if interceptor.lastResp.Payload != task {
-		t.Fatalf("expected interceptor.After to intercept %v, got %v", task, interceptor.lastResp.Payload)
+		t.Fatalf("interceptor.After payload = %v, got %v", interceptor.lastResp.Payload, task)
 	}
 }
 
@@ -400,18 +400,18 @@ func TestClient_InterceptResubscribeToTask(t *testing.T) {
 	eventI := 0
 	for resp, err := range client.ResubscribeToTask(ctx, req) {
 		if err != nil || resp != events[eventI] {
-			t.Fatalf("expected %v, got %v, %v", events[eventI], resp, err)
+			t.Fatalf("client.ResubscribeToTask()[%d] = (%v, %v), want %v", eventI, resp, err, events[eventI])
 		}
 		if interceptor.lastResp.Payload != events[eventI] {
-			t.Fatalf("expected interceptor.After to intercept %dth %v, got %v", eventI, events[eventI], interceptor.lastResp.Payload)
+			t.Fatalf("interceptor.After %d-th payload = %v, want %v", eventI, interceptor.lastResp.Payload, events[eventI])
 		}
 		eventI += 1
 	}
 	if interceptor.lastReq.Method() != "ResubscribeToTask" {
-		t.Fatalf("expected method to be ResubscribeToTask, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got %v, want ResubscribeToTask", interceptor.lastReq.Method())
 	}
 	if interceptor.lastReq.Payload != req {
-		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before payload = %v, want %v", interceptor.lastReq.Payload, req)
 	}
 }
 
@@ -433,18 +433,18 @@ func TestClient_InterceptSendStreamingMessage(t *testing.T) {
 	eventI := 0
 	for resp, err := range client.SendStreamingMessage(ctx, req) {
 		if err != nil || resp != events[eventI] {
-			t.Fatalf("expected %v, got %v, %v", events[eventI], resp, err)
+			t.Fatalf("client.SendStreamingMessage()[%d] = (%v, %v), want %v", eventI, resp, err, events[eventI])
 		}
 		if interceptor.lastResp.Payload != events[eventI] {
-			t.Fatalf("expected interceptor.After to intercept %dth %v, got %v", eventI, events[eventI], interceptor.lastResp.Payload)
+			t.Fatalf("interceptor.After %d-th payload = %v, want %v", eventI, interceptor.lastResp.Payload, events[eventI])
 		}
 		eventI += 1
 	}
 	if interceptor.lastReq.Method() != "SendStreamingMessage" {
-		t.Fatalf("expected method to be SendStreamingMessage, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got %v, want SendStreamingMessage", interceptor.lastReq.Method())
 	}
 	if interceptor.lastReq.Payload != req {
-		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before payload = %v, want %v", interceptor.lastReq.Payload, req)
 	}
 }
 
@@ -461,16 +461,16 @@ func TestClient_InterceptGetTaskPushConfig(t *testing.T) {
 	req := &a2a.GetTaskPushConfigParams{}
 	resp, err := client.GetTaskPushConfig(ctx, req)
 	if interceptor.lastReq.Method() != "GetTaskPushConfig" {
-		t.Fatalf("expected method to be GetTaskPushConfig, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got %v, want GetTaskPushConfig", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != config {
-		t.Fatalf("expected %v, got %v, %v", config, resp, err)
+		t.Fatalf("client.GetTaskPushConfig() = (%v, %v), want %v", resp, err, config)
 	}
 	if interceptor.lastReq.Payload != req {
-		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before payload = %v, want %v", interceptor.lastReq.Payload, req)
 	}
 	if interceptor.lastResp.Payload != config {
-		t.Fatalf("expected interceptor.After to intercept %v, got %v", config, interceptor.lastResp.Payload)
+		t.Fatalf("interceptor.After payload = %v, want %v", interceptor.lastResp.Payload, config)
 	}
 }
 
@@ -487,16 +487,16 @@ func TestClient_InterceptListTaskPushConfig(t *testing.T) {
 	req := &a2a.ListTaskPushConfigParams{}
 	resp, err := client.ListTaskPushConfig(ctx, req)
 	if interceptor.lastReq.Method() != "ListTaskPushConfig" {
-		t.Fatalf("expected method to be ListTaskPushConfig, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got %v, want ListTaskPushConfig", interceptor.lastReq.Method())
 	}
 	if err != nil || len(resp) != 1 || resp[0] != config {
-		t.Fatalf("expected %v, got %v, %v", config, resp, err)
+		t.Fatalf("client.ListTaskPushConfig() = (%v, %v), want %v", resp, err, config)
 	}
 	if interceptor.lastReq.Payload != req {
-		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before payload = %v, want %v", interceptor.lastReq.Payload, req)
 	}
 	if interceptor.lastResp.Payload.([]*a2a.TaskPushConfig)[0] != config {
-		t.Fatalf("expected interceptor.After to intercept %v, got %v", config, interceptor.lastResp.Payload)
+		t.Fatalf("interceptor.After payload = %v, want %v", interceptor.lastResp.Payload, config)
 	}
 }
 
@@ -513,16 +513,16 @@ func TestClient_InterceptSetTaskPushConfig(t *testing.T) {
 	req := &a2a.TaskPushConfig{}
 	resp, err := client.SetTaskPushConfig(ctx, req)
 	if interceptor.lastReq.Method() != "SetTaskPushConfig" {
-		t.Fatalf("expected method to be SetTaskPushConfig, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got %v, want SetTaskPushConfig", interceptor.lastReq.Method())
 	}
 	if err != nil || resp != config {
-		t.Fatalf("expected %v, got %v, %v", config, resp, err)
+		t.Fatalf("client.SetTaskPushConfig() = (%v, %v), want %v", resp, err, config)
 	}
 	if interceptor.lastReq.Payload != req {
-		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before payload = %v, want %v", interceptor.lastReq.Payload, req)
 	}
 	if interceptor.lastResp.Payload != config {
-		t.Fatalf("expected interceptor.After to intercept %v, got %v", config, interceptor.lastResp.Payload)
+		t.Fatalf("interceptor.After payload = %v, want %v", interceptor.lastResp.Payload, config)
 	}
 }
 
@@ -538,16 +538,16 @@ func TestClient_InterceptDeleteTaskPushConfig(t *testing.T) {
 	req := &a2a.DeleteTaskPushConfigParams{}
 	err := client.DeleteTaskPushConfig(ctx, req)
 	if interceptor.lastReq.Method() != "DeleteTaskPushConfig" {
-		t.Fatalf("expected method to be DeleteTaskPushConfig, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got %v, want DeleteTaskPushConfig", interceptor.lastReq.Method())
 	}
 	if err != nil {
-		t.Fatalf("expected delete to succeed, got %v", err)
+		t.Fatalf("client.DeleteTaskPushConfig() error = %v, want nil", err)
 	}
 	if interceptor.lastReq.Payload != req {
-		t.Fatalf("expected interceptor.Before to intercept %v, got %v", req, interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before payload = %v, want %v", interceptor.lastReq.Payload, req)
 	}
 	if interceptor.lastResp.Payload != nil {
-		t.Fatalf("expected interceptor.After to intercept nil, got %v", interceptor.lastResp.Payload)
+		t.Fatalf("interceptor.After payload = %v, want nil", interceptor.lastResp.Payload)
 	}
 }
 
@@ -563,15 +563,15 @@ func TestClient_InterceptGetAgentCard(t *testing.T) {
 	client := newTestClient(transport, interceptor)
 	resp, err := client.GetAgentCard(ctx)
 	if interceptor.lastReq.Method() != "GetAgentCard" {
-		t.Fatalf("expected method to be GetAgentCard, got %v", interceptor.lastReq.Method())
+		t.Fatalf("wrong method: got %v, want GetAgentCard", interceptor.lastReq.Method())
 	}
 	if err != nil {
-		t.Fatalf("expected delete to succeed, got %v", err)
+		t.Fatalf("client.GetAgentCard() error = %v, want nil", err)
 	}
 	if interceptor.lastReq.Payload != nil {
-		t.Fatalf("expected interceptor.Before to intercept nil, got %v", interceptor.lastReq.Payload)
+		t.Fatalf("interceptor.Before payload = %v, want nil", interceptor.lastReq.Payload)
 	}
 	if interceptor.lastResp.Payload != resp {
-		t.Fatalf("expected interceptor.After to intercept nil, got %v", interceptor.lastResp.Payload)
+		t.Fatalf("interceptor.After payload = %v, want nil", interceptor.lastResp.Payload)
 	}
 }

--- a/a2aclient/middleware.go
+++ b/a2aclient/middleware.go
@@ -71,6 +71,9 @@ func CallMetaFrom(ctx context.Context) (CallMeta, bool) {
 	return meta, ok
 }
 
+// WithCallMeta allows CallInterceptors to attach information like auth credentials
+// to a request. Transport implementations will attach these to the call in
+// a transport-specific way (eg. headers in HTTP).
 func WithCallMeta(ctx context.Context, meta CallMeta) context.Context {
 	return context.WithValue(ctx, callMetaKey{}, meta)
 }

--- a/a2aclient/middleware.go
+++ b/a2aclient/middleware.go
@@ -71,6 +71,10 @@ func CallMetaFrom(ctx context.Context) (CallMeta, bool) {
 	return meta, ok
 }
 
+func WithCallMeta(ctx context.Context, meta CallMeta) context.Context {
+	return context.WithValue(ctx, callMetaKey{}, meta)
+}
+
 // CallContextFrom allows CallInterceptors to get additional information about the intercepted request.
 func CallContextFrom(ctx context.Context) (CallContext, bool) {
 	callCtx, ok := ctx.Value(callContextKey{}).(CallContext)
@@ -85,8 +89,16 @@ func WithSessionID(ctx context.Context, sid SessionID) context.Context {
 		return context.WithValue(ctx, callContextKey{}, callCtx)
 	}
 
-	callCtx := CallContext{SessionID: sid}
-	return context.WithValue(ctx, callContextKey{}, callCtx)
+	return context.WithValue(ctx, callContextKey{}, CallContext{SessionID: sid})
+}
+
+func withMethod(ctx context.Context, method string) context.Context {
+	if callCtx, ok := CallContextFrom(ctx); ok {
+		callCtx.Method = method
+		return context.WithValue(ctx, callContextKey{}, callCtx)
+	}
+
+	return context.WithValue(ctx, callContextKey{}, CallContext{Method: method})
 }
 
 // PassthroughInterceptor can be used by CallInterceptor implementers who don't need all methods.

--- a/a2aclient/middleware.go
+++ b/a2aclient/middleware.go
@@ -71,10 +71,7 @@ func CallMetaFrom(ctx context.Context) (CallMeta, bool) {
 	return meta, ok
 }
 
-// WithCallMeta allows CallInterceptors to attach information like auth credentials
-// to a request. Transport implementations will attach these to the call in
-// a transport-specific way (eg. headers in HTTP).
-func WithCallMeta(ctx context.Context, meta CallMeta) context.Context {
+func withCallMeta(ctx context.Context, meta CallMeta) context.Context {
 	return context.WithValue(ctx, callMetaKey{}, meta)
 }
 


### PR DESCRIPTION
### Details

The PR implements `CallInterceptor` invocations and adds tests which demonstrate how interceptors can be used to observe, modify and reject requests and responses.

`CallInterceptor` can use `Request.Method()` to understand which method is being called and be able to extract a typed value from `Request.Payload`.

`CallInterceptor` can modify `Request.CallMeta` to attach information like auth headers to the request context. `Transport` can access the aggregated `CallMeta` using `CallMetaFrom(ctx)` and add it to the request in a transport-specific way (eg. HTTP headers).

re https://github.com/a2aproject/a2a-go/issues/47
