### PR TITLE
feat: get task implementation

### DIFF
--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -126,10 +126,6 @@ func (h *defaultRequestHandler) OnGetTask(ctx context.Context, query *a2a.TaskQu
 		return nil, fmt.Errorf("failed to get task: %w", err)
 	}
 
-	if task == nil {
-		return nil, a2a.ErrTaskNotFound
-	}
-
 	if query.HistoryLength != nil {
 		historyLength := *query.HistoryLength
 

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -159,7 +159,7 @@ func newTaskStore(history ...*a2a.Message) TaskStore {
 			}
 
 			if taskID == notExistsTaskID {
-				return nil, nil
+				return nil, a2a.ErrTaskNotFound
 			}
 
 			return &a2a.Task{
@@ -382,7 +382,7 @@ func TestDefaultRequestHandler_OnGetTask(t *testing.T) {
 		{
 			name:    "task not found",
 			query:   &a2a.TaskQueryParams{ID: notExistsTaskID},
-			wantErr: a2a.ErrTaskNotFound,
+			wantErr: fmt.Errorf("failed to get task: %w", a2a.ErrTaskNotFound),
 		},
 		{
 			name:      "get task with limited HistoryLength",

--- a/a2asrv/tasks.go
+++ b/a2asrv/tasks.go
@@ -48,6 +48,6 @@ type TaskStore interface {
 	// Save stores a task.
 	Save(ctx context.Context, task *a2a.Task) error
 
-	// Get retrieves a task by ID.
+	// Get retrieves a task by ID. If a Task doesn't exist the method should return [a2a.ErrTaskNotFound].
 	Get(ctx context.Context, taskID a2a.TaskID) (*a2a.Task, error)
 }


### PR DESCRIPTION
**Added:** `OnGetTask` implementation
**Added:** `OnCancelTask` implementation
**Added:** Tests for implementations

The PR implements `OnGetTask` and `OnCancelTask`. `OnGetTask` and `OnCancelTask` use `TaskStore` to manage task states. `OnCancelTask` check `Task.Status.State` with `Terminal` function to cancel the tasks not in terminal state.

re #21 