### PR TITLE
fix: remove keep-alive messages

### DIFF
--- a/a2asrv/jsonrpc.go
+++ b/a2asrv/jsonrpc.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"iter"
 	"net/http"
-	"time"
 
 	"github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/internal/jsonrpc"
@@ -147,18 +146,11 @@ func (h *JSONRPCHandler) handleStreamingRequest(ctx context.Context, rw http.Res
 		eventSeqToSSEDataStream(requestCtx, req, sseChan, events)
 	}()
 
-	keepAliveTicker := time.NewTicker(30 * time.Second)
-	defer keepAliveTicker.Stop()
-
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-keepAliveTicker.C:
-			if err := sseWriter.WriteKeepAlive(ctx); err != nil {
-				log.Error(ctx, "failed to send keep-alive", err)
-				return
-			}
+		// TODO: start sending keep-alive when other SDK-s support it: https://github.com/a2aproject/a2a-python/issues/540
 		case data, ok := <-sseChan:
 			if !ok {
 				return


### PR DESCRIPTION
fix #99

Although sending keep-alive messages is compliant with the SSE standard, we unfortunately have to remove this feature for now to maintain compatibility with the widely-used python-sdk.
