### PR TITLE
feat: allow creating grpc transport from service client

### DIFF
--- a/a2aclient/grpc.go
+++ b/a2aclient/grpc.go
@@ -57,8 +57,8 @@ func NewGRPCTransport(conn *grpc.ClientConn) Transport {
 	}
 }
 
-// NewGRPCTransportFromClient can be used for creating GRPC transport implementation where connection
-// is managed externally and encapsulated in service client. Transport Destroy will be a no-op.
+// NewGRPCTransportFromClient creates a gRPC transport where the connection is managed
+// externally and encapsulated in the service client. The transport's Destroy method is a no-op.
 func NewGRPCTransportFromClient(client a2apb.A2AServiceClient) Transport {
 	return &grpcTransport{
 		client:      client,


### PR DESCRIPTION
The simplest step towards allowing custom GRPC transport factories for usages when clients are short-lived and ClientConn should be outliving them.

#109 

Release-As: 0.3.3