### PR TITLE
chore: fix nightly ci run failing because of a flaky test

### DIFF
--- a/internal/taskexec/manager_test.go
+++ b/internal/taskexec/manager_test.go
@@ -598,7 +598,7 @@ func TestManager_ConcurrentCancelationsResolveToTheSameResult(t *testing.T) {
 		wg.Done()
 	}()
 	<-ready
-	time.Sleep(5*time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 
 	close(canceler1.block)
 	want := &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCanceled}}


### PR DESCRIPTION
Flaky tests were making some scheduling assumptions, more specifically: when ready channel is closed manager.Cancel immediately makes progress to get to the critical section before cancelation event gets written and dispatched.
this failed in nightly run with `-count 100`, failed locally with `-count 1000` before fix.