### PR TITLE
fix: nil parts must be empty array when encoded to JSON 

### DIFF
--- a/a2a/core.go
+++ b/a2a/core.go
@@ -466,6 +466,13 @@ func (m *TaskStatusUpdateEvent) TaskInfo() TaskInfo {
 // ContentParts is an array of content parts that form the message body or an artifact.
 type ContentParts []Part
 
+func (j ContentParts) MarshalJSON() ([]byte, error) {
+	if j == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal([]Part(j))
+}
+
 func (j *ContentParts) UnmarshalJSON(b []byte) error {
 	type typedPart struct {
 		Kind string `json:"kind"`

--- a/a2a/json_test.go
+++ b/a2a/json_test.go
@@ -160,6 +160,21 @@ func TestSecuritySchemeJSONCodec(t *testing.T) {
 	}
 }
 
+func TestEventMarshalEmptyContentParts(t *testing.T) {
+	event := &TaskArtifactUpdateEvent{Artifact: &Artifact{ID: "art-123"}}
+	jsonBytes, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Marshal() failed: %v", err)
+	}
+	var decoded TaskArtifactUpdateEvent
+	if err := json.Unmarshal(jsonBytes, &decoded); err != nil {
+		t.Fatalf("Unmarshal() failed: %v", err)
+	}
+	if !strings.Contains(string(jsonBytes), `"parts":[]`) {
+		t.Fatalf("json.Marshal() = %q, want parts to be non-nil", string(jsonBytes))
+	}
+}
+
 func TestAgentCardParsing(t *testing.T) {
 	cardJSON := `
 {


### PR DESCRIPTION
We use `type ContentParts []Part` to handle json encoding of parts.
nil was incorrectly encoded as a missing value leading to protocol-incompatible types (parts must be present).