### PR TITLE
fix: provide request-level metadata in RequestContext

### DIFF
--- a/a2asrv/agentexec.go
+++ b/a2asrv/agentexec.go
@@ -176,7 +176,7 @@ func (f *factory) loadExecRequestContext(ctx context.Context, tid a2a.TaskID, pa
 		StoredTask: storedTask,
 		TaskID:     storedTask.ID,
 		ContextID:  storedTask.ContextID,
-		Metadata:   msg.Metadata,
+		Metadata:   params.Metadata,
 	}
 	return reqCtx, storedTask, nil
 }


### PR DESCRIPTION
This should be request-level metadata as per comment for RequestContext->Metadata. Also, message-level metadata are already avavilable through the message field.