### PR TITLE
integration with conformance test suite

### DIFF
--- a/e2e/tck/orchestrate_tck.py
+++ b/e2e/tck/orchestrate_tck.py
@@ -1,0 +1,116 @@
+# Copyright 2026 The A2A Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import requests
+import subprocess
+import os           
+import sys
+
+TCK_DIR = os.path.abspath("../../../a2a-tck")
+TCK_VENV_PYTHON = os.path.join(TCK_DIR, ".venv", "bin", "python")
+SUT_URL = "http://localhost:9999"
+
+def wait_for_server(url, expected_status=200, timeout=120, interval=2):
+    start_time = time.time()
+    print(f"⏳ Waiting for server at: {url}")
+
+    while True:
+        elapsed_time = time.time() - start_time
+        
+        if elapsed_time >= timeout:
+            print(f"❌ Timeout: Server did not respond with {expected_status} within {timeout}s.")
+            sys.exit(1)
+
+        try:
+            response = requests.get(url, timeout=5)
+            status_code = response.status_code
+        except requests.exceptions.RequestException:
+            status_code = "No Response"
+
+        if status_code == expected_status:
+            print(f"✅ Server is up! Received status {status_code} after {int(elapsed_time)}s.")
+            return True
+
+        print(f"⏳ Status: {status_code}. Retrying in {interval}s...")
+        time.sleep(interval)
+
+def setup_tck_env():
+    print("Setting up TCK environment...")
+    if not os.path.exists(TCK_DIR):
+        print("TCK directory not found")
+        sys.exit(1)
+    
+    run_shell_command("curl -LsSf https://astral.sh/uv/install.sh | sh", cwd=TCK_DIR)
+    run_shell_command("uv venv --clear", cwd=TCK_DIR)
+    run_shell_command("uv pip install -e .", cwd=TCK_DIR)
+
+def run_shell_command(command, cwd=None):
+    env = os.environ.copy()
+    venv_bin = os.path.dirname(TCK_VENV_PYTHON)
+    env["PATH"] = venv_bin + os.pathsep + env.get("PATH", "")
+    env["UV_INDEX_URL"] = "https://pypi.org/simple"
+
+    result = subprocess.run(command, shell=True, cwd=cwd, env=env)
+
+def start_and_test(protocol):
+    sut_process = subprocess.Popen(
+        f"go run . --mode {protocol}", 
+        shell=True, 
+        cwd=".",
+    )
+    time.sleep(1) 
+    if sut_process.poll() is not None:
+        print("❌ Critical Error: The Go SUT failed to start immediately.")
+        sys.exit(1)
+
+    card_url = f"{SUT_URL}/.well-known/agent-card.json"
+    if not wait_for_server(card_url):
+        print("Server failed to start")
+        return False
+
+    caregories = ["mandatory", "capabilities"]
+
+    try:
+        for category in caregories:
+            print(f"Running TCK ({category}) for {protocol}...")
+            run_shell_command(
+                f"./run_tck.py --sut-url {SUT_URL} --category {category} --transports {protocol}",
+                cwd=TCK_DIR
+            )
+            return True
+    except Exception as e:
+        print(f"❌ Error running TCK: {e}")
+        return False
+    finally:
+        print("🛑 Stopping SUT...")
+        sut_process.terminate()
+        sut_process.wait(timeout=5)
+        run_shell_command("fuser -k 9999/tcp || true", cwd=".")
+
+def main():
+    setup_tck_env()
+    protocols = ["jsonrpc", "grpc"] 
+    failed = []
+    for protocol in protocols:
+        if not start_and_test(protocol):
+            failed.append(protocol)
+    if not failed:
+        print("✅ TCK passed for all protocols")
+        return
+    print(f"❌ TCK failed for protocols: {failed}")
+    sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/e2e/tck/run_tck.sh
+++ b/e2e/tck/run_tck.sh
@@ -1,0 +1,17 @@
+# Copyright 2026 The A2A Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+python3 orchestrate_tck.py

--- a/e2e/tck/sut.go
+++ b/e2e/tck/sut.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2agrpc"
+	"github.com/a2aproject/a2a-go/a2asrv"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	mode := flag.String("mode", "http", "mode to run in: http(JSON-RPC/REST) or grpc")
+	httpPort := flag.Int("http-port", 9999, "HTTP port")
+	grpcPort := flag.Int("grpc-port", 9998, "gRPC port")
+	flag.Parse()
+
+	agentExecutor := newCustomAgentExecutor()
+
+	var cardUrl string
+	var preferredTransport a2a.TransportProtocol
+	switch *mode {
+	case "grpc":
+		cardUrl = fmt.Sprintf("http://localhost:%d", *grpcPort)
+		preferredTransport = a2a.TransportProtocolGRPC
+	// TODO: handle REST case
+	default:
+		cardUrl = fmt.Sprintf("http://localhost:%d/invoke", *httpPort)
+		preferredTransport = a2a.TransportProtocolJSONRPC
+	}
+
+	agentCard := &a2a.AgentCard{
+		Name:               "TCK Core Agent",
+		Description:        "A complete A2A agent implementation designed specifically for testing with the A2A Technology Compatibility Kit (TCK)",
+		URL:                cardUrl,
+		Version:            "1.0.0",
+		PreferredTransport: preferredTransport,
+		DefaultInputModes:  []string{"text"},
+		DefaultOutputModes: []string{"text"},
+		Capabilities:       a2a.AgentCapabilities{Streaming: true},
+		// security
+		Skills: []a2a.AgentSkill{
+			{
+				ID:          "tck_core_agent",
+				Name:        "TCK Core Agent",
+				Description: "A complete A2A agent implementation designed for TCK testing",
+				Tags:        []string{"hello world", "how are you", "goodbye", "hi"},
+				Examples:    []string{"tck", "testing", "core", "complete"},
+			},
+		},
+	}
+
+	requestHandler := a2asrv.NewHandler(agentExecutor, a2asrv.WithExtendedAgentCard(agentCard))
+
+	var group errgroup.Group
+	group.Go(func() error {
+		return startGRPCServer(*grpcPort, requestHandler)
+	})
+	group.Go(func() error {
+		return startHTTPServer(*httpPort, agentCard, requestHandler)
+	})
+	if err := group.Wait(); err != nil {
+		log.Fatalf("Server shutdown: %v", err)
+	}
+
+}
+
+func startGRPCServer(port int, handler a2asrv.RequestHandler) error {
+	grpcListener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return fmt.Errorf("failed to bind gRPC port: %w", err)
+	}
+	log.Printf("Starting a gRPC server on 127.0.0.1:%d", port)
+
+	grpcHandler := a2agrpc.NewHandler(handler)
+	grpcServer := grpc.NewServer()
+	grpcHandler.RegisterWith(grpcServer)
+	return grpcServer.Serve(grpcListener)
+}
+
+func startHTTPServer(port int, card *a2a.AgentCard, handler a2asrv.RequestHandler) error {
+	httpListener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return fmt.Errorf("failed to bind HTTP port: %w", err)
+	}
+	log.Printf("Starting an HTTP server on 127.0.0.1:%d", port)
+
+	mux := http.NewServeMux()
+
+	// serve public card
+	mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(card))
+
+	// serve JSON-RPC endpoint
+	mux.Handle("/invoke", a2asrv.NewJSONRPCHandler(handler))
+
+	// TODO: serve REST endpoint
+
+	return http.Serve(httpListener, mux)
+}

--- a/e2e/tck/sut_agent_executor.go
+++ b/e2e/tck/sut_agent_executor.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	"github.com/a2aproject/a2a-go/a2asrv"
+	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+)
+
+type SUTAgentExecutor struct{}
+
+func (c *SUTAgentExecutor) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, q eventqueue.Queue) error {
+	task := reqCtx.StoredTask
+
+	if task == nil {
+		event := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateSubmitted, nil)
+		if err := q.Write(ctx, event); err != nil {
+			return fmt.Errorf("failed to write state submitted: %w", err)
+		}
+	}
+
+	event := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateWorking, nil)
+	if err := q.Write(ctx, event); err != nil {
+		return fmt.Errorf("failed to write state working: %w", err)
+	}
+
+	event = a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateCompleted, nil)
+	event.Final = true
+	if err := q.Write(ctx, event); err != nil {
+		return fmt.Errorf("failed to write state completed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *SUTAgentExecutor) Cancel(ctx context.Context, reqCtx *a2asrv.RequestContext, q eventqueue.Queue) error {
+	task := reqCtx.StoredTask
+	if task == nil {
+		return a2a.ErrTaskNotFound
+	}
+	if task.Status.State == a2a.TaskStateCanceled || task.Status.State == a2a.TaskStateCompleted || task.Status.State == a2a.TaskStateFailed {
+		return a2a.ErrTaskNotCancelable
+	}
+	if err := q.Write(ctx, &a2a.TaskStatusUpdateEvent{
+		ContextID: task.ContextID,
+		Final:     true,
+		Status:    a2a.TaskStatus{State: a2a.TaskStateCanceled},
+		TaskID:    task.ID,
+	}); err != nil {
+		return fmt.Errorf("failed to write state canceled: %w", err)
+	}
+	return nil
+}
+
+func newCustomAgentExecutor() a2asrv.AgentExecutor {
+	return &SUTAgentExecutor{}
+}


### PR DESCRIPTION
Implemented SUT in Go (e2e/tck/sut.go) to facilitate compliance testing against the A2A TCK.

Also added an orchestration script (e2e/tck/run_tck.sh) that automates the testing lifecycle—setting up the environment, starting the SUT, running the TCK tests.

### How to run locally:

Navigate to the e2e directory:
```bash
cd e2e/tck
```
Run the automation script:
```bash
./run_tck.sh