### PR TITLE
test: integration with conformance test suite

### DIFF
--- a/e2e/tck/run_tck.sh
+++ b/e2e/tck/run_tck.sh
@@ -16,4 +16,4 @@
 
 set -euo pipefail
 
-python3 orchestrate_tck.py
+python3 orchestrate_tck.py "$@"

--- a/e2e/tck/sut_agent_executor.go
+++ b/e2e/tck/sut_agent_executor.go
@@ -54,9 +54,7 @@ func (c *SUTAgentExecutor) Cancel(ctx context.Context, reqCtx *a2asrv.RequestCon
 	if task == nil {
 		return a2a.ErrTaskNotFound
 	}
-	if task.Status.State == a2a.TaskStateCanceled || task.Status.State == a2a.TaskStateCompleted || task.Status.State == a2a.TaskStateFailed {
-		return a2a.ErrTaskNotCancelable
-	}
+
 	event := a2a.NewStatusUpdateEvent(reqCtx, a2a.TaskStateCanceled, nil)
 	event.Final = true
 	if err := q.Write(ctx, event); err != nil {


### PR DESCRIPTION
Implemented SUT in Go (e2e/tck/sut.go) to facilitate compliance testing against the A2A TCK.

Also added an orchestration script (e2e/tck/run_tck.sh) that automates the testing lifecycle—setting up the environment, starting the SUT, running the TCK tests.

How to run locally:
Navigate to the e2e directory:
```bash
cd e2e/tck
```
Run the automation script:
```bash
./run_tck.sh