### PR TITLE
fix: final event overriding task failure event

### DIFF
--- a/a2asrv/agentexec.go
+++ b/a2asrv/agentexec.go
@@ -358,6 +358,7 @@ func (p *processor) setTaskFailed(ctx context.Context, event a2a.Event, err erro
 	}
 	return &taskexec.ProcessorResult{
 		ExecutionResult: versioned.Task,
+		EventOverride:   versioned.Task,
 		TaskVersion:     versioned.Version,
 	}, nil
 }

--- a/internal/taskexec/api.go
+++ b/internal/taskexec/api.go
@@ -72,6 +72,9 @@ type ProcessorResult struct {
 	ExecutionResult a2a.SendMessageResult
 	// TaskVersion is the version of the task after the event was processed.
 	TaskVersion a2a.TaskVersion
+	// EventOverride can be returned by the processor to change which event gets emitted to subscribers.
+	// This is useful when we failed to process a malformed event and moved the task to failed state.
+	EventOverride a2a.Event
 }
 
 // Executor implementation starts an agent execution.

--- a/internal/taskexec/execution_handler.go
+++ b/internal/taskexec/execution_handler.go
@@ -56,7 +56,11 @@ func (h *executionHandler) processEvents(ctx context.Context) (a2a.SendMessageRe
 		}
 
 		if h.handledEventQueue != nil {
-			if err := h.handledEventQueue.WriteVersioned(ctx, event, processResult.TaskVersion); err != nil {
+			toEmit := event
+			if processResult.EventOverride != nil {
+				toEmit = processResult.EventOverride
+			}
+			if err := h.handledEventQueue.WriteVersioned(ctx, toEmit, processResult.TaskVersion); err != nil {
 				log.Info(ctx, "execution context canceled during subscriber notification attempt", "cause", context.Cause(ctx))
 				return h.handleErrorFn(ctx, context.Cause(ctx))
 			}


### PR DESCRIPTION
Fixes a bug when processor fails to handle a final event and moves a task failed state.
The fact that it was a final event makes consumers unsubscribe from the event stream.
This means that they never receive the final "failed" update and think the task was completed successfully. 