### PR TITLE
feat: callinterceptor supports payload override-client

### DIFF
--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -234,7 +234,7 @@ func (c *Client) GetAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
 	}
 
 	method := "GetAgentCard"
-	var req *struct{}
+	var req struct{}
 	ctx, _, err := interceptBefore(ctx, c, method, req)
 	if err != nil {
 		return nil, err

--- a/a2aclient/client_test.go
+++ b/a2aclient/client_test.go
@@ -788,13 +788,11 @@ func TestClient_InterceptGetAgentCard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client.GetAgentCard() error = %v, want nil", err)
 	}
-	if interceptor.lastReq.Payload != nil {
-		if ptr, ok := interceptor.lastReq.Payload.(*struct{}); !ok || ptr != nil {
-			t.Fatalf("interceptor.Before payload = %v, want nil", interceptor.lastReq.Payload)
-		}
+	if interceptor.lastReq.Payload != struct{}{} {
+		t.Fatalf("interceptor.Before payload = %v, want struct{}", interceptor.lastReq.Payload)
 	}
 	if interceptor.lastResp.Payload != resp {
-		t.Fatalf("interceptor.After payload = %v, want nil", interceptor.lastResp.Payload)
+		t.Fatalf("interceptor.After payload = %v, want %v", interceptor.lastResp.Payload, resp)
 	}
 }
 


### PR DESCRIPTION
Updated interceptBefore and interceptAfter to parametrized functions, without receiver.
Interceptors can now swap entire Request/Response objects and inject or suppress errors.

Added tests verifying request/response replacement, error injection, error suppression, and type safety guardrails.