### PR TITLE
feat: implement tasks/list RPC

### DIFF
--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -77,6 +77,18 @@ func (c *Client) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.
 	return interceptAfter(ctx, c, method, resp, err)
 }
 
+func (c *Client) ListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	method := "ListTasks"
+
+	ctx, interceptedReq, err := interceptBefore(ctx, c, method, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.transport.ListTasks(ctx, interceptedReq)
+	return interceptAfter(ctx, c, method, resp, err)
+}
+
 func (c *Client) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
 	method := "CancelTask"
 

--- a/a2aclient/client_test.go
+++ b/a2aclient/client_test.go
@@ -28,6 +28,7 @@ import (
 
 type testTransport struct {
 	GetTaskFn              func(context.Context, *a2a.TaskQueryParams) (*a2a.Task, error)
+	ListTasksFn            func(context.Context, *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error)
 	CancelTaskFn           func(context.Context, *a2a.TaskIDParams) (*a2a.Task, error)
 	SendMessageFn          func(context.Context, *a2a.MessageSendParams) (a2a.SendMessageResult, error)
 	ResubscribeToTaskFn    func(context.Context, *a2a.TaskIDParams) iter.Seq2[a2a.Event, error]
@@ -43,6 +44,13 @@ var _ Transport = (*testTransport)(nil)
 
 func (t *testTransport) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error) {
 	return t.GetTaskFn(ctx, query)
+}
+
+func (t *testTransport) ListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	if t.ListTasksFn != nil {
+		return t.ListTasksFn(ctx, req)
+	}
+	return &a2a.ListTasksResponse{}, nil
 }
 
 func (t *testTransport) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {

--- a/a2aclient/grpc.go
+++ b/a2aclient/grpc.go
@@ -90,6 +90,20 @@ func (c *grpcTransport) GetTask(ctx context.Context, query *a2a.TaskQueryParams)
 	return pbconv.FromProtoTask(pResp)
 }
 
+func (c *grpcTransport) ListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	pReq, err := pbconv.ToProtoListTasksRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	pResp, err := c.client.ListTasks(ctx, pReq)
+	if err != nil {
+		return nil, grpcutil.FromGRPCError(err)
+	}
+
+	return pbconv.FromProtoListTasksResponse(pResp)
+}
+
 func (c *grpcTransport) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
 	req, err := pbconv.ToProtoCancelTaskRequest(id)
 	if err != nil {

--- a/a2aclient/jsonrpc.go
+++ b/a2aclient/jsonrpc.go
@@ -282,6 +282,21 @@ func (t *jsonrpcTransport) GetTask(ctx context.Context, query *a2a.TaskQueryPara
 	return &task, nil
 }
 
+// ListTasks lists tasks matching the specified criteria.
+func (t *jsonrpcTransport) ListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	result, err := t.sendRequest(ctx, jsonrpc.MethodTasksList, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp a2a.ListTasksResponse
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal list tasks response: %w", err)
+	}
+
+	return &resp, nil
+}
+
 // CancelTask requests cancellation of a task.
 func (t *jsonrpcTransport) CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error) {
 	result, err := t.sendRequest(ctx, jsonrpc.MethodTasksCancel, id)

--- a/a2aclient/transport.go
+++ b/a2aclient/transport.go
@@ -28,6 +28,9 @@ type Transport interface {
 	// GetTask calls the 'tasks/get' protocol method.
 	GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error)
 
+	// ListTasks calls the 'tasks/list' protocol method.
+	ListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error)
+
 	// CancelTask calls the 'tasks/cancel' protocol method.
 	CancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error)
 
@@ -79,6 +82,10 @@ type unimplementedTransport struct{}
 var _ Transport = (*unimplementedTransport)(nil)
 
 func (unimplementedTransport) GetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error) {
+	return nil, errNotImplemented
+}
+
+func (unimplementedTransport) ListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
 	return nil, errNotImplemented
 }
 

--- a/a2apb/pbconv/from_proto.go
+++ b/a2apb/pbconv/from_proto.go
@@ -175,6 +175,25 @@ func fromProtoSendMessageConfig(conf *a2apb.SendMessageConfiguration) (*a2a.Mess
 	return result, nil
 }
 
+func FromProtoListTasksResponse(resp *a2apb.ListTasksResponse) (*a2a.ListTasksResponse, error) {
+	if resp == nil {
+		return nil, nil
+	}
+	tasks := make([]*a2a.Task, len(resp.GetTasks()))
+	for i, pTask := range resp.GetTasks() {
+		task, err := FromProtoTask(pTask)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert task: %w", err)
+		}
+		tasks[i] = task
+	}
+	return &a2a.ListTasksResponse{
+		Tasks:         tasks,
+		TotalSize:     int(resp.GetTotalSize()),
+		NextPageToken: resp.GetNextPageToken(),
+	}, nil
+}
+
 func FromProtoGetTaskRequest(req *a2apb.GetTaskRequest) (*a2a.TaskQueryParams, error) {
 	if req == nil {
 		return nil, nil

--- a/a2apb/pbconv/to_proto.go
+++ b/a2apb/pbconv/to_proto.go
@@ -104,6 +104,26 @@ func toProtoSendMessageConfig(config *a2a.MessageSendConfig) (*a2apb.SendMessage
 	return pConf, nil
 }
 
+func ToProtoListTasksRequest(req *a2a.ListTasksRequest) (*a2apb.ListTasksRequest, error) {
+	if req == nil {
+		return nil, nil
+	}
+	pReq := &a2apb.ListTasksRequest{
+		ContextId:        req.ContextID,
+		PageSize:         int32(req.PageSize),
+		PageToken:        req.PageToken,
+		HistoryLength:    int32(req.HistoryLength),
+		IncludeArtifacts: req.IncludeArtifacts,
+	}
+	if req.Status != "" {
+		pReq.Status = toProtoTaskState(req.Status)
+	}
+	if req.LastUpdatedAfter != nil {
+		pReq.LastUpdatedTime = timestamppb.New(*req.LastUpdatedAfter)
+	}
+	return pReq, nil
+}
+
 func ToProtoGetTaskRequest(params *a2a.TaskQueryParams) (*a2apb.GetTaskRequest, error) {
 	if params == nil {
 		return nil, nil

--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -34,6 +34,9 @@ type RequestHandler interface {
 	// OnGetTask handles the 'tasks/get' protocol method.
 	OnGetTask(ctx context.Context, query *a2a.TaskQueryParams) (*a2a.Task, error)
 
+	// OnListTasks handles the 'tasks/list' protocol method.
+	OnListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error)
+
 	// OnCancelTask handles the 'tasks/cancel' protocol method.
 	OnCancelTask(ctx context.Context, id *a2a.TaskIDParams) (*a2a.Task, error)
 
@@ -201,6 +204,10 @@ func (h *defaultRequestHandler) OnGetTask(ctx context.Context, query *a2a.TaskQu
 	}
 
 	return task, nil
+}
+
+func (h *defaultRequestHandler) OnListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	return h.taskStore.List(ctx, req)
 }
 
 func (h *defaultRequestHandler) OnCancelTask(ctx context.Context, params *a2a.TaskIDParams) (*a2a.Task, error) {

--- a/a2asrv/intercepted_handler.go
+++ b/a2asrv/intercepted_handler.go
@@ -53,6 +53,17 @@ func (h *InterceptedHandler) OnGetTask(ctx context.Context, query *a2a.TaskQuery
 	return interceptAfter(ctx, h, callCtx, response, err)
 }
 
+func (h *InterceptedHandler) OnListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	ctx, callCtx := withMethodCallContext(ctx, "OnListTasks")
+	ctx = h.withLoggerContext(ctx)
+	ctx, interceptedReq, err := interceptBefore(ctx, h, callCtx, req)
+	if err != nil {
+		return nil, err
+	}
+	response, err := h.Handler.OnListTasks(ctx, interceptedReq)
+	return interceptAfter(ctx, h, callCtx, response, err)
+}
+
 func (h *InterceptedHandler) OnCancelTask(ctx context.Context, params *a2a.TaskIDParams) (*a2a.Task, error) {
 	ctx, callCtx := withMethodCallContext(ctx, "OnCancelTask")
 	if params != nil {

--- a/a2asrv/intercepted_handler_test.go
+++ b/a2asrv/intercepted_handler_test.go
@@ -43,6 +43,14 @@ func (h *mockHandler) OnGetTask(ctx context.Context, query *a2a.TaskQueryParams)
 	return &a2a.Task{}, nil
 }
 
+func (h *mockHandler) OnListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	h.lastCallContext, _ = CallContextFrom(ctx)
+	if h.resultErr != nil {
+		return nil, h.resultErr
+	}
+	return &a2a.ListTasksResponse{}, nil
+}
+
 func (h *mockHandler) OnCancelTask(ctx context.Context, params *a2a.TaskIDParams) (*a2a.Task, error) {
 	h.lastCallContext, _ = CallContextFrom(ctx)
 	if h.resultErr != nil {

--- a/a2asrv/jsonrpc.go
+++ b/a2asrv/jsonrpc.go
@@ -151,6 +151,8 @@ func (h *jsonrpcHandler) handleRequest(ctx context.Context, rw http.ResponseWrit
 	switch req.Method {
 	case jsonrpc.MethodTasksGet:
 		result, err = h.onGetTask(ctx, req.Params)
+	case jsonrpc.MethodTasksList:
+		result, err = h.onListTasks(ctx, req.Params)
 	case jsonrpc.MethodMessageSend:
 		result, err = h.onSendMessage(ctx, req.Params)
 	case jsonrpc.MethodTasksCancel:
@@ -301,6 +303,14 @@ func (h *jsonrpcHandler) onGetTask(ctx context.Context, raw json.RawMessage) (*a
 		return nil, handleUnmarshalError(err)
 	}
 	return h.handler.OnGetTask(ctx, &query)
+}
+
+func (h *jsonrpcHandler) onListTasks(ctx context.Context, raw json.RawMessage) (*a2a.ListTasksResponse, error) {
+	var req a2a.ListTasksRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return nil, handleUnmarshalError(err)
+	}
+	return h.handler.OnListTasks(ctx, &req)
 }
 
 func (h *jsonrpcHandler) onCancelTask(ctx context.Context, raw json.RawMessage) (*a2a.Task, error) {

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -32,6 +32,7 @@ const (
 	MethodMessageSend          = "message/send"
 	MethodMessageStream        = "message/stream"
 	MethodTasksGet             = "tasks/get"
+	MethodTasksList            = "tasks/list"
 	MethodTasksCancel          = "tasks/cancel"
 	MethodTasksResubscribe     = "tasks/resubscribe"
 	MethodPushConfigGet        = "tasks/pushNotificationConfig/get"


### PR DESCRIPTION
## What

Wire the `tasks/list` method through all protocol layers: JSON-RPC client/server, gRPC client, proto conversion, transport interface, request handler, and intercepted handler.

## Why

The TSC voted to add `tasks/list` with filtering and pagination to the spec for 0.4.0. The task store already implements `List()` with all the filtering logic (context ID, status, last updated time, pagination, history length, artifacts). This was just never exposed through the protocol.

## Implementation details

Pure plumbing - no new business logic. Each layer gets the obvious `ListTasks` method that delegates to the next:

- `Transport` interface + `unimplementedTransport` stub
- JSON-RPC client: sends `tasks/list`, unmarshals `ListTasksResponse`
- JSON-RPC server: dispatches `tasks/list` to `onListTasks`
- gRPC client: converts via pbconv, calls proto `ListTasks`
- `RequestHandler` interface + default impl delegates to `taskStore.List()`
- `InterceptedHandler`: wraps with before/after interceptors
- `MethodTasksList` constant added

## References

re https://github.com/a2aproject/a2a-go/issues/58
Spec PR: https://github.com/a2aproject/A2A/pull/831