### PR TITLE
fix: GetTaskRequest nil pointer assignment check

### DIFF
--- a/a2apb/v1/pbconv/to_proto.go
+++ b/a2apb/v1/pbconv/to_proto.go
@@ -128,13 +128,13 @@ func ToProtoGetTaskRequest(req *a2a.GetTaskRequest) (*a2apb.GetTaskRequest, erro
 	}
 
 	result := &a2apb.GetTaskRequest{
-		Tenant:        req.Tenant,
-		Id:            string(req.ID),
+		Tenant: req.Tenant,
+		Id:     string(req.ID),
 	}
 
 	if req.HistoryLength != nil {
 		result.HistoryLength = proto.Int32(int32(*req.HistoryLength))
-	}	
+	}
 
 	return result, nil
 }


### PR DESCRIPTION
Added check for nil pointer. Mandatory check required to stop failure/crash if the history length is not provided.