### PR TITLE
docs(a2asrv): add Example_* test functions for pkg.go.dev documentation

### DIFF
--- a/a2asrv/example_test.go
+++ b/a2asrv/example_test.go
@@ -186,7 +186,7 @@ func ExampleUser() {
 
 	interceptor := &testInterceptor{
 		BeforeFn: func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) (context.Context, any, error) {
-			if auth, ok := callCtx.ServiceParams().Get("authorization"); ok && strings.HasPrefix(auth[0], "Bearer ") {
+			if auth, ok := callCtx.ServiceParams().Get("authorization"); ok && len(auth) > 0 && strings.HasPrefix(auth[0], "Bearer ") {
 				if name := authenticate(auth[0]); name != "" {
 					callCtx.User = a2asrv.NewAuthenticatedUser(name, nil)
 				}
@@ -287,8 +287,8 @@ func ExampleServiceParams() {
 	var capturedHeader string
 
 	interceptor := &testInterceptor{
-		BeforeFn: func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) (context.Context, any, error) {
-			if vals, ok := callCtx.ServiceParams().Get("x-custom-header"); ok {
+		BeforeFn: func(ctx context.Context, callCtx *a2asrv.CallContext, _ *a2asrv.Request) (context.Context, any, error) {
+			if vals, ok := callCtx.ServiceParams().Get("x-custom-header"); ok && len(vals) > 0 {
 				capturedHeader = vals[0]
 			}
 			return ctx, nil, nil


### PR DESCRIPTION
## Description

Ref #257 🦕

### Motivation

The `a2asrv/` server package does not include testable examples (`Example_*` functions). Usage snippets exist in the README and `doc.go`, but they are not executable, not validated by `go test`, and do not render as function-level examples on **pkg.go.dev**.

### Changes

Add `a2asrv/example_test.go` using `package a2asrv_test` (external test package), following Go's `ExampleXxx` / `ExampleType_Method` naming convention.

Examples added for the following public API surface:

| Function / Type | Example demonstrates |
|---|---|
| `NewHandler` | Creating a basic request handler with an `AgentExecutor` |
| `NewHandler` (withOptions) | Creating a handler with `WithExtendedAgentCard` and `WithCallInterceptors` |
| `NewJSONRPCHandler` | Wrapping a handler with JSON-RPC transport and registering with `http.ServeMux` |
| `NewStaticAgentCardHandler` | Serving a static `AgentCard` via httptest and verifying JSON response |
| `NewAgentCardHandler` | Serving a dynamic `AgentCard` via an `AgentCardProducerFn` |
| `WellKnownAgentCardPath` | Displaying the standard well-known path constant |
| `WithCallInterceptors` | Adding server-side middleware to a handler |
| `PassthroughCallInterceptor` | Demonstrating the no-op `Before`/`After` interceptor lifecycle |
| `NewCallContext` | Creating a call context with `ServiceParams` and reading request metadata |
| `NewServiceParams` | Case-insensitive service parameter lookups |
| `CallContext.Extensions` | Requesting, activating, and inspecting extensions |

All examples include `// Output:` comments and are validated by `go test`.

### Tests

The examples themselves are tests — validated through output matching. All 12 pass. Existing tests are unaffected.

```
go test ./a2asrv/ -v -run Example
```

### Additional context

Import paths follow the current module declaration (`github.com/a2aproject/a2a-go`), consistent with the temporary revert in #254 (ref #250). Happy to update if the module path changes.

This is the first of two PRs addressing #257. The second PR will add examples for `a2aclient/`.