### PR TITLE
fix: task modified after save

### DIFF
--- a/internal/taskupdate/manager.go
+++ b/internal/taskupdate/manager.go
@@ -111,7 +111,10 @@ func (mgr *Manager) Process(ctx context.Context, event a2a.Event) (*taskstore.St
 }
 
 func (mgr *Manager) updateArtifact(ctx context.Context, event *a2a.TaskArtifactUpdateEvent) (*taskstore.StoredTask, error) {
-	task := mgr.lastStored.Task
+	task, err := utils.DeepCopy(mgr.lastStored.Task)
+	if err != nil {
+		return nil, err
+	}
 
 	// The copy is required because the event will be passed to subscriber goroutines, while
 	// the artifact might be modified in our goroutine by other TaskArtifactUpdateEvent-s.

--- a/internal/taskupdate/manager_test.go
+++ b/internal/taskupdate/manager_test.go
@@ -126,13 +126,38 @@ func TestManager_TaskImmutableAfterSave(t *testing.T) {
 	if err != nil {
 		t.Fatalf("m.Process() failed to save task: %v", err)
 	}
-	_, err = m.Process(t.Context(), a2a.NewArtifactEvent(task, a2a.NewTextPart("hello!")))
+
+	result1, err := m.Process(t.Context(), a2a.NewArtifactEvent(task, a2a.NewTextPart("foo")))
 	if err != nil {
 		t.Fatalf("m.Process() failed to save task: %v", err)
 	}
-
 	if len(task.Artifacts) != 0 {
 		t.Fatalf("task artifact length = %d, want empty", len(task.Artifacts))
+	}
+
+	result2, err := m.Process(t.Context(), a2a.NewArtifactEvent(task, a2a.NewTextPart("bar")))
+	if err != nil {
+		t.Fatalf("m.Process() failed to save task: %v", err)
+	}
+	if len(result2.Task.Artifacts) != 2 {
+		t.Fatalf("task artifact length = %d, want 2", len(result2.Task.Artifacts))
+	}
+	if len(result1.Task.Artifacts) != 1 {
+		t.Fatalf("task artifact length = %d, want 1", len(result1.Task.Artifacts))
+	}
+
+	result3, err := m.Process(t.Context(), a2a.NewStatusUpdateEvent(task, a2a.TaskStateCompleted, nil))
+	if err != nil {
+		t.Fatalf("m.Process() failed to save task: %v", err)
+	}
+	if result3.Task.Status.State != a2a.TaskStateCompleted {
+		t.Fatalf("task state after update = %q, want = %q", result3.Task.Status.State, a2a.TaskStateCompleted)
+	}
+	if result1.Task.Status.State != a2a.TaskStateWorking {
+		t.Fatalf("previous result state changed to = %q, want = %q", result1.Task.Status.State, a2a.TaskStateWorking)
+	}
+	if result2.Task.Status.State != a2a.TaskStateWorking {
+		t.Fatalf("previous result state changed to = %q, want = %q", result2.Task.Status.State, a2a.TaskStateWorking)
 	}
 }
 


### PR DESCRIPTION
We were capturing a reference to a2a.Task event. 
With in-memory consumers this meant that queue readers could potentially see incorrect task state:

1. Task emitted and reference captured
2. Artifact update emitted and applied to the task
3. Event consumers receives the Task event and sees the Artifact already in it