### PR TITLE
fix: correct json discriminator keys

### DIFF
--- a/a2a/auth.go
+++ b/a2a/auth.go
@@ -91,16 +91,17 @@ func (s NamedSecuritySchemes) MarshalJSON() ([]byte, error) {
 	for name, scheme := range s {
 		var wrapped any
 		switch v := scheme.(type) {
+		// TODO: remove short JSON discriminator keys after transition period
 		case APIKeySecurityScheme:
-			wrapped = map[string]any{"apiKey": v}
+			wrapped = map[string]any{"apiKey": v, "apiKeySecurityScheme": v}
 		case HTTPAuthSecurityScheme:
-			wrapped = map[string]any{"http": v}
+			wrapped = map[string]any{"http": v, "httpAuthSecurityScheme": v}
 		case OpenIDConnectSecurityScheme:
-			wrapped = map[string]any{"openIdConnect": v}
+			wrapped = map[string]any{"openIdConnect": v, "openIdConnectSecurityScheme": v}
 		case MutualTLSSecurityScheme:
-			wrapped = map[string]any{"mutualTLS": v}
+			wrapped = map[string]any{"mutualTLS": v, "mtlsSecurityScheme": v}
 		case OAuth2SecurityScheme:
-			wrapped = map[string]any{"oauth2": v}
+			wrapped = map[string]any{"oauth2": v, "oauth2SecurityScheme": v}
 		default:
 			return nil, fmt.Errorf("unknown security scheme type %T", v)
 		}
@@ -122,7 +123,7 @@ func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
 		if err := json.Unmarshal(rawMessage, &raw); err != nil {
 			return err
 		}
-
+		// TODO: remove short JSON discriminator keys after transition period
 		if v, ok := raw["apiKey"]; ok {
 			var scheme APIKeySecurityScheme
 			if err := json.Unmarshal(v, &scheme); err != nil {
@@ -148,6 +149,36 @@ func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
 			}
 			result[name] = scheme
 		} else if v, ok := raw["openIdConnect"]; ok {
+			var scheme OpenIDConnectSecurityScheme
+			if err := json.Unmarshal(v, &scheme); err != nil {
+				return err
+			}
+			result[name] = scheme
+		} else if v, ok := raw["apiKeySecurityScheme"]; ok {
+			var scheme APIKeySecurityScheme
+			if err := json.Unmarshal(v, &scheme); err != nil {
+				return err
+			}
+			result[name] = scheme
+		} else if v, ok := raw["httpAuthSecurityScheme"]; ok {
+			var scheme HTTPAuthSecurityScheme
+			if err := json.Unmarshal(v, &scheme); err != nil {
+				return err
+			}
+			result[name] = scheme
+		} else if v, ok := raw["mtlsSecurityScheme"]; ok {
+			var scheme MutualTLSSecurityScheme
+			if err := json.Unmarshal(v, &scheme); err != nil {
+				return err
+			}
+			result[name] = scheme
+		} else if v, ok := raw["oauth2SecurityScheme"]; ok {
+			var scheme OAuth2SecurityScheme
+			if err := json.Unmarshal(v, &scheme); err != nil {
+				return err
+			}
+			result[name] = scheme
+		} else if v, ok := raw["openIdConnectSecurityScheme"]; ok {
 			var scheme OpenIDConnectSecurityScheme
 			if err := json.Unmarshal(v, &scheme); err != nil {
 				return err

--- a/a2a/json_test.go
+++ b/a2a/json_test.go
@@ -86,11 +86,11 @@ func TestSecuritySchemeJSONCodec(t *testing.T) {
 	}
 
 	entriesJSON := []string{
-		`"name1":{"apiKey":{"location":"cookie","name":"abc"}}`,
-		`"name2":{"openIdConnect":{"openIdConnectUrl":"url"}}`,
-		`"name3":{"mutualTLS":{"description":"optional"}}`,
-		`"name4":{"http":{"bearerFormat":"JWT","scheme":"Bearer"}}`,
-		`"name5":{"oauth2":{"oauth2MetadataUrl": "https://test.com", "description": "test","flows":{"password":{"scopes":{"email":"read user emails"},"tokenUrl":"url"}}}}`,
+		`"name1":{"apiKeySecurityScheme":{"location":"cookie","name":"abc"}}`,
+		`"name2":{"openIdConnectSecurityScheme":{"openIdConnectUrl":"url"}}`,
+		`"name3":{"mtlsSecurityScheme":{"description":"optional"}}`,
+		`"name4":{"httpAuthSecurityScheme":{"bearerFormat":"JWT","scheme":"Bearer"}}`,
+		`"name5":{"oauth2SecurityScheme":{"oauth2MetadataUrl": "https://test.com", "description": "test","flows":{"password":{"scopes":{"email":"read user emails"},"tokenUrl":"url"}}}}`,
 	}
 	wantJSON := fmt.Sprintf("{%s}", strings.Join(entriesJSON, ","))
 
@@ -132,7 +132,7 @@ func TestAgentCardParsing(t *testing.T) {
   },
   "securitySchemes": {
     "google": {
-      "openIdConnect": {
+      "openIdConnectSecurityScheme": {
         "openIdConnectUrl": "https://accounts.google.com/.well-known/openid-configuration"
       }
     }


### PR DESCRIPTION
closes #296 

Updated MarshalJSON and UnmarshalJSON for NamedSecuritySchemes to output both the legacy short keys and the spec compliant long keys.

Added TODO comments to track the eventual removal of legacy keys.

Updated test cases and expected JSON strings to reflect the new naming convention.