### PR TITLE
fix: drop original error after override

### DIFF
--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -168,12 +168,6 @@ func (c *Client) ResubscribeToTask(ctx context.Context, id *a2a.TaskIDParams) it
 				yield(nil, errOverride)
 				return
 			}
-
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-
 			if !yield(interceptedEvent, nil) {
 				return
 			}


### PR DESCRIPTION
Removed redundant error check after interceptor override in a2aclient.ResubscribeToTask