### PR TITLE
feat: add tenant propagation

### DIFF
--- a/a2a/tenant.go
+++ b/a2a/tenant.go
@@ -1,0 +1,32 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2a
+
+import (
+	"context"
+)
+
+type tenantKeyType struct{}
+
+// TenantFrom returns the value of the tenant field if it was set present in the request.
+func TenantFrom(ctx context.Context) (string, bool) {
+	t, ok := ctx.Value(tenantKeyType{}).(string)
+	return t, ok
+}
+
+// AttachTenant attaches the tenant to the context. It can later be retrieved using [TenantFrom].
+func AttachTenant(ctx context.Context, tenant string) context.Context {
+	return context.WithValue(ctx, tenantKeyType{}, tenant)
+}

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -40,6 +40,9 @@ type Config struct {
 	// If there's no overlap in supported Transport Factory will return an error on Client
 	// creation attempt.
 	PreferredTransports []a2a.TransportProtocol
+	// DisableTenantPropagation disables tenant propagation.
+	// If true, the client will not attach tenant from context to the request.
+	DisableTenantPropagation bool
 }
 
 // Client represents a transport-agnostic implementation of A2A client.

--- a/a2aclient/factory.go
+++ b/a2aclient/factory.go
@@ -96,7 +96,7 @@ func (f *Factory) CreateFromCard(ctx context.Context, card *a2a.AgentCard) (*Cli
 		return nil, err
 	}
 
-	conn, selected, err := createTransport(ctx, candidates, card)
+	conn, selected, err := createTransport(ctx, candidates, card, &f.config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open a connection: %w", err)
 	}
@@ -124,7 +124,7 @@ func (f *Factory) CreateFromEndpoints(ctx context.Context, endpoints []*a2a.Agen
 		return nil, err
 	}
 
-	conn, selected, err := createTransport(ctx, candidates, nil)
+	conn, selected, err := createTransport(ctx, candidates, nil, &f.config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open a connection: %w", err)
 	}
@@ -140,7 +140,7 @@ func (f *Factory) CreateFromEndpoints(ctx context.Context, endpoints []*a2a.Agen
 
 // createTransport attempts to connect using the provided transports, returning the first
 // one that succeeds. If all transports fail, it returns an error.
-func createTransport(ctx context.Context, candidates []transportCandidate, card *a2a.AgentCard) (Transport, *transportCandidate, error) {
+func createTransport(ctx context.Context, candidates []transportCandidate, card *a2a.AgentCard, config *Config) (Transport, *transportCandidate, error) {
 	if len(candidates) == 0 {
 		return nil, nil, fmt.Errorf("empty list of transport candidates was provided")
 	}
@@ -164,9 +164,7 @@ func createTransport(ctx context.Context, candidates []transportCandidate, card 
 		log.Info(ctx, "some transports failed to connect", "failures", failures)
 	}
 
-	if selected.endpoint.Tenant != "" {
-		transport = &tenantTransportDecorator{base: transport, tenant: selected.endpoint.Tenant}
-	}
+	transport = &tenantTransportDecorator{base: transport, tenant: selected.endpoint.Tenant, config: config}
 
 	return transport, selected, nil
 }

--- a/a2aclient/transport.go
+++ b/a2aclient/transport.go
@@ -152,10 +152,11 @@ func (d *tenantTransportDecorator) updateTenant(ctx context.Context, current str
 	if d.tenant != "" {
 		return d.tenant
 	}
-	if d.config == nil || !d.config.DisableTenantPropagation {
-		if tenant, ok := a2a.TenantFrom(ctx); ok {
-			return tenant
-		}
+	if d.config != nil && d.config.DisableTenantPropagation {
+		return ""
+	}
+	if tenant, ok := a2a.TenantFrom(ctx); ok {
+		return tenant
 	}
 	return ""
 }

--- a/a2aclient/transport.go
+++ b/a2aclient/transport.go
@@ -152,7 +152,7 @@ func (d *tenantTransportDecorator) updateTenant(ctx context.Context, current str
 	if d.tenant != "" {
 		return d.tenant
 	}
-	if d.config != nil && !d.config.DisableTenantPropagation {
+	if d.config == nil || !d.config.DisableTenantPropagation {
 		if tenant, ok := a2a.TenantFrom(ctx); ok {
 			return tenant
 		}

--- a/a2aclient/transport.go
+++ b/a2aclient/transport.go
@@ -140,69 +140,78 @@ func (unimplementedTransport) Destroy() error {
 type tenantTransportDecorator struct {
 	base   Transport
 	tenant string
+	config *Config
 }
 
 var _ Transport = (*tenantTransportDecorator)(nil)
 
-func (d *tenantTransportDecorator) updateTenant(current string) string {
+func (d *tenantTransportDecorator) updateTenant(ctx context.Context, current string) string {
 	if current != "" {
 		return current
 	}
-	return d.tenant
+	if d.tenant != "" {
+		return d.tenant
+	}
+	if d.config != nil && !d.config.DisableTenantPropagation {
+		if tenant, ok := a2a.TenantFrom(ctx); ok {
+			return tenant
+		}
+	}
+	return ""
 }
 
 func (d *tenantTransportDecorator) GetTask(ctx context.Context, params ServiceParams, req *a2a.GetTaskRequest) (*a2a.Task, error) {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.GetTask(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) ListTasks(ctx context.Context, params ServiceParams, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.ListTasks(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) CancelTask(ctx context.Context, params ServiceParams, req *a2a.CancelTaskRequest) (*a2a.Task, error) {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.CancelTask(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) SendMessage(ctx context.Context, params ServiceParams, req *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.SendMessage(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) SubscribeToTask(ctx context.Context, params ServiceParams, req *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.SubscribeToTask(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) SendStreamingMessage(ctx context.Context, params ServiceParams, req *a2a.SendMessageRequest) iter.Seq2[a2a.Event, error] {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.SendStreamingMessage(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.GetTaskPushConfig(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.ListTaskPushConfigs(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.CreateTaskPushConfig(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) DeleteTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.DeleteTaskPushConfigRequest) error {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.DeleteTaskPushConfig(ctx, params, req)
 }
 
 func (d *tenantTransportDecorator) GetExtendedAgentCard(ctx context.Context, params ServiceParams, req *a2a.GetExtendedAgentCardRequest) (*a2a.AgentCard, error) {
-	req.Tenant = d.updateTenant(req.Tenant)
+	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.GetExtendedAgentCard(ctx, params, req)
 }
 

--- a/a2aext/propagator_test.go
+++ b/a2aext/propagator_test.go
@@ -229,7 +229,7 @@ func TestDefaultPropagation(t *testing.T) {
 				a2aclient.WithCallInterceptors(NewActivator(tc.serverASupports...)),
 			)
 			if err != nil {
-				t.Fatalf("a2aclient.NewFromEndpoints() error = %v", err)
+				t.Fatalf("a2aclient.NewFromCard() error = %v", err)
 			}
 
 			resp, err := client.SendMessage(ctx, &a2a.SendMessageRequest{

--- a/a2asrv/intercepted_handler.go
+++ b/a2asrv/intercepted_handler.go
@@ -288,6 +288,11 @@ func (h *InterceptedHandler) withLoggerContext(ctx context.Context, attrs ...any
 // attachMethodCallContext is a private utility function which modifies CallContext.method if a CallContext
 // was passed by a transport implementation or initializes a new CallContext with the provided method.
 func attachMethodCallContext(ctx context.Context, method string, tenant string) (context.Context, *CallContext) {
+	// AttachTenant needed for a2aclient package, which is not aware of CallContext.
+	if tenant != "" {
+		ctx = a2a.AttachTenant(ctx, tenant)
+	}
+
 	callCtx, ok := CallContextFrom(ctx)
 	if !ok {
 		ctx, callCtx = NewCallContext(ctx, nil)

--- a/e2e/tenant_propagation_test.go
+++ b/e2e/tenant_propagation_test.go
@@ -76,7 +76,7 @@ func TestTenantPropagation(t *testing.T) {
 				return func(yield func(a2a.Event, error) bool) {
 					gotTenant = execCtx.Tenant
 					event := a2a.NewSubmittedTask(execCtx, execCtx.Message)
-					event.Status = a2a.TaskStatus{State: a2a.TaskStateCompleted}
+					event.Status.State = a2a.TaskStateCompleted
 					yield(event, nil)
 				}
 			}))

--- a/e2e/tenant_propagation_test.go
+++ b/e2e/tenant_propagation_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/internal/testutil/testexecutor"
+)
+
+func TestTenantPropagation(t *testing.T) {
+	tests := []struct {
+		name               string
+		incomingTenant     string
+		ifaceTenant        string
+		explicitTenant     string
+		disablePropagation bool
+		wantTenant         string
+	}{
+		{
+			name:           "explicit tenant wins over all",
+			incomingTenant: "incomingTenant",
+			ifaceTenant:    "ifaceTenant",
+			explicitTenant: "explicitTenant",
+			wantTenant:     "explicitTenant",
+		},
+		{
+			name:           "iface tenant wins over ctx tenant",
+			incomingTenant: "incomingTenant",
+			ifaceTenant:    "ifaceTenant",
+			wantTenant:     "ifaceTenant",
+		},
+		{
+			name:           "context fallback",
+			incomingTenant: "incomingTenant",
+			wantTenant:     "incomingTenant",
+		},
+		{
+			name:       "no tenant",
+			wantTenant: "",
+		},
+		{
+			name:               "propagation disabled",
+			incomingTenant:     "incomingTenant",
+			disablePropagation: true,
+			wantTenant:         "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			var gotTenant string
+
+			serverBIface := startServer(t, testexecutor.FromFunction(func(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+				return func(yield func(a2a.Event, error) bool) {
+					gotTenant = execCtx.Tenant
+					event := a2a.NewSubmittedTask(execCtx, execCtx.Message)
+					event.Status = a2a.TaskStatus{State: a2a.TaskStateCompleted}
+					yield(event, nil)
+				}
+			}))
+			serverBIface.Tenant = tc.ifaceTenant
+
+			serverAIface := startServer(t, newProxyExecutor(proxyTarget{ai: serverBIface}, tc.disablePropagation, tc.explicitTenant))
+			serverAIface.Tenant = tc.incomingTenant
+			client, err := a2aclient.NewFromEndpoints(ctx, []*a2a.AgentInterface{serverAIface})
+			if err != nil {
+				t.Fatalf("a2aclient.NewFromEndpoints() error = %v", err)
+			}
+			resp, err := client.SendMessage(ctx, &a2a.SendMessageRequest{
+				Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("Hi!")),
+			})
+			if err != nil {
+				t.Fatalf("client.SendMessage() error = %v", err)
+			}
+			if task, ok := resp.(*a2a.Task); !ok || task.Status.State != a2a.TaskStateCompleted {
+				t.Fatalf("client.SendMessage() = %v, want completed task", resp)
+			}
+			if gotTenant != tc.wantTenant {
+				t.Fatalf("gotTenant = %q, wantTenant = %q", gotTenant, tc.wantTenant)
+			}
+		})
+	}
+}
+
+type proxyTarget struct {
+	ai *a2a.AgentInterface
+}
+
+func (pt proxyTarget) newClient(ctx context.Context, disablePropagation bool) (*a2aclient.Client, error) {
+	if pt.ai != nil {
+		client, err := a2aclient.NewFromEndpoints(ctx, []*a2a.AgentInterface{pt.ai}, a2aclient.WithConfig(a2aclient.Config{
+			DisableTenantPropagation: disablePropagation,
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return client, nil
+	}
+	return nil, fmt.Errorf("agent interface not provided")
+}
+
+func newProxyExecutor(target proxyTarget, disablePropagation bool, explicitTenant string) a2asrv.AgentExecutor {
+	return testexecutor.FromFunction(func(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+		return func(yield func(a2a.Event, error) bool) {
+			client, err := target.newClient(ctx, disablePropagation)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			resp, err := client.SendMessage(ctx, &a2a.SendMessageRequest{
+				Message: a2a.NewMessage(a2a.MessageRoleUser, execCtx.Message.Parts...),
+				Tenant:  explicitTenant,
+			})
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+
+			task, ok := resp.(*a2a.Task)
+			if !ok {
+				yield(nil, fmt.Errorf("client.SendMessage() = %v, want completed task", resp))
+				return
+			}
+
+			task.ID = execCtx.TaskID
+			task.ContextID = execCtx.ContextID
+			yield(task, nil)
+		}
+	})
+}
+
+func startServer(t *testing.T, executor a2asrv.AgentExecutor) *a2a.AgentInterface {
+	t.Helper()
+	reqHandler := a2asrv.NewHandler(executor)
+	server := httptest.NewServer(a2asrv.NewJSONRPCHandler(reqHandler))
+	t.Cleanup(server.Close)
+	return a2a.NewAgentInterface(server.URL, a2a.TransportProtocolJSONRPC)
+}


### PR DESCRIPTION
- Server attaches tenant to context in `attachMethodCallContext`, enabling `a2aclient` to read it via `a2a.TenantFrom(ctx)`
- `tenantTransportDecorator` now falls back to context-based tenant when neither explicit `req.Tenant` nor `AgentInterface.Tenant` is set
- New `Config.DisableTenantPropagation` flag to opt out of fall back to context-based tenant
- E2E test covering the full priority chain: tenant set directly in request > tenant set in `a2a.AgentInterface.Tenant`> tenant set in context > none