### PR TITLE
fix: extra query and execution cleanup race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.14](https://github.com/a2aproject/a2a-go/compare/v0.3.13...v0.3.14) (2026-04-15)
+
+### Bug Fixes
+
+* fix unnecessary task store get in local execution mode
+
 ## [0.3.13](https://github.com/a2aproject/a2a-go/compare/v0.3.12...v0.3.13) (2026-03-30)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.15](https://github.com/a2aproject/a2a-go/compare/v0.3.14...v0.3.15) (2026-04-15)
+
+### Bug Fixes
+
+* fix message rejected during input_required resumption due to execution cleanup race (#303)
+
 ## [0.3.14](https://github.com/a2aproject/a2a-go/compare/v0.3.13...v0.3.14) (2026-04-15)
 
 ### Bug Fixes

--- a/a2asrv/agentexec.go
+++ b/a2asrv/agentexec.go
@@ -108,11 +108,12 @@ type AgentExecutionCleaner interface {
 }
 
 type factory struct {
-	taskStore       TaskStore
-	pushSender      PushSender
-	pushConfigStore PushConfigStore
-	agent           AgentExecutor
-	interceptors    []RequestContextInterceptor
+	taskStore          TaskStore
+	pushSender         PushSender
+	pushConfigStore    PushConfigStore
+	agent              AgentExecutor
+	interceptors       []RequestContextInterceptor
+	taskRetrySupported bool
 }
 
 var _ taskexec.Factory = (*factory)(nil)
@@ -151,6 +152,10 @@ type executionContext struct {
 // loadExecutionContext returns the information necessary for creating agent executor and agent event processor.
 func (f *factory) loadExecutionContext(ctx context.Context, tid a2a.TaskID, params *a2a.MessageSendParams) (*executionContext, error) {
 	msg := params.Message
+
+	if msg.TaskID == "" && !f.taskRetrySupported {
+		return f.createNewExecutionContext(tid, params)
+	}
 
 	storedTask, lastVersion, err := f.taskStore.Get(ctx, tid)
 	if errors.Is(err, a2a.ErrTaskNotFound) && msg.TaskID == "" {

--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -145,11 +145,12 @@ func NewHandler(executor AgentExecutor, options ...RequestHandlerOption) Request
 	}
 
 	execFactory := &factory{
-		agent:           h.agentExecutor,
-		taskStore:       h.taskStore,
-		pushSender:      h.pushSender,
-		pushConfigStore: h.pushConfigStore,
-		interceptors:    h.reqContextInterceptors,
+		agent:              h.agentExecutor,
+		taskStore:          h.taskStore,
+		pushSender:         h.pushSender,
+		pushConfigStore:    h.pushConfigStore,
+		interceptors:       h.reqContextInterceptors,
+		taskRetrySupported: h.workQueue != nil,
 	}
 	if h.workQueue != nil {
 		if h.taskStore == nil || h.queueManager == nil {

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"iter"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1115,37 +1116,63 @@ func TestRequestHandler_OnSendMessage_AgentExecutionFails(t *testing.T) {
 }
 
 func TestRequestHandler_OnSendMessage_NoTaskCreated(t *testing.T) {
-	ctx := t.Context()
-	getCalled := 0
-	savedCalled := 0
-	mockStore := testutil.NewTestTaskStore()
-	mockStore.GetFunc = func(ctx context.Context, taskID a2a.TaskID) (*a2a.Task, a2a.TaskVersion, error) {
-		getCalled += 1
-		return nil, a2a.TaskVersionMissing, a2a.ErrTaskNotFound
-	}
-	mockStore.SaveFunc = func(ctx context.Context, task *a2a.Task, event a2a.Event, prevTask *a2a.Task, version a2a.TaskVersion) (a2a.TaskVersion, error) {
-		savedCalled += 1
-		return version, nil
-	}
+	for _, clusterMode := range []bool{false, true} {
+		name := "local"
+		if clusterMode {
+			name = "cluster"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			var getCalled atomic.Int32
+			savedCalled := 0
+			mockStore := testutil.NewTestTaskStore()
+			mockStore.GetFunc = func(ctx context.Context, taskID a2a.TaskID) (*a2a.Task, a2a.TaskVersion, error) {
+				getCalled.Add(1)
+				return nil, a2a.TaskVersionMissing, a2a.ErrTaskNotFound
+			}
+			mockStore.SaveFunc = func(ctx context.Context, task *a2a.Task, event a2a.Event, prevTask *a2a.Task, version a2a.TaskVersion) (a2a.TaskVersion, error) {
+				savedCalled += 1
+				return version, nil
+			}
 
-	executor := newEventReplayAgent([]a2a.Event{newAgentMessage("hello")}, nil)
-	handler := NewHandler(executor, WithTaskStore(mockStore))
+			executor := newEventReplayAgent([]a2a.Event{newAgentMessage("hello")}, nil)
+			var opts []RequestHandlerOption
+			if clusterMode {
+				opts = append(opts, WithClusterMode(ClusterConfig{
+					QueueManager: testutil.NewTestQueueManager(),
+					WorkQueue:    testutil.NewInMemoryWorkQueue(),
+					TaskStore:    mockStore,
+				}))
+			} else {
+				opts = append(opts, WithTaskStore(mockStore))
+			}
+			handler := NewHandler(executor, opts...)
 
-	result, gotErr := handler.OnSendMessage(ctx, &a2a.MessageSendParams{
-		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "Work"}),
-	})
-	if gotErr != nil {
-		t.Fatalf("OnSendMessage() error = %v, wantErr nil", gotErr)
-	}
-	if _, ok := result.(*a2a.Message); !ok {
-		t.Fatalf("OnSendMessage() = %v, want a2a.Message", result)
-	}
+			result, gotErr := handler.OnSendMessage(ctx, &a2a.MessageSendParams{
+				Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.TextPart{Text: "Work"}),
+			})
+			if gotErr != nil {
+				t.Fatalf("OnSendMessage() error = %v, wantErr nil", gotErr)
+			}
+			if _, ok := result.(*a2a.Message); !ok {
+				t.Fatalf("OnSendMessage() = %v, want a2a.Message", result)
+			}
 
-	if getCalled != 1 {
-		t.Fatalf("OnSendMessage() TaskStore.Get called %d times, want 1", getCalled)
-	}
-	if savedCalled > 0 {
-		t.Fatalf("OnSendMessage() TaskStore.Save called %d times, want 0", savedCalled)
+			var wantGetCalls int32 = 0
+			if clusterMode {
+				// in cluster mode the first get call is performed on task submission to prevent work submission for
+				// tasks in finished state.
+				// the second get call is performed before starting an execution even when a message does not reference
+				// a task, because workqueue implementation can support retries
+				wantGetCalls = 2
+			}
+			if getCalled.Load() != wantGetCalls {
+				t.Fatalf("OnSendMessage() TaskStore.Get called %d times, want %d", getCalled.Load(), wantGetCalls)
+			}
+			if savedCalled > 0 {
+				t.Fatalf("OnSendMessage() TaskStore.Save called %d times, want 0", savedCalled)
+			}
+		})
 	}
 }
 

--- a/internal/taskexec/local_manager.go
+++ b/internal/taskexec/local_manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 
 	"github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
@@ -70,6 +71,10 @@ type localExecution struct {
 
 	pipe         *eventpipe.Local
 	queueManager eventqueue.Manager
+
+	// exiting flag is set to true after we know the execution is about to finish.
+	// a fast client might attempt to send a follow-up before the execution gets unregistered.
+	exiting atomic.Bool
 }
 
 var _ Manager = (*localManager)(nil)
@@ -135,6 +140,10 @@ func (m *localManager) Execute(ctx context.Context, params *a2a.MessageSendParam
 		tid = a2a.NewTaskID()
 	} else {
 		tid = params.Message.TaskID
+		// handle fast client sending a follow-up message before execution was unregistered
+		if err := m.waitForExiting(ctx, tid); err != nil {
+			return nil, err
+		}
 	}
 
 	execution, err := m.createExecution(ctx, tid, params)
@@ -159,6 +168,20 @@ func (m *localManager) Execute(ctx context.Context, params *a2a.MessageSendParam
 	go m.handleExecution(detachedCtx, execution, eventBroadcastQueue)
 
 	return newLocalSubscription(execution, defaultSubReadQueue), nil
+}
+
+func (m *localManager) waitForExiting(ctx context.Context, tid a2a.TaskID) error {
+	m.mu.Lock()
+	exec, ok := m.executions[tid]
+	m.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	if !exec.exiting.Load() {
+		return ErrExecutionInProgress
+	}
+	_, _ = exec.result.wait(ctx)
+	return ctx.Err()
 }
 
 func (m *localManager) createExecution(ctx context.Context, tid a2a.TaskID, params *a2a.MessageSendParams) (*localExecution, error) {
@@ -243,8 +266,12 @@ func (m *localManager) handleExecution(ctx context.Context, execution *localExec
 	handler := &executionHandler{
 		agentEvents:       execution.pipe.Reader,
 		handledEventQueue: eventBroadcast,
-		handleEventFn:     processor.Process,
-		handleErrorFn:     processor.ProcessError,
+		handleEventFn: func(ctx context.Context, e a2a.Event) (*ProcessorResult, error) {
+			result, err := processor.Process(ctx, e)
+			execution.exiting.Store(err != nil || result.ExecutionResult != nil)
+			return result, err
+		},
+		handleErrorFn: processor.ProcessError,
 	}
 	result, err := runProducerConsumer(
 		ctx,

--- a/internal/testutil/workqueue.go
+++ b/internal/testutil/workqueue.go
@@ -53,3 +53,20 @@ func NewTestWorkQueue() *TestWorkQueue {
 		Payloads: make([]*workqueue.Payload, 0),
 	}
 }
+
+// NewInMemoryWorkQueue is a simple workqueue implementation.
+func NewInMemoryWorkQueue() *TestWorkQueue {
+	var handler workqueue.HandlerFn
+	tq := &TestWorkQueue{
+		WriteFunc: func(ctx context.Context, p *workqueue.Payload) (a2a.TaskID, error) {
+			go func(ctx context.Context) {
+				_, _ = handler(ctx, p)
+			}(context.WithoutCancel(ctx))
+			return p.TaskID, nil
+		},
+		RegisterHandlerFunc: func(cc limiter.ConcurrencyConfig, hf workqueue.HandlerFn) {
+			handler = hf
+		},
+	}
+	return tq
+}


### PR DESCRIPTION
* Fix an extra task store get on non-followup agent execution in non-cluster mode. If message taskID is an empty string and there's no workqueue we're basically trying to look-up a random uuid in task store, which always results in ErrTaskNotFound.
* Fix an execution cleanup race for fast client follow-up (#303)

Tested race by inserting a `time.Sleep(...)` in local manager cleanupExecution