### PR TITLE
fix: update error handling to match spec

### DIFF
--- a/a2a/auth.go
+++ b/a2a/auth.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 )
 
+// PROTOCOL_DOMAIN is the domain used for A2A protocol.
+const PROTOCOL_DOMAIN = "a2a-protocol.org"
+
 // SecurityRequirements describes a set of security requirements that must be present on a request.
 // For example, to specify that mutual TLS AND an oauth2 token for specific scopes is required, the
 // following requirements object needs to be created:

--- a/a2a/auth.go
+++ b/a2a/auth.go
@@ -20,9 +20,6 @@ import (
 	"fmt"
 )
 
-// PROTOCOL_DOMAIN is the domain used for A2A protocol.
-const PROTOCOL_DOMAIN = "a2a-protocol.org"
-
 // SecurityRequirements describes a set of security requirements that must be present on a request.
 // For example, to specify that mutual TLS AND an oauth2 token for specific scopes is required, the
 // following requirements object needs to be created:

--- a/a2a/core.go
+++ b/a2a/core.go
@@ -23,6 +23,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// ProtocolDomain is the domain used for A2A protocol.
+const ProtocolDomain = "a2a-protocol.org"
+
 // ProtocolVersion is a string constant which represents a version of the protocol.
 type ProtocolVersion string
 

--- a/a2a/errors.go
+++ b/a2a/errors.go
@@ -81,13 +81,13 @@ var (
 )
 
 // ErrorReason returns the reason string for an error.
-func ErrorReason(err error) (string, bool) {
+func ErrorReason(err error) string {
 	for sentinel, reason := range errorReason {
 		if errors.Is(err, sentinel) {
-			return reason, true
+			return reason
 		}
 	}
-	return "", false
+	return "INTERNAL_ERROR"
 }
 
 var errorReason = map[error]string{
@@ -125,20 +125,14 @@ type Error struct {
 // ErrorInfo returns the ErrorInfo typed detail. If not present, it will be created.
 func (e *Error) ErrorInfo() *errordetails.Typed {
 	existing := slices.IndexFunc(e.TypedDetails, func(d *errordetails.Typed) bool {
-		return d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo"
+		return d.TypeURL == errordetails.ErrorInfoType
 	})
 	if existing != -1 {
 		return e.TypedDetails[existing]
 	}
-	reason, _ := ErrorReason(e.Err)
+	reason := ErrorReason(e.Err)
 
-	e.TypedDetails = append(e.TypedDetails, &errordetails.Typed{
-		TypeURL: "type.googleapis.com/google.rpc.ErrorInfo",
-		Value: map[string]any{
-			"domain": PROTOCOL_DOMAIN,
-			"reason": reason,
-		},
-	})
+	e.TypedDetails = append(e.TypedDetails, errordetails.NewErrorInfo(reason, ProtocolDomain, nil))
 	return e.TypedDetails[len(e.TypedDetails)-1]
 }
 
@@ -173,5 +167,11 @@ func (e *Error) WithDetails(details map[string]any) *Error {
 func (e *Error) WithErrorInfoMeta(meta map[string]string) *Error {
 	typedErr := e.ErrorInfo()
 	typedErr.Value["metadata"] = meta
+	return e
+}
+
+// WithTypedDetails adds typed details to the error.
+func (e *Error) WithTypedDetails(details ...*errordetails.Typed) *Error {
+	e.TypedDetails = append(e.TypedDetails, details...)
 	return e
 }

--- a/a2a/errors.go
+++ b/a2a/errors.go
@@ -14,9 +14,14 @@
 
 package a2a
 
-import "errors"
+import (
+	"errors"
+	"slices"
 
-// https://a2a-protocol.org/latest/specification/#8-error-handling
+	"github.com/a2aproject/a2a-go/v2/errordetails"
+)
+
+// https://a2a-protocol.org/latest/specification/#332-error-handling
 var (
 	// ErrParseError indicates that server received payload that was not well-formed.
 	ErrParseError = errors.New("parse error")
@@ -75,6 +80,32 @@ var (
 	ErrUnauthorized = errors.New("permission denied")
 )
 
+// ErrorReason returns the reason string for an error.
+func ErrorReason(err error) (string, bool) {
+	reason, exists := errorReason[err]
+	return reason, exists
+}
+
+var errorReason = map[error]string{
+	ErrParseError:                   "PARSE_ERROR",
+	ErrInvalidRequest:               "INVALID_REQUEST",
+	ErrMethodNotFound:               "METHOD_NOT_FOUND",
+	ErrInvalidParams:                "INVALID_PARAMS",
+	ErrInternalError:                "INTERNAL_ERROR",
+	ErrServerError:                  "SERVER_ERROR",
+	ErrTaskNotFound:                 "TASK_NOT_FOUND",
+	ErrTaskNotCancelable:            "TASK_NOT_CANCELABLE",
+	ErrPushNotificationNotSupported: "PUSH_NOTIFICATION_NOT_SUPPORTED",
+	ErrUnsupportedOperation:         "UNSUPPORTED_OPERATION",
+	ErrUnsupportedContentType:       "CONTENT_TYPE_NOT_SUPPORTED",
+	ErrInvalidAgentResponse:         "INVALID_AGENT_RESPONSE",
+	ErrExtendedCardNotConfigured:    "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
+	ErrExtensionSupportRequired:     "EXTENSION_SUPPORT_REQUIRED",
+	ErrVersionNotSupported:          "VERSION_NOT_SUPPORTED",
+	ErrUnauthenticated:              "UNAUTHENTICATED",
+	ErrUnauthorized:                 "UNAUTHORIZED",
+}
+
 // Error provides control over the message and details returned to clients.
 type Error struct {
 	// Err is the underlying error. It will be used for transport-specific code selection.
@@ -83,6 +114,28 @@ type Error struct {
 	Message string
 	// Details can contain additional structured information about the error.
 	Details map[string]any
+	// TypedDetails contains typed details about the error.
+	TypedDetails []*errordetails.Typed
+}
+
+// ErrorInfo returns the ErrorInfo typed detail. If not present, it will be created.
+func (e *Error) ErrorInfo() *errordetails.Typed {
+	existing := slices.IndexFunc(e.TypedDetails, func(d *errordetails.Typed) bool {
+		return d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo"
+	})
+	if existing != -1 {
+		return e.TypedDetails[existing]
+	}
+	reason, _ := ErrorReason(e.Err)
+
+	e.TypedDetails = append(e.TypedDetails, &errordetails.Typed{
+		TypeURL: "type.googleapis.com/google.rpc.ErrorInfo",
+		Value: map[string]any{
+			"domain": PROTOCOL_DOMAIN,
+			"reason": reason,
+		},
+	})
+	return e.TypedDetails[len(e.TypedDetails)-1]
 }
 
 // Error returns the error message.
@@ -109,5 +162,12 @@ func NewError(err error, message string) *Error {
 // WithDetails attaches structured data to the error.
 func (e *Error) WithDetails(details map[string]any) *Error {
 	e.Details = details
+	return e
+}
+
+// WithErrorInfoMeta adds metadata to the ErrorInfo typed detail.
+func (e *Error) WithErrorInfoMeta(meta map[string]string) *Error {
+	typedErr := e.ErrorInfo()
+	typedErr.Value["metadata"] = meta
 	return e
 }

--- a/a2aclient/jsonrpc.go
+++ b/a2aclient/jsonrpc.go
@@ -131,7 +131,7 @@ func (t *jsonrpcTransport) sendRequest(ctx context.Context, method string, param
 	}
 
 	if resp.Error != nil {
-		return nil, resp.Error.ToA2AError()
+		return nil, jsonrpc.FromJSONRPCError(resp.Error)
 	}
 
 	return resp.Result, nil
@@ -174,7 +174,7 @@ func parseSSEStream(body io.Reader) iter.Seq2[json.RawMessage, error] {
 				return
 			}
 			if resp.Error != nil {
-				yield(nil, resp.Error.ToA2AError())
+				yield(nil, jsonrpc.FromJSONRPCError(resp.Error))
 				return
 			}
 			if !yield(resp.Result, nil) {

--- a/a2aclient/jsonrpc_test.go
+++ b/a2aclient/jsonrpc_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/errordetails"
 	"github.com/a2aproject/a2a-go/v2/internal/jsonrpc"
 	"github.com/google/go-cmp/cmp"
 )
@@ -231,7 +232,7 @@ func TestJSONRPCTransport_ListTasks(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(wantResult, tasks); diff != "" {
-		t.Fatalf("ListTasks wrong result (-got +want): %s", diff)
+		t.Fatalf("ListTasks wrong result (+got -want): %s", diff)
 	}
 }
 
@@ -607,7 +608,9 @@ func TestJSONRPCTransport_WithHTTPClient(t *testing.T) {
 }
 
 func TestJSONRPCTransport_ErrorDetails(t *testing.T) {
-	wantMsg, wantDetails := "Access Denied", map[string]any{"reason": "expired_token", "scope": "read"}
+	wantMsg := "Access Denied"
+	wantDetails := map[string]any{"reason": "expired_token", "scope": "read"}
+	typedDetails := []*errordetails.Typed{errordetails.NewTyped("google.protobuf.Struct", wantDetails)}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		req := mustDecodeJSONRPC(t, r, "GetTask")
 
@@ -617,7 +620,7 @@ func TestJSONRPCTransport_ErrorDetails(t *testing.T) {
 			Error: &jsonrpc.Error{
 				Code:    -31403,
 				Message: wantMsg,
-				Data:    wantDetails,
+				Data:    typedDetails,
 			},
 		}
 		_ = json.NewEncoder(w).Encode(resp)

--- a/a2aclient/rest.go
+++ b/a2aclient/rest.go
@@ -125,7 +125,7 @@ func (t *RESTTransport) sendRequest(ctx context.Context, req *restRequest) (*htt
 				log.Error(ctx, "failed to close http response body", err)
 			}
 		}()
-		return nil, rest.ToA2AError(httpResp)
+		return nil, rest.FromRESTError(httpResp)
 	}
 
 	return httpResp, nil

--- a/a2acompat/a2av0/jsonrpc_client.go
+++ b/a2acompat/a2av0/jsonrpc_client.go
@@ -130,7 +130,7 @@ func (t *jsonrpcTransport) sendRequest(ctx context.Context, method string, param
 	}
 
 	if resp.Error != nil {
-		return nil, resp.Error.ToA2AError()
+		return nil, jsonrpc.FromJSONRPCError(resp.Error)
 	}
 
 	return resp.Result, nil
@@ -171,7 +171,7 @@ func parseSSEStream(body io.Reader) iter.Seq2[json.RawMessage, error] {
 				return
 			}
 			if resp.Error != nil {
-				yield(nil, resp.Error.ToA2AError())
+				yield(nil, jsonrpc.FromJSONRPCError(resp.Error))
 				return
 			}
 			if !yield(resp.Result, nil) {

--- a/a2acompat/a2av0/rest_client.go
+++ b/a2acompat/a2av0/rest_client.go
@@ -138,7 +138,7 @@ func (t *restCompatTransport) sendRequest(ctx context.Context, req *compatRestRe
 				log.Error(ctx, "failed to close http response body", err)
 			}
 		}()
-		return nil, rest.ToA2AError(resp)
+		return nil, rest.FromRESTError(resp)
 	}
 	return resp, nil
 }

--- a/a2asrv/jsonrpc_test.go
+++ b/a2asrv/jsonrpc_test.go
@@ -277,12 +277,12 @@ func TestJSONRPC_Validations(t *testing.T) {
 				if payload.Error == nil {
 					t.Errorf("payload.Error = nil, want %v", tc.wantErr)
 				}
-				if !errors.Is(payload.Error.ToA2AError(), tc.wantErr) {
-					t.Errorf("payload.Error = %v, want %v", payload.Error.ToA2AError(), tc.wantErr)
+				if !errors.Is(jsonrpc.FromJSONRPCError(payload.Error), tc.wantErr) {
+					t.Errorf("payload.Error = %v, want %v", jsonrpc.FromJSONRPCError(payload.Error), tc.wantErr)
 				}
 			} else {
 				if payload.Error != nil {
-					t.Errorf("payload.Error = %v, want nil", payload.Error.ToA2AError())
+					t.Errorf("payload.Error = %v, want nil", jsonrpc.FromJSONRPCError(payload.Error))
 				}
 				if diff := cmp.Diff(tc.want, payload.Result); diff != "" {
 					t.Errorf("payload.Result = %v, want %v", payload.Result, tc.want)

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -359,7 +359,7 @@ func TestREST_InvalidPayloads(t *testing.T) {
 				t.Errorf("got Content-Type %q, want application/json", contentType)
 			}
 
-			gotErr := rest.ToA2AError(resp)
+			gotErr := rest.FromRESTError(resp)
 
 			if !errors.Is(gotErr, expectedErr) {
 				t.Errorf("got error %v, want %v", gotErr, expectedErr)
@@ -415,7 +415,7 @@ func TestREST_ListTasksParseErrors(t *testing.T) {
 				t.Fatalf("resp.StatusCode = %d, want non-200 for invalid query params", resp.StatusCode)
 			}
 
-			gotErr := rest.ToA2AError(resp)
+			gotErr := rest.FromRESTError(resp)
 			if !errors.Is(gotErr, a2a.ErrInvalidRequest) {
 				t.Fatalf("rest.ToA2AError() = %v, want %v", gotErr, a2a.ErrInvalidRequest)
 			}

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -417,7 +417,7 @@ func TestREST_ListTasksParseErrors(t *testing.T) {
 
 			gotErr := rest.FromRESTError(resp)
 			if !errors.Is(gotErr, a2a.ErrInvalidRequest) {
-				t.Fatalf("rest.ToA2AError() = %v, want %v", gotErr, a2a.ErrInvalidRequest)
+				t.Fatalf("rest.FromRESTError() = %v, want %v", gotErr, a2a.ErrInvalidRequest)
 			}
 		})
 	}

--- a/errordetails/errordetails.go
+++ b/errordetails/errordetails.go
@@ -22,6 +22,12 @@ import (
 	"maps"
 )
 
+// Error detail type URLs
+const (
+	ErrorInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
+	StructType    = "type.googleapis.com/google.protobuf.Struct"
+)
+
 // Typed is a wrapper around a value that is marshaled with a type URL.
 type Typed struct {
 	TypeURL string
@@ -31,6 +37,23 @@ type Typed struct {
 // NewTyped creates a new Typed error detail.
 func NewTyped(t string, v map[string]any) *Typed {
 	return &Typed{TypeURL: t, Value: v}
+}
+
+// NewErrorInfo creates a new ErrorInfo error detail.
+func NewErrorInfo(reason string, domain string, metadata map[string]string) *Typed {
+	value := map[string]any{
+		"reason": reason,
+		"domain": domain,
+	}
+	if len(metadata) > 0 {
+		value["metadata"] = metadata
+	}
+	return NewTyped(ErrorInfoType, value)
+}
+
+// NewFromStruct creates a new StructType error detail from a map.
+func NewFromStruct(details map[string]any) *Typed {
+	return NewTyped(StructType, details)
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/errordetails/errordetails.go
+++ b/errordetails/errordetails.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package errordetails provides utilities for working with error details.
+*/
+package errordetails
+
+import (
+	"encoding/json"
+	"maps"
+)
+
+// Typed is a wrapper around a value that is marshaled with a type URL.
+type Typed struct {
+	TypeURL string
+	Value   map[string]any
+}
+
+// NewTyped creates a new Typed error detail.
+func NewTyped(t string, v map[string]any) *Typed {
+	return &Typed{TypeURL: t, Value: v}
+}
+
+// MarshalJSON implements json.Marshaler.
+func (w *Typed) MarshalJSON() ([]byte, error) {
+	typed := maps.Clone(w.Value)
+	typed["@type"] = w.TypeURL
+	return json.Marshal(typed)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (w *Typed) UnmarshalJSON(data []byte) error {
+	var v map[string]any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	if t, ok := v["@type"].(string); ok {
+		w.TypeURL = t
+		delete(v, "@type")
+	} else {
+		w.TypeURL = "google.protobuf.Struct"
+	}
+	w.Value = v
+	return nil
+}

--- a/errordetails/errordetails.go
+++ b/errordetails/errordetails.go
@@ -73,7 +73,7 @@ func (w *Typed) UnmarshalJSON(data []byte) error {
 		w.TypeURL = t
 		delete(v, "@type")
 	} else {
-		w.TypeURL = "google.protobuf.Struct"
+		w.TypeURL = StructType
 	}
 	w.Value = v
 	return nil

--- a/errordetails/errordetails_test.go
+++ b/errordetails/errordetails_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errordetails
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestErrorDetailsJSONCodec(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    *Typed
+		wantJSON string
+		// For unmarshal-only cases (no round-trip)
+		unmarshalOnly bool
+		inputJSON     string
+		wantTypeURL   string
+		wantValue     map[string]any
+	}{
+		// Round-trip
+		{
+			name:     "ErrorInfo with data",
+			input:    NewTyped("type.googleapis.com/google.rpc.ErrorInfo", map[string]any{"reason": "TASK_NOT_FOUND", "domain": "a2a-protocol.org"}),
+			wantJSON: `{"@type":"type.googleapis.com/google.rpc.ErrorInfo","domain":"a2a-protocol.org","reason":"TASK_NOT_FOUND"}`,
+		},
+		{
+			name:     "Struct with data",
+			input:    NewTyped("type.googleapis.com/google.protobuf.Struct", map[string]any{"foo": "bar"}),
+			wantJSON: `{"@type":"type.googleapis.com/google.protobuf.Struct","foo":"bar"}`,
+		},
+		{
+			name:     "empty value",
+			input:    NewTyped("type.googleapis.com/google.rpc.ErrorInfo", map[string]any{}),
+			wantJSON: `{"@type":"type.googleapis.com/google.rpc.ErrorInfo"}`,
+		},
+		{
+			name:          "missing @type defaults to Struct",
+			unmarshalOnly: true,
+			inputJSON:     `{"foo":"bar"}`,
+			wantTypeURL:   "google.protobuf.Struct",
+			wantValue:     map[string]any{"foo": "bar"},
+		},
+		{
+			name:          "non-string @type defaults to Struct",
+			unmarshalOnly: true,
+			inputJSON:     `{"@type":123,"foo":"bar"}`,
+			wantTypeURL:   "google.protobuf.Struct",
+			wantValue:     map[string]any{"@type": float64(123), "foo": "bar"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.unmarshalOnly {
+				var got Typed
+				if err := json.Unmarshal([]byte(tc.inputJSON), &got); err != nil {
+					t.Fatalf("Unmarshal() error = %v", err)
+				}
+				if got.TypeURL != tc.wantTypeURL {
+					t.Fatalf("Unmarshal() TypeURL = %q, want %q", got.TypeURL, tc.wantTypeURL)
+				}
+				if diff := cmp.Diff(tc.wantValue, got.Value); diff != "" {
+					t.Fatalf("Unmarshal() Value mismatch (+got,-want):\n%s", diff)
+				}
+				return
+			}
+			gotJSON, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			if string(gotJSON) != tc.wantJSON {
+				t.Fatalf("Marshal() = %s, want %s", gotJSON, tc.wantJSON)
+			}
+			// Verify immutability
+			if _, exists := tc.input.Value["@type"]; exists {
+				t.Fatalf("Marshal() mutated original Value map with @type key")
+			}
+			var got Typed
+			if err := json.Unmarshal(gotJSON, &got); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if got.TypeURL != tc.input.TypeURL {
+				t.Fatalf("Round-trip TypeURL = %q, want %q", got.TypeURL, tc.input.TypeURL)
+			}
+			if diff := cmp.Diff(tc.input.Value, got.Value); diff != "" {
+				t.Fatalf("Round-trip Value mismatch (+got,-want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/errordetails/errordetails_test.go
+++ b/errordetails/errordetails_test.go
@@ -36,31 +36,31 @@ func TestErrorDetailsJSONCodec(t *testing.T) {
 		// Round-trip
 		{
 			name:     "ErrorInfo with data",
-			input:    NewTyped("type.googleapis.com/google.rpc.ErrorInfo", map[string]any{"reason": "TASK_NOT_FOUND", "domain": "a2a-protocol.org"}),
+			input:    NewTyped(ErrorInfoType, map[string]any{"reason": "TASK_NOT_FOUND", "domain": "a2a-protocol.org"}),
 			wantJSON: `{"@type":"type.googleapis.com/google.rpc.ErrorInfo","domain":"a2a-protocol.org","reason":"TASK_NOT_FOUND"}`,
 		},
 		{
 			name:     "Struct with data",
-			input:    NewTyped("type.googleapis.com/google.protobuf.Struct", map[string]any{"foo": "bar"}),
+			input:    NewTyped(StructType, map[string]any{"foo": "bar"}),
 			wantJSON: `{"@type":"type.googleapis.com/google.protobuf.Struct","foo":"bar"}`,
 		},
 		{
 			name:     "empty value",
-			input:    NewTyped("type.googleapis.com/google.rpc.ErrorInfo", map[string]any{}),
+			input:    NewTyped(ErrorInfoType, map[string]any{}),
 			wantJSON: `{"@type":"type.googleapis.com/google.rpc.ErrorInfo"}`,
 		},
 		{
 			name:          "missing @type defaults to Struct",
 			unmarshalOnly: true,
 			inputJSON:     `{"foo":"bar"}`,
-			wantTypeURL:   "google.protobuf.Struct",
+			wantTypeURL:   StructType,
 			wantValue:     map[string]any{"foo": "bar"},
 		},
 		{
 			name:          "non-string @type defaults to Struct",
 			unmarshalOnly: true,
 			inputJSON:     `{"@type":123,"foo":"bar"}`,
-			wantTypeURL:   "google.protobuf.Struct",
+			wantTypeURL:   StructType,
 			wantValue:     map[string]any{"@type": float64(123), "foo": "bar"},
 		},
 	}

--- a/internal/grpcutil/errors.go
+++ b/internal/grpcutil/errors.go
@@ -21,6 +21,7 @@ import (
 	"maps"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/errordetails"
 	"github.com/a2aproject/a2a-go/v2/log"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
@@ -30,34 +31,33 @@ import (
 )
 
 var errorMappings = []struct {
-	code   codes.Code
-	err    error
-	reason string
+	code codes.Code
+	err  error
 }{
 	// Primary mappings (used for FromGRPCError as the first match is chosen)
-	{codes.NotFound, a2a.ErrTaskNotFound, "TASK_NOT_FOUND"},
-	{codes.FailedPrecondition, a2a.ErrTaskNotCancelable, "TASK_NOT_CANCELABLE"},
-	{codes.Unimplemented, a2a.ErrUnsupportedOperation, "UNSUPPORTED_OPERATION"},
-	{codes.InvalidArgument, a2a.ErrInvalidParams, "INVALID_PARAMS"},
-	{codes.Internal, a2a.ErrInternalError, "INTERNAL_ERROR"},
-	{codes.Unauthenticated, a2a.ErrUnauthenticated, "UNAUTHENTICATED"},
-	{codes.PermissionDenied, a2a.ErrUnauthorized, "UNAUTHORIZED"},
-	{codes.Canceled, context.Canceled, "INTERNAL_ERROR"},
-	{codes.DeadlineExceeded, context.DeadlineExceeded, "INTERNAL_ERROR"},
+	{codes.NotFound, a2a.ErrTaskNotFound},
+	{codes.FailedPrecondition, a2a.ErrTaskNotCancelable},
+	{codes.FailedPrecondition, a2a.ErrUnsupportedOperation},
+	{codes.InvalidArgument, a2a.ErrInvalidParams},
+	{codes.Internal, a2a.ErrInternalError},
+	{codes.Unauthenticated, a2a.ErrUnauthenticated},
+	{codes.PermissionDenied, a2a.ErrUnauthorized},
+	{codes.Canceled, context.Canceled},
+	{codes.DeadlineExceeded, context.DeadlineExceeded},
 
 	// Secondary mappings (only used for ToGRPCError)
-	{codes.FailedPrecondition, a2a.ErrExtendedCardNotConfigured, "EXTENDED_AGENT_CARD_NOT_CONFIGURED"},
-	{codes.Unimplemented, a2a.ErrPushNotificationNotSupported, "PUSH_NOTIFICATION_NOT_SUPPORTED"},
-	{codes.Unimplemented, a2a.ErrMethodNotFound, "METHOD_NOT_FOUND"},
-	{codes.InvalidArgument, a2a.ErrUnsupportedContentType, "UNSUPPORTED_CONTENT_TYPE"},
-	{codes.InvalidArgument, a2a.ErrInvalidRequest, "INVALID_REQUEST"},
-	{codes.Internal, a2a.ErrInvalidAgentResponse, "INVALID_AGENT_RESPONSE"},
+	{codes.FailedPrecondition, a2a.ErrExtendedCardNotConfigured},
+	{codes.FailedPrecondition, a2a.ErrPushNotificationNotSupported},
+	{codes.Unimplemented, a2a.ErrMethodNotFound},
+	{codes.InvalidArgument, a2a.ErrUnsupportedContentType},
+	{codes.InvalidArgument, a2a.ErrInvalidRequest},
+	{codes.Internal, a2a.ErrInvalidAgentResponse},
 
 	// Additional mappings from a2a/errors.go
-	{codes.FailedPrecondition, a2a.ErrExtensionSupportRequired, "EXTENSION_SUPPORT_REQUIRED"},
-	{codes.Unimplemented, a2a.ErrVersionNotSupported, "VERSION_NOT_SUPPORTED"},
-	{codes.InvalidArgument, a2a.ErrParseError, "PARSE_ERROR"},
-	{codes.Internal, a2a.ErrServerError, "SERVER_ERROR"},
+	{codes.FailedPrecondition, a2a.ErrExtensionSupportRequired},
+	{codes.FailedPrecondition, a2a.ErrVersionNotSupported},
+	{codes.InvalidArgument, a2a.ErrParseError},
+	{codes.Internal, a2a.ErrServerError},
 }
 
 // ToGRPCError translates a2a errors into gRPC status errors.
@@ -76,40 +76,50 @@ func ToGRPCError(err error) error {
 	for _, mapping := range errorMappings {
 		if errors.Is(err, mapping.err) {
 			code = mapping.code
-			reason = mapping.reason
+			if r, ok := a2a.ErrorReason(mapping.err); ok {
+				reason = r
+			}
 			break
 		}
 	}
 
 	st := status.New(code, err.Error())
-
-	additionalMeta := map[string]any{}
-	errInfoMeta := map[string]string{}
+	var errInfoMeta map[string]string
 	var a2aErr *a2a.Error
-	if errors.As(err, &a2aErr) && len(a2aErr.Details) > 0 {
-		for k, v := range a2aErr.Details {
-			if s, ok := v.(string); ok {
-				errInfoMeta[k] = s
+	var messages []protoadapt.MessageV1
+
+	if errors.As(err, &a2aErr) {
+		if len(a2aErr.Details) > 0 {
+			s, err := structpb.NewStruct(a2aErr.Details)
+			if err == nil {
+				messages = append(messages, s)
 			} else {
-				additionalMeta[k] = v
+				log.Warn(context.Background(), "failed to convert error meta to proto", "error", err, "meta", a2aErr.Details)
+			}
+		}
+		for _, d := range a2aErr.TypedDetails {
+			if d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
+				if m, ok := d.Value["metadata"].(map[string]string); ok {
+					errInfoMeta = m
+				} else {
+					log.Warn(context.Background(), "failed to convert error meta to proto", "error", err, "meta", d.Value)
+				}
+			} else {
+				s, err := structpb.NewStruct(d.Value)
+				if err != nil {
+					log.Warn(context.Background(), "failed to convert error meta to proto", "error", err, "meta", d.Value)
+					continue
+				}
+				messages = append(messages, s)
 			}
 		}
 	}
 
-	errInfo := &errdetails.ErrorInfo{Reason: reason, Domain: "a2a-protocol.org"}
+	errInfo := &errdetails.ErrorInfo{Reason: reason, Domain: a2a.PROTOCOL_DOMAIN}
 	if len(errInfoMeta) > 0 {
 		errInfo.Metadata = errInfoMeta
 	}
-
-	var messages = []protoadapt.MessageV1{errInfo}
-	if len(additionalMeta) > 0 {
-		s, err := structpb.NewStruct(additionalMeta)
-		if err == nil {
-			messages = append(messages, s)
-		} else {
-			log.Warn(context.Background(), "failed to convert error meta to proto", "error", err, "meta", additionalMeta)
-		}
-	}
+	messages = append(messages, errInfo)
 
 	withDetails, err := st.WithDetails(messages...)
 	if err != nil {
@@ -130,24 +140,31 @@ func FromGRPCError(err error) error {
 	}
 
 	var reason string
-
+	var typedDetails []*errordetails.Typed
+	errInfoMeta := make(map[string]string)
 	details := make(map[string]any)
+	firstStruct := true
+
 	for _, d := range s.Details() {
 		switch v := d.(type) {
 		case *errdetails.ErrorInfo:
 			reason = v.Reason
-			for k, val := range v.Metadata {
-				details[k] = val
-			}
+			maps.Copy(errInfoMeta, v.Metadata)
 		case *structpb.Struct:
-			maps.Copy(details, v.AsMap())
+			// Add the first struct to Err.Details.
+			if firstStruct {
+				maps.Copy(details, v.AsMap())
+				firstStruct = false
+			}
+			// Add every struct including the first one to Err.TypedDetails.
+			typedDetails = append(typedDetails, errordetails.NewTyped("google.protobuf.Struct", v.AsMap()))
 		}
 	}
 
 	baseErr := a2a.ErrInternalError
 	if reason != "" {
 		for _, mapping := range errorMappings {
-			if mapping.reason == reason && s.Code() == mapping.code {
+			if r, ok := a2a.ErrorReason(mapping.err); ok && r == reason && s.Code() == mapping.code {
 				baseErr = mapping.err
 				break
 			}
@@ -162,8 +179,13 @@ func FromGRPCError(err error) error {
 	}
 
 	errOut := a2a.NewError(baseErr, s.Message())
+	if len(errInfoMeta) > 0 {
+		errOut = errOut.WithErrorInfoMeta(errInfoMeta)
+	}
 	if len(details) > 0 {
 		errOut = errOut.WithDetails(details)
 	}
+	errOut.TypedDetails = append(errOut.TypedDetails, typedDetails...)
+
 	return errOut
 }

--- a/internal/grpcutil/errors.go
+++ b/internal/grpcutil/errors.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
+	"github.com/a2aproject/a2a-go/v2/internal/utils"
 	"github.com/a2aproject/a2a-go/v2/log"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
@@ -76,9 +77,7 @@ func ToGRPCError(err error) error {
 	for _, mapping := range errorMappings {
 		if errors.Is(err, mapping.err) {
 			code = mapping.code
-			if r, ok := a2a.ErrorReason(mapping.err); ok {
-				reason = r
-			}
+			reason = a2a.ErrorReason(mapping.err)
 			break
 		}
 	}
@@ -98,11 +97,11 @@ func ToGRPCError(err error) error {
 			}
 		}
 		for _, d := range a2aErr.TypedDetails {
-			if d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
-				if m, ok := d.Value["metadata"].(map[string]string); ok {
-					errInfoMeta = m
-				} else {
-					log.Warn(context.Background(), "failed to convert error meta to proto", "error", err, "meta", d.Value)
+			if d.TypeURL == errordetails.ErrorInfoType {
+				if rawMeta, ok := d.Value["metadata"]; ok {
+					if m, ok := utils.ToStringMap(rawMeta); ok {
+						errInfoMeta = m
+					}
 				}
 			} else {
 				s, err := structpb.NewStruct(d.Value)
@@ -115,7 +114,7 @@ func ToGRPCError(err error) error {
 		}
 	}
 
-	errInfo := &errdetails.ErrorInfo{Reason: reason, Domain: a2a.PROTOCOL_DOMAIN}
+	errInfo := &errdetails.ErrorInfo{Reason: reason, Domain: a2a.ProtocolDomain}
 	if len(errInfoMeta) > 0 {
 		errInfo.Metadata = errInfoMeta
 	}
@@ -157,14 +156,14 @@ func FromGRPCError(err error) error {
 				firstStruct = false
 			}
 			// Add every struct including the first one to Err.TypedDetails.
-			typedDetails = append(typedDetails, errordetails.NewTyped("google.protobuf.Struct", v.AsMap()))
+			typedDetails = append(typedDetails, errordetails.NewFromStruct(v.AsMap()))
 		}
 	}
 
 	baseErr := a2a.ErrInternalError
 	if reason != "" {
 		for _, mapping := range errorMappings {
-			if r, ok := a2a.ErrorReason(mapping.err); ok && r == reason && s.Code() == mapping.code {
+			if a2a.ErrorReason(mapping.err) == reason && s.Code() == mapping.code {
 				baseErr = mapping.err
 				break
 			}

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -106,7 +106,7 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 				"str": "hello",
 			}),
 			inputTypedDetails: []*errordetails.Typed{
-				errordetails.NewTyped("google.protobuf.Struct", map[string]any{
+				errordetails.NewFromStruct(map[string]any{
 					"extra": "should not leak into details",
 				}),
 			},
@@ -278,8 +278,8 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 					if v.Reason != tc.wantReason {
 						t.Errorf("ErrorInfo.Reason = %q, want %q", v.Reason, tc.wantReason)
 					}
-					if v.Domain != a2a.PROTOCOL_DOMAIN {
-						t.Errorf("ErrorInfo.Domain = %q, want %q", v.Domain, a2a.PROTOCOL_DOMAIN)
+					if v.Domain != a2a.ProtocolDomain {
+						t.Errorf("ErrorInfo.Domain = %q, want %q", v.Domain, a2a.ProtocolDomain)
 					}
 					if diff := cmp.Diff(tc.wantMeta, v.Metadata); diff != "" {
 						t.Errorf("ErrorInfo.Metadata mismatch (+got,-want):\n%s", diff)
@@ -302,8 +302,8 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 				t.Fatalf("Round-trip details mismatch (+got,-want):\n%s", diff)
 			}
 			errInfo := a2aBack.ErrorInfo()
-			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.PROTOCOL_DOMAIN {
-				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.PROTOCOL_DOMAIN)
+			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.ProtocolDomain {
+				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.ProtocolDomain)
 			}
 			if reason, ok := errInfo.Value["reason"].(string); !ok || reason != tc.wantReason {
 				t.Fatalf("Round-trip ErrorInfo reason = %q, want %q", reason, tc.wantReason)
@@ -322,7 +322,7 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 				foundDetailsInTypedDetails := false
 				structCount := 0
 				for _, td := range a2aBack.TypedDetails {
-					if td.TypeURL != "google.protobuf.Struct" {
+					if td.TypeURL != errordetails.StructType {
 						continue
 					}
 					structCount++
@@ -336,7 +336,7 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 				wantStructCount := 1
 				if tc.inputTypedDetails != nil {
 					for _, td := range tc.inputTypedDetails {
-						if td.TypeURL == "google.protobuf.Struct" {
+						if td.TypeURL == errordetails.StructType {
 							wantStructCount++
 						}
 					}

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -35,14 +35,8 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 		name              string
 		inputError        *a2a.Error
 		inputTypedDetails []*errordetails.Typed
-		// midpoint (gRPC status) assertions
-		wantCode   codes.Code
-		wantReason string
-		wantMeta   map[string]string
-		// end point (a2a error) assertions
-		wantBaseErr error
-		wantMessage string
-		wantDetails map[string]any
+		wantCode          codes.Code
+		want              *a2a.Error
 	}{
 		{
 			name: "TaskNotFound with details and metadata",
@@ -51,15 +45,21 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 			}).WithDetails(map[string]any{
 				"num": float64(123),
 			}),
-			wantCode:   codes.NotFound,
-			wantReason: "TASK_NOT_FOUND",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrTaskNotFound,
-			wantMessage: "task not found",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			wantCode: codes.NotFound,
+			want: &a2a.Error{
+				Err:     a2a.ErrTaskNotFound,
+				Message: "task not found",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("TASK_NOT_FOUND", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -69,15 +69,21 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 			}).WithDetails(map[string]any{
 				"num": float64(123),
 			}),
-			wantCode:   codes.InvalidArgument,
-			wantReason: "PARSE_ERROR",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrParseError,
-			wantMessage: "wrapped parse error",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			wantCode: codes.InvalidArgument,
+			want: &a2a.Error{
+				Err:     a2a.ErrParseError,
+				Message: "wrapped parse error",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("PARSE_ERROR", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -87,15 +93,21 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 			}).WithDetails(map[string]any{
 				"str": "hello",
 			}),
-			wantCode:   codes.InvalidArgument,
-			wantReason: "INVALID_PARAMS",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrInvalidParams,
-			wantMessage: "invalid params",
-			wantDetails: map[string]any{
-				"str": "hello",
+			wantCode: codes.InvalidArgument,
+			want: &a2a.Error{
+				Err:     a2a.ErrInvalidParams,
+				Message: "invalid params",
+				Details: map[string]any{
+					"str": "hello",
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("INVALID_PARAMS", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"str": "hello",
+					}),
+				},
 			},
 		},
 		{
@@ -110,36 +122,48 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 					"extra": "should not leak into details",
 				}),
 			},
-			wantCode:   codes.FailedPrecondition,
-			wantReason: "EXTENSION_SUPPORT_REQUIRED",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrExtensionSupportRequired,
-			wantMessage: "extension support required",
-			wantDetails: map[string]any{
-				"str": "hello",
+			wantCode: codes.FailedPrecondition,
+			want: &a2a.Error{
+				Err:     a2a.ErrExtensionSupportRequired,
+				Message: "extension support required",
+				Details: map[string]any{
+					"str": "hello",
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("EXTENSION_SUPPORT_REQUIRED", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"str": "hello",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"extra": "should not leak into details",
+					}),
+				},
 			},
 		},
 		{
-			name:        "InvalidRequest without extra details",
-			inputError:  a2a.NewError(a2a.ErrInvalidRequest, "invalid request"),
-			wantCode:    codes.InvalidArgument,
-			wantReason:  "INVALID_REQUEST",
-			wantBaseErr: a2a.ErrInvalidRequest,
-			wantMessage: "invalid request",
+			name:       "InvalidRequest without extra details",
+			inputError: a2a.NewError(a2a.ErrInvalidRequest, "invalid request"),
+			wantCode:   codes.InvalidArgument,
 		},
 		{
 			name: "MethodNotFound with details only",
 			inputError: a2a.NewError(a2a.ErrMethodNotFound, "method not found").WithDetails(map[string]any{
 				"str": "hello",
 			}),
-			wantCode:    codes.Unimplemented,
-			wantReason:  "METHOD_NOT_FOUND",
-			wantBaseErr: a2a.ErrMethodNotFound,
-			wantMessage: "method not found",
-			wantDetails: map[string]any{
-				"str": "hello",
+			wantCode: codes.Unimplemented,
+			want: &a2a.Error{
+				Err:     a2a.ErrMethodNotFound,
+				Message: "method not found",
+				Details: map[string]any{
+					"str": "hello",
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewFromStruct(map[string]any{
+						"str": "hello",
+					}),
+				},
 			},
 		},
 		{
@@ -147,13 +171,16 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 			inputError: a2a.NewError(a2a.ErrServerError, "server error").WithErrorInfoMeta(map[string]string{
 				"foo": "bar",
 			}),
-			wantCode:   codes.Internal,
-			wantReason: "SERVER_ERROR",
-			wantMeta: map[string]string{
-				"foo": "bar",
+			wantCode: codes.Internal,
+			want: &a2a.Error{
+				Err:     a2a.ErrServerError,
+				Message: "server error",
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("SERVER_ERROR", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+				},
 			},
-			wantBaseErr: a2a.ErrServerError,
-			wantMessage: "server error",
 		},
 		{
 			name: "TaskNotCancelable ErrorInfo override",
@@ -162,93 +189,67 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 			}).WithErrorInfoMeta(map[string]string{
 				"new_key": "new_value",
 			}),
-			wantCode:    codes.FailedPrecondition,
-			wantReason:  "TASK_NOT_CANCELABLE",
-			wantBaseErr: a2a.ErrTaskNotCancelable,
-			wantMessage: "task not cancelable",
-			wantMeta: map[string]string{
-				"new_key": "new_value",
+			wantCode: codes.FailedPrecondition,
+			want: &a2a.Error{
+				Err:     a2a.ErrTaskNotCancelable,
+				Message: "task not cancelable",
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("TASK_NOT_CANCELABLE", a2a.ProtocolDomain, map[string]string{
+						"new_key": "new_value",
+					}),
+				},
 			},
 		},
 		{
-			name:        "PushNotificationNotSupported",
-			inputError:  a2a.NewError(a2a.ErrPushNotificationNotSupported, "push notification not supported"),
-			wantCode:    codes.FailedPrecondition,
-			wantReason:  "PUSH_NOTIFICATION_NOT_SUPPORTED",
-			wantBaseErr: a2a.ErrPushNotificationNotSupported,
-			wantMessage: "push notification not supported",
+			name:       "PushNotificationNotSupported",
+			inputError: a2a.NewError(a2a.ErrPushNotificationNotSupported, "push notification not supported"),
+			wantCode:   codes.FailedPrecondition,
 		},
 		{
-			name:        "UnsupportedOperation",
-			inputError:  a2a.NewError(a2a.ErrUnsupportedOperation, "unsupported operation"),
-			wantCode:    codes.FailedPrecondition,
-			wantReason:  "UNSUPPORTED_OPERATION",
-			wantBaseErr: a2a.ErrUnsupportedOperation,
-			wantMessage: "unsupported operation",
+			name:       "UnsupportedOperation",
+			inputError: a2a.NewError(a2a.ErrUnsupportedOperation, "unsupported operation"),
+			wantCode:   codes.FailedPrecondition,
 		},
 		{
-			name:        "UnsupportedContentType",
-			inputError:  a2a.NewError(a2a.ErrUnsupportedContentType, "unsupported content type"),
-			wantCode:    codes.InvalidArgument,
-			wantReason:  "CONTENT_TYPE_NOT_SUPPORTED",
-			wantBaseErr: a2a.ErrUnsupportedContentType,
-			wantMessage: "unsupported content type",
+			name:       "UnsupportedContentType",
+			inputError: a2a.NewError(a2a.ErrUnsupportedContentType, "unsupported content type"),
+			wantCode:   codes.InvalidArgument,
 		},
 		{
-			name:        "InvalidAgentResponse",
-			inputError:  a2a.NewError(a2a.ErrInvalidAgentResponse, "invalid agent response"),
-			wantCode:    codes.Internal,
-			wantReason:  "INVALID_AGENT_RESPONSE",
-			wantBaseErr: a2a.ErrInvalidAgentResponse,
-			wantMessage: "invalid agent response",
+			name:       "InvalidAgentResponse",
+			inputError: a2a.NewError(a2a.ErrInvalidAgentResponse, "invalid agent response"),
+			wantCode:   codes.Internal,
 		},
 		{
-			name:        "ExtendedCardNotConfigured",
-			inputError:  a2a.NewError(a2a.ErrExtendedCardNotConfigured, "extended card not configured"),
-			wantCode:    codes.FailedPrecondition,
-			wantReason:  "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
-			wantBaseErr: a2a.ErrExtendedCardNotConfigured,
-			wantMessage: "extended card not configured",
+			name:       "ExtendedCardNotConfigured",
+			inputError: a2a.NewError(a2a.ErrExtendedCardNotConfigured, "extended card not configured"),
+			wantCode:   codes.FailedPrecondition,
 		},
 		{
-			name:        "VersionNotSupported",
-			inputError:  a2a.NewError(a2a.ErrVersionNotSupported, "version not supported"),
-			wantCode:    codes.FailedPrecondition,
-			wantReason:  "VERSION_NOT_SUPPORTED",
-			wantBaseErr: a2a.ErrVersionNotSupported,
-			wantMessage: "version not supported",
+			name:       "VersionNotSupported",
+			inputError: a2a.NewError(a2a.ErrVersionNotSupported, "version not supported"),
+			wantCode:   codes.FailedPrecondition,
 		},
 		{
-			name:        "Unauthenticated",
-			inputError:  a2a.NewError(a2a.ErrUnauthenticated, "unauthenticated"),
-			wantCode:    codes.Unauthenticated,
-			wantReason:  "UNAUTHENTICATED",
-			wantBaseErr: a2a.ErrUnauthenticated,
-			wantMessage: "unauthenticated",
+			name:       "Unauthenticated",
+			inputError: a2a.NewError(a2a.ErrUnauthenticated, "unauthenticated"),
+			wantCode:   codes.Unauthenticated,
 		},
 		{
-			name:        "Unauthorized",
-			inputError:  a2a.NewError(a2a.ErrUnauthorized, "unauthorized"),
-			wantCode:    codes.PermissionDenied,
-			wantReason:  "UNAUTHORIZED",
-			wantBaseErr: a2a.ErrUnauthorized,
-			wantMessage: "unauthorized",
+			name:       "Unauthorized",
+			inputError: a2a.NewError(a2a.ErrUnauthorized, "unauthorized"),
+			wantCode:   codes.PermissionDenied,
 		},
 		{
-			name:        "InternalError",
-			inputError:  a2a.NewError(a2a.ErrInternalError, "internal error"),
-			wantCode:    codes.Internal,
-			wantReason:  "INTERNAL_ERROR",
-			wantBaseErr: a2a.ErrInternalError,
-			wantMessage: "internal error",
+			name:       "InternalError",
+			inputError: a2a.NewError(a2a.ErrInternalError, "internal error"),
+			wantCode:   codes.Internal,
 		},
 		{
-			name:        "Unknown error roundtrips to Internal",
-			inputError:  a2a.NewError(errors.New("unknown error"), "unknown error"),
-			wantCode:    codes.Internal,
-			wantReason:  "INTERNAL_ERROR",
-			wantBaseErr: a2a.ErrInternalError,
-			wantMessage: "unknown error",
+			name:       "Unknown error roundtrips to Internal",
+			inputError: a2a.NewError(errors.New("unknown error"), "unknown error"),
+			wantCode:   codes.Internal,
+			want:       a2a.NewError(a2a.ErrInternalError, "unknown error"),
 		},
 	}
 
@@ -267,83 +268,23 @@ func TestGRPCErrorRoundTrip(t *testing.T) {
 			if st.Code() != tc.wantCode {
 				t.Fatalf("ToGRPCError() code = %v, want %v", st.Code(), tc.wantCode)
 			}
-			if st.Message() != tc.wantMessage {
-				t.Fatalf("ToGRPCError() message = %q, want %q", st.Message(), tc.wantMessage)
-			}
-
-			var foundErrorInfo bool
-			for _, d := range st.Details() {
-				if v, ok := d.(*errdetails.ErrorInfo); ok {
-					foundErrorInfo = true
-					if v.Reason != tc.wantReason {
-						t.Errorf("ErrorInfo.Reason = %q, want %q", v.Reason, tc.wantReason)
-					}
-					if v.Domain != a2a.ProtocolDomain {
-						t.Errorf("ErrorInfo.Domain = %q, want %q", v.Domain, a2a.ProtocolDomain)
-					}
-					if diff := cmp.Diff(tc.wantMeta, v.Metadata); diff != "" {
-						t.Errorf("ErrorInfo.Metadata mismatch (+got,-want):\n%s", diff)
-					}
-				}
-			}
-			if !foundErrorInfo {
-				t.Errorf("ErrorInfo not found in details")
-			}
 
 			back := FromGRPCError(got)
 			var a2aBack *a2a.Error
 			if !errors.As(back, &a2aBack) {
 				t.Fatalf("Expected *a2a.Error")
 			}
-			if !errors.Is(a2aBack.Err, tc.wantBaseErr) {
-				t.Fatalf("Round-trip error = %v, want %v", a2aBack.Err, tc.wantBaseErr)
+			want := tc.want
+			if want == nil {
+				want = tc.inputError
 			}
-			if diff := cmp.Diff(tc.wantDetails, a2aBack.Details); diff != "" {
-				t.Fatalf("Round-trip details mismatch (+got,-want):\n%s", diff)
-			}
-			errInfo := a2aBack.ErrorInfo()
-			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.ProtocolDomain {
-				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.ProtocolDomain)
-			}
-			if reason, ok := errInfo.Value["reason"].(string); !ok || reason != tc.wantReason {
-				t.Fatalf("Round-trip ErrorInfo reason = %q, want %q", reason, tc.wantReason)
-			}
-			if tc.wantMeta != nil {
-				metadata, ok := errInfo.Value["metadata"].(map[string]string)
-				if !ok {
-					t.Fatalf("Round-trip ErrorInfo metadata not found or wrong type: %v", errInfo.Value["metadata"])
-				}
-				if diff := cmp.Diff(tc.wantMeta, metadata); diff != "" {
-					t.Fatalf("Round-trip ErrorInfo metadata mismatch (+got,-want):\n%s", diff)
-				}
-			}
-
-			if tc.wantDetails != nil {
-				foundDetailsInTypedDetails := false
-				structCount := 0
-				for _, td := range a2aBack.TypedDetails {
-					if td.TypeURL != errordetails.StructType {
-						continue
-					}
-					structCount++
-					if cmp.Equal(tc.wantDetails, td.Value) {
-						foundDetailsInTypedDetails = true
-					}
-				}
-				if !foundDetailsInTypedDetails {
-					t.Fatalf("Round-trip TypedDetails missing struct with expected details")
-				}
-				wantStructCount := 1
-				if tc.inputTypedDetails != nil {
-					for _, td := range tc.inputTypedDetails {
-						if td.TypeURL == errordetails.StructType {
-							wantStructCount++
-						}
-					}
-				}
-				if structCount != wantStructCount {
-					t.Fatalf("Round-trip TypedDetails struct count = %d, want %d", structCount, wantStructCount)
-				}
+			if diff := cmp.Diff(*want, *a2aBack,
+				cmpopts.EquateErrors(),
+				cmpopts.IgnoreMapEntries(func(k string, _ string) bool {
+					return k == "timestamp"
+				}),
+			); diff != "" {
+				t.Fatalf("Round-trip error mismatch (+got, -want):\n%s", diff)
 			}
 		})
 	}

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -21,14 +21,337 @@ import (
 	"testing"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/errordetails"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestToGRPCError(t *testing.T) {
+func TestGRPCErrorRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		inputError        *a2a.Error
+		inputTypedDetails []*errordetails.Typed
+		// midpoint (gRPC status) assertions
+		wantCode   codes.Code
+		wantReason string
+		wantMeta   map[string]string
+		// end point (a2a error) assertions
+		wantBaseErr error
+		wantMessage string
+		wantDetails map[string]any
+	}{
+		{
+			name: "TaskNotFound with details and metadata",
+			inputError: a2a.NewError(a2a.ErrTaskNotFound, "task not found").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantCode:   codes.NotFound,
+			wantReason: "TASK_NOT_FOUND",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrTaskNotFound,
+			wantMessage: "task not found",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "Wrapped ParseError with details and metadata",
+			inputError: a2a.NewError(fmt.Errorf("wrapped error: %w", a2a.ErrParseError), "wrapped parse error").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantCode:   codes.InvalidArgument,
+			wantReason: "PARSE_ERROR",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrParseError,
+			wantMessage: "wrapped parse error",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "InvalidParams with details and metadata",
+			inputError: a2a.NewError(a2a.ErrInvalidParams, "invalid params").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"str": "hello",
+			}),
+			wantCode:   codes.InvalidArgument,
+			wantReason: "INVALID_PARAMS",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrInvalidParams,
+			wantMessage: "invalid params",
+			wantDetails: map[string]any{
+				"str": "hello",
+			},
+		},
+		{
+			name: "ExtensionSupportRequired with details, typed details and metadata",
+			inputError: a2a.NewError(a2a.ErrExtensionSupportRequired, "extension support required").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"str": "hello",
+			}),
+			inputTypedDetails: []*errordetails.Typed{
+				errordetails.NewTyped("google.protobuf.Struct", map[string]any{
+					"extra": "should not leak into details",
+				}),
+			},
+			wantCode:   codes.FailedPrecondition,
+			wantReason: "EXTENSION_SUPPORT_REQUIRED",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrExtensionSupportRequired,
+			wantMessage: "extension support required",
+			wantDetails: map[string]any{
+				"str": "hello",
+			},
+		},
+		{
+			name:        "InvalidRequest without extra details",
+			inputError:  a2a.NewError(a2a.ErrInvalidRequest, "invalid request"),
+			wantCode:    codes.InvalidArgument,
+			wantReason:  "INVALID_REQUEST",
+			wantBaseErr: a2a.ErrInvalidRequest,
+			wantMessage: "invalid request",
+		},
+		{
+			name: "MethodNotFound with details only",
+			inputError: a2a.NewError(a2a.ErrMethodNotFound, "method not found").WithDetails(map[string]any{
+				"str": "hello",
+			}),
+			wantCode:    codes.Unimplemented,
+			wantReason:  "METHOD_NOT_FOUND",
+			wantBaseErr: a2a.ErrMethodNotFound,
+			wantMessage: "method not found",
+			wantDetails: map[string]any{
+				"str": "hello",
+			},
+		},
+		{
+			name: "ServerError with ErrorInfo only",
+			inputError: a2a.NewError(a2a.ErrServerError, "server error").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}),
+			wantCode:   codes.Internal,
+			wantReason: "SERVER_ERROR",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrServerError,
+			wantMessage: "server error",
+		},
+		{
+			name: "TaskNotCancelable ErrorInfo override",
+			inputError: a2a.NewError(a2a.ErrTaskNotCancelable, "task not cancelable").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithErrorInfoMeta(map[string]string{
+				"new_key": "new_value",
+			}),
+			wantCode:    codes.FailedPrecondition,
+			wantReason:  "TASK_NOT_CANCELABLE",
+			wantBaseErr: a2a.ErrTaskNotCancelable,
+			wantMessage: "task not cancelable",
+			wantMeta: map[string]string{
+				"new_key": "new_value",
+			},
+		},
+		{
+			name:        "PushNotificationNotSupported",
+			inputError:  a2a.NewError(a2a.ErrPushNotificationNotSupported, "push notification not supported"),
+			wantCode:    codes.FailedPrecondition,
+			wantReason:  "PUSH_NOTIFICATION_NOT_SUPPORTED",
+			wantBaseErr: a2a.ErrPushNotificationNotSupported,
+			wantMessage: "push notification not supported",
+		},
+		{
+			name:        "UnsupportedOperation",
+			inputError:  a2a.NewError(a2a.ErrUnsupportedOperation, "unsupported operation"),
+			wantCode:    codes.FailedPrecondition,
+			wantReason:  "UNSUPPORTED_OPERATION",
+			wantBaseErr: a2a.ErrUnsupportedOperation,
+			wantMessage: "unsupported operation",
+		},
+		{
+			name:        "UnsupportedContentType",
+			inputError:  a2a.NewError(a2a.ErrUnsupportedContentType, "unsupported content type"),
+			wantCode:    codes.InvalidArgument,
+			wantReason:  "CONTENT_TYPE_NOT_SUPPORTED",
+			wantBaseErr: a2a.ErrUnsupportedContentType,
+			wantMessage: "unsupported content type",
+		},
+		{
+			name:        "InvalidAgentResponse",
+			inputError:  a2a.NewError(a2a.ErrInvalidAgentResponse, "invalid agent response"),
+			wantCode:    codes.Internal,
+			wantReason:  "INVALID_AGENT_RESPONSE",
+			wantBaseErr: a2a.ErrInvalidAgentResponse,
+			wantMessage: "invalid agent response",
+		},
+		{
+			name:        "ExtendedCardNotConfigured",
+			inputError:  a2a.NewError(a2a.ErrExtendedCardNotConfigured, "extended card not configured"),
+			wantCode:    codes.FailedPrecondition,
+			wantReason:  "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
+			wantBaseErr: a2a.ErrExtendedCardNotConfigured,
+			wantMessage: "extended card not configured",
+		},
+		{
+			name:        "VersionNotSupported",
+			inputError:  a2a.NewError(a2a.ErrVersionNotSupported, "version not supported"),
+			wantCode:    codes.FailedPrecondition,
+			wantReason:  "VERSION_NOT_SUPPORTED",
+			wantBaseErr: a2a.ErrVersionNotSupported,
+			wantMessage: "version not supported",
+		},
+		{
+			name:        "Unauthenticated",
+			inputError:  a2a.NewError(a2a.ErrUnauthenticated, "unauthenticated"),
+			wantCode:    codes.Unauthenticated,
+			wantReason:  "UNAUTHENTICATED",
+			wantBaseErr: a2a.ErrUnauthenticated,
+			wantMessage: "unauthenticated",
+		},
+		{
+			name:        "Unauthorized",
+			inputError:  a2a.NewError(a2a.ErrUnauthorized, "unauthorized"),
+			wantCode:    codes.PermissionDenied,
+			wantReason:  "UNAUTHORIZED",
+			wantBaseErr: a2a.ErrUnauthorized,
+			wantMessage: "unauthorized",
+		},
+		{
+			name:        "InternalError",
+			inputError:  a2a.NewError(a2a.ErrInternalError, "internal error"),
+			wantCode:    codes.Internal,
+			wantReason:  "INTERNAL_ERROR",
+			wantBaseErr: a2a.ErrInternalError,
+			wantMessage: "internal error",
+		},
+		{
+			name:        "Unknown error roundtrips to Internal",
+			inputError:  a2a.NewError(errors.New("unknown error"), "unknown error"),
+			wantCode:    codes.Internal,
+			wantReason:  "INTERNAL_ERROR",
+			wantBaseErr: a2a.ErrInternalError,
+			wantMessage: "unknown error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.inputTypedDetails != nil {
+				tc.inputError.TypedDetails = append(tc.inputError.TypedDetails, tc.inputTypedDetails...)
+			}
+			got := ToGRPCError(tc.inputError)
+			st, ok := status.FromError(got)
+			if !ok {
+				t.Fatalf("Expected gRPC status error")
+			}
+			if st.Code() != tc.wantCode {
+				t.Fatalf("ToGRPCError() code = %v, want %v", st.Code(), tc.wantCode)
+			}
+			if st.Message() != tc.wantMessage {
+				t.Fatalf("ToGRPCError() message = %q, want %q", st.Message(), tc.wantMessage)
+			}
+
+			var foundErrorInfo bool
+			for _, d := range st.Details() {
+				if v, ok := d.(*errdetails.ErrorInfo); ok {
+					foundErrorInfo = true
+					if v.Reason != tc.wantReason {
+						t.Errorf("ErrorInfo.Reason = %q, want %q", v.Reason, tc.wantReason)
+					}
+					if v.Domain != a2a.PROTOCOL_DOMAIN {
+						t.Errorf("ErrorInfo.Domain = %q, want %q", v.Domain, a2a.PROTOCOL_DOMAIN)
+					}
+					if diff := cmp.Diff(tc.wantMeta, v.Metadata); diff != "" {
+						t.Errorf("ErrorInfo.Metadata mismatch (+got,-want):\n%s", diff)
+					}
+				}
+			}
+			if !foundErrorInfo {
+				t.Errorf("ErrorInfo not found in details")
+			}
+
+			back := FromGRPCError(got)
+			var a2aBack *a2a.Error
+			if !errors.As(back, &a2aBack) {
+				t.Fatalf("Expected *a2a.Error")
+			}
+			if !errors.Is(a2aBack.Err, tc.wantBaseErr) {
+				t.Fatalf("Round-trip error = %v, want %v", a2aBack.Err, tc.wantBaseErr)
+			}
+			if diff := cmp.Diff(tc.wantDetails, a2aBack.Details); diff != "" {
+				t.Fatalf("Round-trip details mismatch (+got,-want):\n%s", diff)
+			}
+			errInfo := a2aBack.ErrorInfo()
+			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.PROTOCOL_DOMAIN {
+				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.PROTOCOL_DOMAIN)
+			}
+			if reason, ok := errInfo.Value["reason"].(string); !ok || reason != tc.wantReason {
+				t.Fatalf("Round-trip ErrorInfo reason = %q, want %q", reason, tc.wantReason)
+			}
+			if tc.wantMeta != nil {
+				metadata, ok := errInfo.Value["metadata"].(map[string]string)
+				if !ok {
+					t.Fatalf("Round-trip ErrorInfo metadata not found or wrong type: %v", errInfo.Value["metadata"])
+				}
+				if diff := cmp.Diff(tc.wantMeta, metadata); diff != "" {
+					t.Fatalf("Round-trip ErrorInfo metadata mismatch (+got,-want):\n%s", diff)
+				}
+			}
+
+			if tc.wantDetails != nil {
+				foundDetailsInTypedDetails := false
+				structCount := 0
+				for _, td := range a2aBack.TypedDetails {
+					if td.TypeURL != "google.protobuf.Struct" {
+						continue
+					}
+					structCount++
+					if cmp.Equal(tc.wantDetails, td.Value) {
+						foundDetailsInTypedDetails = true
+					}
+				}
+				if !foundDetailsInTypedDetails {
+					t.Fatalf("Round-trip TypedDetails missing struct with expected details")
+				}
+				wantStructCount := 1
+				if tc.inputTypedDetails != nil {
+					for _, td := range tc.inputTypedDetails {
+						if td.TypeURL == "google.protobuf.Struct" {
+							wantStructCount++
+						}
+					}
+				}
+				if structCount != wantStructCount {
+					t.Fatalf("Round-trip TypedDetails struct count = %d, want %d", structCount, wantStructCount)
+				}
+			}
+		})
+	}
+}
+
+func TestToGRPCErrorEdgeCases(t *testing.T) {
+	t.Parallel()
+
 	wrappedTaskNotFound := fmt.Errorf("wrapping: %w", a2a.ErrTaskNotFound)
 	unknownError := errors.New("some unknown error")
 	grpcError := status.Error(codes.AlreadyExists, "already there")
@@ -45,7 +368,7 @@ func TestToGRPCError(t *testing.T) {
 			wantNil: true,
 		},
 		{
-			name: "ErrTaskNotFound",
+			name: "plain sentinel error",
 			err:  a2a.ErrTaskNotFound,
 			want: status.Error(codes.NotFound, a2a.ErrTaskNotFound.Error()),
 		},
@@ -53,46 +376,6 @@ func TestToGRPCError(t *testing.T) {
 			name: "wrapped ErrTaskNotFound",
 			err:  wrappedTaskNotFound,
 			want: status.Error(codes.NotFound, wrappedTaskNotFound.Error()),
-		},
-		{
-			name: "ErrTaskNotCancelable",
-			err:  a2a.ErrTaskNotCancelable,
-			want: status.Error(codes.FailedPrecondition, a2a.ErrTaskNotCancelable.Error()),
-		},
-		{
-			name: "ErrPushNotificationNotSupported",
-			err:  a2a.ErrPushNotificationNotSupported,
-			want: status.Error(codes.Unimplemented, a2a.ErrPushNotificationNotSupported.Error()),
-		},
-		{
-			name: "ErrUnsupportedOperation",
-			err:  a2a.ErrUnsupportedOperation,
-			want: status.Error(codes.Unimplemented, a2a.ErrUnsupportedOperation.Error()),
-		},
-		{
-			name: "ErrUnsupportedContentType",
-			err:  a2a.ErrUnsupportedContentType,
-			want: status.Error(codes.InvalidArgument, a2a.ErrUnsupportedContentType.Error()),
-		},
-		{
-			name: "ErrInvalidRequest",
-			err:  a2a.ErrInvalidRequest,
-			want: status.Error(codes.InvalidArgument, a2a.ErrInvalidRequest.Error()),
-		},
-		{
-			name: "ErrInvalidParams",
-			err:  a2a.ErrInvalidParams,
-			want: status.Error(codes.InvalidArgument, a2a.ErrInvalidParams.Error()),
-		},
-		{
-			name: "ErrExtendedCardNotConfigured",
-			err:  a2a.ErrExtendedCardNotConfigured,
-			want: status.Error(codes.FailedPrecondition, a2a.ErrExtendedCardNotConfigured.Error()),
-		},
-		{
-			name: "ErrInvalidAgentResponse",
-			err:  a2a.ErrInvalidAgentResponse,
-			want: status.Error(codes.Internal, a2a.ErrInvalidAgentResponse.Error()),
 		},
 		{
 			name: "context canceled",
@@ -110,11 +393,6 @@ func TestToGRPCError(t *testing.T) {
 			want: status.Error(codes.Internal, unknownError.Error()),
 		},
 		{
-			name: "a2a error unwrapped",
-			err:  a2a.NewError(a2a.ErrInvalidParams, "custom message"),
-			want: status.Error(codes.InvalidArgument, "custom message"),
-		},
-		{
 			name: "structpb conversion failure",
 			err:  a2a.NewError(errors.New("bad details"), "oops").WithDetails(map[string]any{"func": func() {}}),
 			want: status.Error(codes.Internal, "oops"),
@@ -128,6 +406,8 @@ func TestToGRPCError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := ToGRPCError(tt.err)
 			if tt.wantNil {
 				if got != nil {
@@ -145,41 +425,15 @@ func TestToGRPCError(t *testing.T) {
 			if gotSt.Code() != wantSt.Code() {
 				t.Fatalf("ToGRPCError() code = %v, want %v", gotSt.Code(), wantSt.Code())
 			}
-			if len(wantSt.Details()) == 0 {
-				return
-			}
-			if len(gotSt.Details()) != len(wantSt.Details()) {
-				t.Fatalf("ToGRPCError() details len = %d, want %d", len(gotSt.Details()), len(wantSt.Details()))
-			}
-			for i := range gotSt.Details() {
-				gotDetail, ok1 := gotSt.Details()[i].(*structpb.Struct)
-				wantDetail, ok2 := wantSt.Details()[i].(*structpb.Struct)
-				if !ok1 || !ok2 {
-					t.Fatalf("ToGRPCError() details expected structpb.Struct")
-				}
-				if len(gotDetail.Fields) != len(wantDetail.Fields) {
-					t.Errorf("ToGRPCError() details fields len = %d, want %d", len(gotDetail.Fields), len(wantDetail.Fields))
-				}
-				if v, ok := wantDetail.Fields["reason"]; ok {
-					if gotV, ok := gotDetail.Fields["reason"]; !ok || gotV.GetStringValue() != v.GetStringValue() {
-						t.Errorf("ToGRPCError() details field 'reason' mismatch")
-					}
-				}
+			if gotSt.Message() != wantSt.Message() {
+				t.Fatalf("ToGRPCError() message = %q, want %q", gotSt.Message(), wantSt.Message())
 			}
 		})
 	}
 }
 
-func TestFromGRPCError(t *testing.T) {
-	testDetails := map[string]any{"reason": "test"}
-	stDetails, err := structpb.NewStruct(testDetails)
-	if err != nil {
-		t.Fatalf("Failed to create structpb: %v", err)
-	}
-	stWithDetails, err := status.New(codes.NotFound, "not found").WithDetails(stDetails)
-	if err != nil {
-		t.Fatalf("Failed to attach details: %v", err)
-	}
+func TestFromGRPCErrorEdgeCases(t *testing.T) {
+	t.Parallel()
 
 	tests := []struct {
 		name string
@@ -197,34 +451,16 @@ func TestFromGRPCError(t *testing.T) {
 			want: errors.New("simple error"), // Should return as is
 		},
 		{
-			name: "NotFound -> ErrTaskNotFound",
-			err:  status.Error(codes.NotFound, "foo"),
-			want: a2a.NewError(a2a.ErrTaskNotFound, "foo"),
-		},
-		{
 			name: "Unknown code -> ErrInternalError",
 			err:  status.Error(codes.Unknown, "unknown"),
 			want: a2a.NewError(a2a.ErrInternalError, "unknown"),
-		},
-		{
-			name: "Unauthenticated -> ErrUnauthenticated",
-			err:  status.Error(codes.Unauthenticated, "auth failed"),
-			want: a2a.NewError(a2a.ErrUnauthenticated, "auth failed"),
-		},
-		{
-			name: "PermissionDenied -> ErrUnauthorized",
-			err:  status.Error(codes.PermissionDenied, "forbidden"),
-			want: a2a.NewError(a2a.ErrUnauthorized, "forbidden"),
-		},
-		{
-			name: "with details",
-			err:  stWithDetails.Err(),
-			want: a2a.NewError(a2a.ErrTaskNotFound, "not found").WithDetails(testDetails),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := FromGRPCError(tc.err)
 			if tc.want == nil {
 				if got != nil {
@@ -257,119 +493,6 @@ func TestFromGRPCError(t *testing.T) {
 			if !errors.Is(gotBaseErr, wantErr) {
 				t.Errorf("FromGRPCError() base error = %v, want %v", gotBaseErr, wantErr)
 			}
-
-			var wantDetails map[string]any
-			var wantA2AErr *a2a.Error
-			if errors.As(tc.want, &wantA2AErr) {
-				wantDetails = wantA2AErr.Details
-			}
-
-			if wantDetails != nil {
-				var a2aErr *a2a.Error
-				if !errors.As(got, &a2aErr) {
-					t.Fatalf("got error type %T, want *a2a.Error", got)
-				}
-				if diff := cmp.Diff(wantDetails, a2aErr.Details); diff != "" {
-					t.Fatalf("got wrong details (+got,-want) diff = %s", diff)
-				}
-			}
 		})
-	}
-}
-
-func TestFromGRPCError_RoundTrip(t *testing.T) {
-	t.Parallel()
-
-	errsToTest := []error{
-		a2a.ErrTaskNotFound,
-		a2a.ErrTaskNotCancelable,
-		a2a.ErrUnsupportedOperation,
-		a2a.ErrPushNotificationNotSupported,
-		a2a.ErrMethodNotFound,
-		a2a.ErrInvalidParams,
-		a2a.ErrUnsupportedContentType,
-		a2a.ErrInvalidRequest,
-		a2a.ErrInternalError,
-		a2a.ErrInvalidAgentResponse,
-		a2a.ErrExtendedCardNotConfigured,
-		a2a.ErrExtensionSupportRequired,
-		a2a.ErrVersionNotSupported,
-		a2a.ErrParseError,
-		a2a.ErrServerError,
-		a2a.ErrUnauthenticated,
-		a2a.ErrUnauthorized,
-	}
-
-	for _, sentinel := range errsToTest {
-		t.Run(sentinel.Error(), func(t *testing.T) {
-			t.Parallel()
-
-			got := FromGRPCError(ToGRPCError(sentinel))
-			if !errors.Is(got, sentinel) {
-				t.Fatalf("FromGRPCError(ToGRPCError(%v)) = %v, want errors.Is to match", sentinel, got)
-			}
-		})
-	}
-}
-
-func TestErrorInfo(t *testing.T) {
-	err := a2a.NewError(a2a.ErrTaskNotFound, "oops").WithDetails(map[string]any{
-		"foo": "bar",
-		"num": 123,
-	})
-	grpcErr := ToGRPCError(err)
-
-	st, ok := status.FromError(grpcErr)
-	if !ok {
-		t.Fatalf("Expected gRPC status error")
-	}
-
-	var foundErrorInfo bool
-	var foundStruct bool
-	for _, d := range st.Details() {
-		switch v := d.(type) {
-		case *errdetails.ErrorInfo:
-			foundErrorInfo = true
-			if v.Reason != "TASK_NOT_FOUND" {
-				t.Errorf("ErrorInfo.Reason = %q, want %q", v.Reason, "TASK_NOT_FOUND")
-			}
-			if v.Domain != "a2a-protocol.org" {
-				t.Errorf("ErrorInfo.Domain = %q, want %q", v.Domain, "a2a-protocol.org")
-			}
-			if v.Metadata["foo"] != "bar" {
-				t.Errorf("ErrorInfo.Metadata[foo] = %q, want %q", v.Metadata["foo"], "bar")
-			}
-			if _, ok := v.Metadata["num"]; ok {
-				t.Errorf("ErrorInfo.Metadata[num] should not be present")
-			}
-		case *structpb.Struct:
-			foundStruct = true
-			if v.AsMap()["num"].(float64) != 123 {
-				t.Errorf("Struct.num = %v, want %v", v.AsMap()["num"], 123)
-			}
-		}
-	}
-
-	if !foundErrorInfo {
-		t.Errorf("ErrorInfo not found in details")
-	}
-	if !foundStruct {
-		t.Errorf("structpb.Struct not found in details")
-	}
-
-	// Test round-trip
-	back := FromGRPCError(grpcErr)
-	var a2aBack *a2a.Error
-	if !errors.As(back, &a2aBack) {
-		t.Fatalf("Expected *a2a.Error")
-	}
-	if !errors.Is(a2aBack.Err, a2a.ErrTaskNotFound) {
-		t.Errorf("Round-trip error = %v, want %v", a2aBack.Err, a2a.ErrTaskNotFound)
-	}
-	if a2aBack.Details["num"].(float64) != 123 {
-		t.Errorf("Round-trip details[num] = %v, want %v", a2aBack.Details["num"], 123)
-	}
-	if a2aBack.Details["foo"] != "bar" {
-		t.Errorf("Round-trip details[foo] = %v, want %v", a2aBack.Details["foo"], "bar")
 	}
 }

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
+	"github.com/a2aproject/a2a-go/v2/internal/utils"
 )
 
 // JSON-RPC 2.0 protocol constants
@@ -104,9 +105,12 @@ func FromJSONRPCError(e *Error) error {
 
 	result := a2a.NewError(err, msg)
 	for _, d := range e.Data {
-		if d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
-			if m, ok := d.Value["metadata"].(map[string]string); ok {
-				result = result.WithErrorInfoMeta(m)
+		if d.TypeURL == errordetails.ErrorInfoType {
+			if rawMeta, ok := d.Value["metadata"]; ok {
+				m, ok := utils.ToStringMap(rawMeta)
+				if ok {
+					result = result.WithErrorInfoMeta(m)
+				}
 			}
 		} else {
 			if firstStruct {
@@ -142,21 +146,22 @@ func ToJSONRPCError(err error) *Error {
 	for c, target := range codeToError {
 		if errors.Is(err, target) {
 			code = c
-			if r, ok := a2a.ErrorReason(target); ok {
-				reason = r
-			}
+			reason = a2a.ErrorReason(target)
 			break
 		}
 	}
 
 	if errors.As(err, &a2aErr) {
 		if len(a2aErr.Details) > 0 {
-			data = append(data, errordetails.NewTyped("google.protobuf.Struct", a2aErr.Details))
+			data = append(data, errordetails.NewFromStruct(a2aErr.Details))
 		}
 		for _, d := range a2aErr.TypedDetails {
-			if d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
-				if m, ok := d.Value["metadata"].(map[string]string); ok {
-					maps.Copy(metadata, m)
+			if d.TypeURL == errordetails.ErrorInfoType {
+				if rawMeta, ok := d.Value["metadata"]; ok {
+					m, ok := utils.ToStringMap(rawMeta)
+					if ok {
+						maps.Copy(metadata, m)
+					}
 				}
 			} else {
 				data = append(data, d)
@@ -164,11 +169,8 @@ func ToJSONRPCError(err error) *Error {
 		}
 	}
 
-	data = append(data, errordetails.NewTyped("type.googleapis.com/google.rpc.ErrorInfo", map[string]any{
-		"reason":   reason,
-		"domain":   a2a.PROTOCOL_DOMAIN,
-		"metadata": metadata,
-	}))
+	errorInfo := errordetails.NewErrorInfo(reason, a2a.ProtocolDomain, metadata)
+	data = append(data, errorInfo)
 
 	return &Error{
 		Code:    code,

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -19,8 +19,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/errordetails"
 )
 
 // JSON-RPC 2.0 protocol constants
@@ -48,9 +51,9 @@ const (
 // TODO(yarolegovich): Convert to transport-agnostic error format so Client can use errors.Is(err, a2a.ErrMethodNotFound).
 // This needs to be implemented across all transports (currently not in grpc either).
 type Error struct {
-	Code    int            `json:"code"`
-	Message string         `json:"message"`
-	Data    map[string]any `json:"data,omitempty"`
+	Code    int                   `json:"code"`
+	Message string                `json:"message"`
+	Data    []*errordetails.Typed `json:"data,omitempty"`
 }
 
 // Error implements the error interface for jsonrpcError.
@@ -81,8 +84,11 @@ var codeToError = map[int]error{
 	-31403: a2a.ErrUnauthorized,
 }
 
-// ToA2AError converts a JSON-RPC error to an [a2a.Error].
-func (e *Error) ToA2AError() error {
+// FromJSONRPCError converts a JSON-RPC error to an [a2a.Error].
+func FromJSONRPCError(e *Error) error {
+	if e == nil {
+		return nil
+	}
 	err, ok := codeToError[e.Code]
 	if !ok {
 		err = a2a.ErrInternalError
@@ -93,49 +99,81 @@ func (e *Error) ToA2AError() error {
 		msg = err.Error()
 	}
 
+	var typedDetails []*errordetails.Typed
+	firstStruct := true
+
 	result := a2a.NewError(err, msg)
-	if len(e.Data) > 0 {
-		result = result.WithDetails(e.Data)
+	for _, d := range e.Data {
+		if d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
+			if m, ok := d.Value["metadata"].(map[string]string); ok {
+				result = result.WithErrorInfoMeta(m)
+			}
+		} else {
+			if firstStruct {
+				result = result.WithDetails(d.Value)
+				firstStruct = false
+			}
+			typedDetails = append(typedDetails, d)
+		}
 	}
+	result.TypedDetails = append(result.TypedDetails, typedDetails...)
 	return result
 }
 
 // ToJSONRPCError converts an error to a JSON-RPC [Error].
 func ToJSONRPCError(err error) *Error {
-	jsonrpcErr := &Error{}
+	if err == nil {
+		return nil
+	}
+	var jsonrpcErr *Error
 	if errors.As(err, &jsonrpcErr) {
 		return jsonrpcErr
 	}
 
+	code := -32603
+	reason := "INTERNAL_ERROR"
+	var data []*errordetails.Typed
+
 	var a2aErr *a2a.Error
-	if errors.As(err, &a2aErr) {
-		code := -32603
-		for c, target := range codeToError {
-			if errors.Is(a2aErr.Err, target) {
-				code = c
-				break
+	metadata := map[string]string{
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	}
+
+	for c, target := range codeToError {
+		if errors.Is(err, target) {
+			code = c
+			if r, ok := a2a.ErrorReason(target); ok {
+				reason = r
 			}
-		}
-		return &Error{
-			Code:    code,
-			Message: a2aErr.Error(),
-			Data:    a2aErr.Details,
+			break
 		}
 	}
 
-	for code, a2aErr := range codeToError {
-		if errors.Is(err, a2aErr) {
-			return &Error{
-				Code:    code,
-				Message: a2aErr.Error(),
-				Data:    map[string]any{"error": err.Error()},
+	if errors.As(err, &a2aErr) {
+		if len(a2aErr.Details) > 0 {
+			data = append(data, errordetails.NewTyped("google.protobuf.Struct", a2aErr.Details))
+		}
+		for _, d := range a2aErr.TypedDetails {
+			if d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
+				if m, ok := d.Value["metadata"].(map[string]string); ok {
+					maps.Copy(metadata, m)
+				}
+			} else {
+				data = append(data, d)
 			}
 		}
 	}
+
+	data = append(data, errordetails.NewTyped("type.googleapis.com/google.rpc.ErrorInfo", map[string]any{
+		"reason":   reason,
+		"domain":   a2a.PROTOCOL_DOMAIN,
+		"metadata": metadata,
+	}))
+
 	return &Error{
-		Code:    -32603,
-		Message: a2a.ErrInternalError.Error(),
-		Data:    map[string]any{"error": err.Error()},
+		Code:    code,
+		Message: err.Error(),
+		Data:    data,
 	}
 }
 

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestJSONRPCError_RoundTrip(t *testing.T) {
@@ -33,14 +34,8 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 		name         string
 		inputError   *a2a.Error
 		typedDetails []*errordetails.Typed
-		// midpoint (REST response) assertions
-		wantCode   int
-		wantReason string
-		wantMeta   map[string]string
-		// final (A2A error) assertions
-		wantBaseErr error
-		wantMessage string
-		wantDetails map[string]any
+		wantCode     int
+		want         *a2a.Error
 	}{
 		{
 			name:     "Nil error",
@@ -53,15 +48,21 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 			}).WithDetails(map[string]any{
 				"num": float64(123),
 			}),
-			wantCode:   -32001,
-			wantReason: "TASK_NOT_FOUND",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrTaskNotFound,
-			wantMessage: "task not found",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			wantCode: -32001,
+			want: &a2a.Error{
+				Err:     a2a.ErrTaskNotFound,
+				Message: "task not found",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("TASK_NOT_FOUND", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -71,15 +72,21 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 			}).WithDetails(map[string]any{
 				"num": float64(123),
 			}),
-			wantCode:   -32700,
-			wantReason: "PARSE_ERROR",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrParseError,
-			wantMessage: "wrapped parse error",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			wantCode: -32700,
+			want: &a2a.Error{
+				Err:     a2a.ErrParseError,
+				Message: "wrapped parse error",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("PARSE_ERROR", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -89,15 +96,21 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 			}).WithDetails(map[string]any{
 				"num": float64(123),
 			}),
-			wantCode:   -32602,
-			wantReason: "INVALID_PARAMS",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrInvalidParams,
-			wantMessage: "invalid params",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			wantCode: -32602,
+			want: &a2a.Error{
+				Err:     a2a.ErrInvalidParams,
+				Message: "invalid params",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("INVALID_PARAMS", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -112,36 +125,54 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 					"extra": "should not leak into details",
 				}),
 			},
-			wantCode:   -32008,
-			wantReason: "EXTENSION_SUPPORT_REQUIRED",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrExtensionSupportRequired,
-			wantMessage: "extension support required",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			wantCode: -32008,
+			want: &a2a.Error{
+				Err:     a2a.ErrExtensionSupportRequired,
+				Message: "extension support required",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("EXTENSION_SUPPORT_REQUIRED", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"extra": "should not leak into details",
+					}),
+				},
 			},
 		},
 		{
-			name:        "InvalidRequest without extra details",
-			inputError:  a2a.NewError(a2a.ErrInvalidRequest, "invalid request"),
-			wantCode:    -32600,
-			wantReason:  "INVALID_REQUEST",
-			wantBaseErr: a2a.ErrInvalidRequest,
-			wantMessage: "invalid request",
+			name:       "InvalidRequest without extra details",
+			inputError: a2a.NewError(a2a.ErrInvalidRequest, "invalid request"),
+			wantCode:   -32600,
+			want:       errorWithErrorInfo(t, "invalid request", a2a.ErrInvalidRequest, "INVALID_REQUEST"),
 		},
 		{
 			name: "MethodNotFound with details only",
 			inputError: a2a.NewError(a2a.ErrMethodNotFound, "method not found").WithDetails(map[string]any{
 				"num": float64(123),
 			}),
-			wantCode:    -32601,
-			wantReason:  "METHOD_NOT_FOUND",
-			wantBaseErr: a2a.ErrMethodNotFound,
-			wantMessage: "method not found",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			wantCode: -32601,
+			want: &a2a.Error{
+				Err:     a2a.ErrMethodNotFound,
+				Message: "method not found",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewTyped(errordetails.ErrorInfoType, map[string]any{
+						"reason":   "METHOD_NOT_FOUND",
+						"domain":   a2a.ProtocolDomain,
+						"metadata": map[string]string{},
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -149,13 +180,16 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 			inputError: a2a.NewError(a2a.ErrServerError, "server error").WithErrorInfoMeta(map[string]string{
 				"foo": "bar",
 			}),
-			wantCode:   -32000,
-			wantReason: "SERVER_ERROR",
-			wantMeta: map[string]string{
-				"foo": "bar",
+			wantCode: -32000,
+			want: &a2a.Error{
+				Err:     a2a.ErrServerError,
+				Message: "server error",
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("SERVER_ERROR", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+				},
 			},
-			wantBaseErr: a2a.ErrServerError,
-			wantMessage: "server error",
 		},
 		{
 			name: "TaskNotCancelable ErrorInfo override",
@@ -164,93 +198,76 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 			}).WithErrorInfoMeta(map[string]string{
 				"new_key": "new_value",
 			}),
-			wantCode:   -32002,
-			wantReason: "TASK_NOT_CANCELABLE",
-			wantMeta: map[string]string{
-				"new_key": "new_value",
+			wantCode: -32002,
+			want: &a2a.Error{
+				Err:     a2a.ErrTaskNotCancelable,
+				Message: "task not cancelable",
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("TASK_NOT_CANCELABLE", a2a.ProtocolDomain, map[string]string{
+						"new_key": "new_value",
+					}),
+				},
 			},
-			wantBaseErr: a2a.ErrTaskNotCancelable,
-			wantMessage: "task not cancelable",
 		},
 		{
-			name:        "PushNotificationNotSupported",
-			inputError:  a2a.NewError(a2a.ErrPushNotificationNotSupported, "push notification not supported"),
-			wantCode:    -32003,
-			wantReason:  "PUSH_NOTIFICATION_NOT_SUPPORTED",
-			wantBaseErr: a2a.ErrPushNotificationNotSupported,
-			wantMessage: "push notification not supported",
+			name:       "PushNotificationNotSupported",
+			inputError: a2a.NewError(a2a.ErrPushNotificationNotSupported, "push notification not supported"),
+			wantCode:   -32003,
+			want:       errorWithErrorInfo(t, "push notification not supported", a2a.ErrPushNotificationNotSupported, "PUSH_NOTIFICATION_NOT_SUPPORTED"),
 		},
 		{
-			name:        "UnsupportedOperation",
-			inputError:  a2a.NewError(a2a.ErrUnsupportedOperation, "unsupported operation"),
-			wantCode:    -32004,
-			wantReason:  "UNSUPPORTED_OPERATION",
-			wantBaseErr: a2a.ErrUnsupportedOperation,
-			wantMessage: "unsupported operation",
+			name:       "UnsupportedOperation",
+			inputError: a2a.NewError(a2a.ErrUnsupportedOperation, "unsupported operation"),
+			wantCode:   -32004,
+			want:       errorWithErrorInfo(t, "unsupported operation", a2a.ErrUnsupportedOperation, "UNSUPPORTED_OPERATION"),
 		},
 		{
-			name:        "UnsupportedContentType",
-			inputError:  a2a.NewError(a2a.ErrUnsupportedContentType, "unsupported content type"),
-			wantCode:    -32005,
-			wantReason:  "CONTENT_TYPE_NOT_SUPPORTED",
-			wantBaseErr: a2a.ErrUnsupportedContentType,
-			wantMessage: "unsupported content type",
+			name:       "UnsupportedContentType",
+			inputError: a2a.NewError(a2a.ErrUnsupportedContentType, "unsupported content type"),
+			wantCode:   -32005,
+			want:       errorWithErrorInfo(t, "unsupported content type", a2a.ErrUnsupportedContentType, "CONTENT_TYPE_NOT_SUPPORTED"),
 		},
 		{
-			name:        "InvalidAgentResponse",
-			inputError:  a2a.NewError(a2a.ErrInvalidAgentResponse, "invalid agent response"),
-			wantCode:    -32006,
-			wantReason:  "INVALID_AGENT_RESPONSE",
-			wantBaseErr: a2a.ErrInvalidAgentResponse,
-			wantMessage: "invalid agent response",
+			name:       "InvalidAgentResponse",
+			inputError: a2a.NewError(a2a.ErrInvalidAgentResponse, "invalid agent response"),
+			wantCode:   -32006,
+			want:       errorWithErrorInfo(t, "invalid agent response", a2a.ErrInvalidAgentResponse, "INVALID_AGENT_RESPONSE"),
 		},
 		{
-			name:        "ExtendedCardNotConfigured",
-			inputError:  a2a.NewError(a2a.ErrExtendedCardNotConfigured, "extended card not configured"),
-			wantCode:    -32007,
-			wantReason:  "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
-			wantBaseErr: a2a.ErrExtendedCardNotConfigured,
-			wantMessage: "extended card not configured",
+			name:       "ExtendedCardNotConfigured",
+			inputError: a2a.NewError(a2a.ErrExtendedCardNotConfigured, "extended card not configured"),
+			wantCode:   -32007,
+			want:       errorWithErrorInfo(t, "extended card not configured", a2a.ErrExtendedCardNotConfigured, "EXTENDED_AGENT_CARD_NOT_CONFIGURED"),
 		},
 		{
-			name:        "VersionNotSupported",
-			inputError:  a2a.NewError(a2a.ErrVersionNotSupported, "version not supported"),
-			wantCode:    -32009,
-			wantReason:  "VERSION_NOT_SUPPORTED",
-			wantBaseErr: a2a.ErrVersionNotSupported,
-			wantMessage: "version not supported",
+			name:       "VersionNotSupported",
+			inputError: a2a.NewError(a2a.ErrVersionNotSupported, "version not supported"),
+			wantCode:   -32009,
+			want:       errorWithErrorInfo(t, "version not supported", a2a.ErrVersionNotSupported, "VERSION_NOT_SUPPORTED"),
 		},
 		{
-			name:        "Unauthenticated",
-			inputError:  a2a.NewError(a2a.ErrUnauthenticated, "unauthenticated"),
-			wantCode:    -31401,
-			wantReason:  "UNAUTHENTICATED",
-			wantBaseErr: a2a.ErrUnauthenticated,
-			wantMessage: "unauthenticated",
+			name:       "Unauthenticated",
+			inputError: a2a.NewError(a2a.ErrUnauthenticated, "unauthenticated"),
+			wantCode:   -31401,
+			want:       errorWithErrorInfo(t, "unauthenticated", a2a.ErrUnauthenticated, "UNAUTHENTICATED"),
 		},
 		{
-			name:        "Unauthorized",
-			inputError:  a2a.NewError(a2a.ErrUnauthorized, "unauthorized"),
-			wantCode:    -31403,
-			wantReason:  "UNAUTHORIZED",
-			wantBaseErr: a2a.ErrUnauthorized,
-			wantMessage: "unauthorized",
+			name:       "Unauthorized",
+			inputError: a2a.NewError(a2a.ErrUnauthorized, "unauthorized"),
+			wantCode:   -31403,
+			want:       errorWithErrorInfo(t, "unauthorized", a2a.ErrUnauthorized, "UNAUTHORIZED"),
 		},
 		{
-			name:        "InternalError",
-			inputError:  a2a.NewError(a2a.ErrInternalError, "internal error"),
-			wantCode:    -32603,
-			wantReason:  "INTERNAL_ERROR",
-			wantBaseErr: a2a.ErrInternalError,
-			wantMessage: "internal error",
+			name:       "InternalError",
+			inputError: a2a.NewError(a2a.ErrInternalError, "internal error"),
+			wantCode:   -32603,
+			want:       errorWithErrorInfo(t, "internal error", a2a.ErrInternalError, "INTERNAL_ERROR"),
 		},
 		{
-			name:        "UnknownError roundtrips to Internal",
-			inputError:  a2a.NewError(errors.New("unknown error"), "unknown error"),
-			wantCode:    -32603,
-			wantReason:  "INTERNAL_ERROR",
-			wantBaseErr: a2a.ErrInternalError,
-			wantMessage: "unknown error",
+			name:       "UnknownError roundtrips to Internal",
+			inputError: a2a.NewError(errors.New("unknown error"), "unknown error"),
+			wantCode:   -32603,
+			want:       errorWithErrorInfo(t, "unknown error", a2a.ErrInternalError, "INTERNAL_ERROR"),
 		},
 	}
 
@@ -273,37 +290,6 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 			if got.Code != tc.wantCode {
 				t.Fatalf("ToJSONRPCError() Code = %v, want %v", got.Code, tc.wantCode)
 			}
-			if got.Message != tc.wantMessage {
-				t.Errorf("ToJSONRPCError() Message = %v, want %v", got.Message, tc.wantMessage)
-			}
-
-			var foundErrorInfo bool
-			for _, typed := range got.Data {
-				if typed.TypeURL == errordetails.ErrorInfoType {
-					foundErrorInfo = true
-					if typed.Value["reason"] != tc.wantReason {
-						t.Errorf("ErrorInfo.Reason = %v, want %v", typed.Value["reason"], tc.wantReason)
-					}
-					if typed.Value["domain"] != a2a.ProtocolDomain {
-						t.Errorf("ErrorInfo.Domain = %v, want %v", typed.Value["domain"], a2a.ProtocolDomain)
-					}
-					metadata, ok := typed.Value["metadata"].(map[string]string)
-					if !ok {
-						t.Fatalf("ErrorInfo.Metadata = %v, want %v", typed.Value["metadata"], tc.wantMeta)
-					}
-					if timestamp, ok := metadata["timestamp"]; !ok || timestamp == "" {
-						t.Fatalf("ErrorInfo.Metadata = %v, want %v", metadata, tc.wantMeta)
-					}
-					for key, value := range tc.wantMeta {
-						if metadata[key] != value {
-							t.Errorf("ErrorInfo.Metadata = %v, want %v", metadata, tc.wantMeta)
-						}
-					}
-				}
-			}
-			if !foundErrorInfo {
-				t.Fatalf("ErrorInfo not found in details")
-			}
 
 			jsonBytes, err := json.Marshal(got)
 			if err != nil {
@@ -319,62 +305,29 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 			if !errors.As(back, &a2aBack) {
 				t.Fatalf("Expected *a2a.Error")
 			}
-			if !errors.Is(a2aBack.Err, tc.wantBaseErr) {
-				t.Errorf("FromJSONRPCError() = %v, want %v", a2aBack.Err, tc.wantBaseErr)
-			}
-			if diff := cmp.Diff(tc.wantDetails, a2aBack.Details); diff != "" {
-				t.Fatalf("Round-trip details mismatch (+got,-want):\n%s", diff)
-			}
-			if diff := cmp.Diff(tc.wantMessage, a2aBack.Message); diff != "" {
-				t.Fatalf("Round-trip message mismatch (+got,-want):\n%s", diff)
-			}
-			errInfo := a2aBack.ErrorInfo()
-			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.ProtocolDomain {
-				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.ProtocolDomain)
-			}
-			if reason, ok := errInfo.Value["reason"].(string); !ok || reason != tc.wantReason {
-				t.Fatalf("Round-trip ErrorInfo reason = %q, want %q", reason, tc.wantReason)
-			}
-			metadata, ok := errInfo.Value["metadata"].(map[string]string)
-			if !ok {
-				t.Fatalf("Round-trip ErrorInfo metadata not found or wrong type: %v", errInfo.Value["metadata"])
-			}
-			if timestamp, ok := metadata["timestamp"]; !ok || timestamp == "" {
-				t.Fatalf("Round-trip ErrorInfo metadata timestamp not found or empty: %v", metadata)
-			}
-			for key, value := range tc.wantMeta {
-				if metadata[key] != value {
-					t.Errorf("Round-trip ErrorInfo metadata = %v, want %v", metadata, tc.wantMeta)
-				}
-			}
-
-			if tc.wantDetails != nil {
-				foundDetailsInTypedDetails := false
-				structCount := 0
-				for _, td := range a2aBack.TypedDetails {
-					if td.TypeURL != errordetails.StructType {
-						continue
-					}
-					structCount++
-					if cmp.Equal(tc.wantDetails, td.Value) {
-						foundDetailsInTypedDetails = true
-					}
-				}
-				if !foundDetailsInTypedDetails {
-					t.Fatalf("Round-trip TypedDetails missing struct with expected details")
-				}
-				wantStructCount := 1
-				if tc.typedDetails != nil {
-					for _, td := range tc.typedDetails {
-						if td.TypeURL == errordetails.StructType {
-							wantStructCount++
-						}
-					}
-				}
-				if structCount != wantStructCount {
-					t.Fatalf("Round-trip TypedDetails struct count = %d, want %d", structCount, wantStructCount)
-				}
+			if diff := cmp.Diff(*tc.want, *a2aBack,
+				cmpopts.EquateErrors(),
+				cmpopts.IgnoreMapEntries(func(k string, _ string) bool {
+					return k == "timestamp"
+				}),
+			); diff != "" {
+				t.Fatalf("Round-trip error mismatch (+got, -want):\n%s", diff)
 			}
 		})
+	}
+}
+
+func errorWithErrorInfo(t *testing.T, message string, err error, reason string) *a2a.Error {
+	t.Helper()
+	return &a2a.Error{
+		Err:     err,
+		Message: message,
+		TypedDetails: []*errordetails.Typed{
+			errordetails.NewTyped(errordetails.ErrorInfoType, map[string]any{
+				"reason":   reason,
+				"domain":   a2a.ProtocolDomain,
+				"metadata": map[string]string{},
+			}),
+		},
 	}
 }

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -16,144 +16,352 @@ package jsonrpc
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/errordetails"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestJSONRPCError(t *testing.T) {
-	err := &Error{
-		Code:    -32600,
-		Message: "Invalid Request",
-		Data:    map[string]any{"details": "extra info"},
-	}
-
-	errStr := err.Error()
-	if errStr != "jsonrpc error -32600: Invalid Request (data: map[details:extra info])" {
-		t.Errorf("Unexpected error string: %s", errStr)
-	}
-
-	err2 := &Error{Code: -32601, Message: "Method not found"}
-
-	errStr2 := err2.Error()
-	if errStr2 != "jsonrpc error -32601: Method not found" {
-		t.Errorf("Unexpected error string: %s", errStr2)
-	}
-}
-
-func TestToJSONRPCError(t *testing.T) {
+func TestJSONRPCError_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		err  error
-		want *Error
+		checkNil     bool
+		name         string
+		inputError   *a2a.Error
+		typedDetails []*errordetails.Typed
+		// midpoint (REST response) assertions
+		wantCode   int
+		wantReason string
+		wantMeta   map[string]string
+		// final (A2A error) assertions
+		wantBaseErr error
+		wantMessage string
+		wantDetails map[string]any
 	}{
 		{
-			name: "JSONRPCError passthrough",
-			err:  &Error{Code: -32001, Message: "Custom error", Data: map[string]any{"extra": "data"}},
-			want: &Error{Code: -32001, Message: "Custom error", Data: map[string]any{"extra": "data"}},
+			checkNil: true,
 		},
 		{
-			name: "Known a2a error",
-			err:  a2a.ErrTaskNotFound,
-			want: &Error{Code: -32001, Message: a2a.ErrTaskNotFound.Error(), Data: map[string]any{"error": a2a.ErrTaskNotFound.Error()}},
-		},
-		{
-			name: "Known a2a error wrapped",
-			err:  errors.Join(errors.New("context info"), a2a.ErrInvalidParams),
-			want: &Error{Code: -32602, Message: a2a.ErrInvalidParams.Error(), Data: map[string]any{"error": "context info\ninvalid params"}},
-		},
-		{
-			name: "Unknown error - internal error with details preserved",
-			err:  errors.New("database connection failed"),
-			want: &Error{Code: -32603, Message: a2a.ErrInternalError.Error(), Data: map[string]any{"error": "database connection failed"}},
-		},
-		{
-			name: "Unknown error wrapped - internal error with details preserved",
-			err:  errors.New("identity service error: user not authenticated"),
-			want: &Error{Code: -32603, Message: a2a.ErrInternalError.Error(), Data: map[string]any{"error": "identity service error: user not authenticated"}},
-		},
-		{
-			name: "ErrUnauthenticated mapping",
-			err:  a2a.ErrUnauthenticated,
-			want: &Error{Code: -31401, Message: a2a.ErrUnauthenticated.Error(), Data: map[string]any{"error": a2a.ErrUnauthenticated.Error()}},
-		},
-		{
-			name: "a2a.Error with known error",
-			err:  a2a.NewError(a2a.ErrUnauthorized, "You shall not pass").WithDetails(map[string]any{"reason": "expired token"}),
-			want: &Error{Code: -31403, Message: "You shall not pass", Data: map[string]any{"reason": "expired token"}},
-		},
-		{
-			name: "a2a.Error with unknown error",
-			err:  a2a.NewError(errors.New("random thing"), "Something went wrong"),
-			want: &Error{Code: -32603, Message: "Something went wrong", Data: nil},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := ToJSONRPCError(tt.err)
-
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("ToJSONRPCError() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestToA2AError(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		err     *Error
-		wantErr *a2a.Error
-	}{
-		{
-			name:    "known error code",
-			err:     &Error{Code: -32001, Message: "task not found"},
-			wantErr: a2a.NewError(a2a.ErrTaskNotFound, "task not found"),
-		},
-		{
-			name:    "unknown error code",
-			err:     &Error{Code: -99999, Message: "some unknown error"},
-			wantErr: a2a.NewError(a2a.ErrInternalError, "some unknown error"),
-		},
-		{
-			name: "custom",
-			err: &Error{
-				Code:    -32602,
-				Message: "custom",
-				Data:    map[string]any{"field": "foo", "reason": "missing"},
+			name: "TaskNotFound with details and metadata",
+			inputError: a2a.NewError(a2a.ErrTaskNotFound, "task not found").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantCode:   -32001,
+			wantReason: "TASK_NOT_FOUND",
+			wantMeta: map[string]string{
+				"foo": "bar",
 			},
-			wantErr: a2a.NewError(a2a.ErrInvalidParams, "custom").WithDetails(map[string]any{"field": "foo", "reason": "missing"}),
+			wantBaseErr: a2a.ErrTaskNotFound,
+			wantMessage: "task not found",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "Wrapped ParseError with details and metadata",
+			inputError: a2a.NewError(fmt.Errorf("wrapped error: %w", a2a.ErrParseError), "wrapped parse error").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantCode:   -32700,
+			wantReason: "PARSE_ERROR",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrParseError,
+			wantMessage: "wrapped parse error",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "InvalidParams with details and metadata",
+			inputError: a2a.NewError(a2a.ErrInvalidParams, "invalid params").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantCode:   -32602,
+			wantReason: "INVALID_PARAMS",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrInvalidParams,
+			wantMessage: "invalid params",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "ExtensionSupportRequired with details, typed details and metadata",
+			inputError: a2a.NewError(a2a.ErrExtensionSupportRequired, "extension support required").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			typedDetails: []*errordetails.Typed{
+				errordetails.NewTyped("google.protobuf.Struct", map[string]any{
+					"extra": "should not leak into details",
+				}),
+			},
+			wantCode:   -32008,
+			wantReason: "EXTENSION_SUPPORT_REQUIRED",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrExtensionSupportRequired,
+			wantMessage: "extension support required",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name:        "InvalidRequest without extra details",
+			inputError:  a2a.NewError(a2a.ErrInvalidRequest, "invalid request"),
+			wantCode:    -32600,
+			wantReason:  "INVALID_REQUEST",
+			wantBaseErr: a2a.ErrInvalidRequest,
+			wantMessage: "invalid request",
+		},
+		{
+			name: "MethodNotFound with details only",
+			inputError: a2a.NewError(a2a.ErrMethodNotFound, "method not found").WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantCode:    -32601,
+			wantReason:  "METHOD_NOT_FOUND",
+			wantBaseErr: a2a.ErrMethodNotFound,
+			wantMessage: "method not found",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "ServerError with ErrorInfo only",
+			inputError: a2a.NewError(a2a.ErrServerError, "server error").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}),
+			wantCode:   -32000,
+			wantReason: "SERVER_ERROR",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrServerError,
+			wantMessage: "server error",
+		},
+		{
+			name: "TaskNotCancelable ErrorInfo override",
+			inputError: a2a.NewError(a2a.ErrTaskNotCancelable, "task not cancelable").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithErrorInfoMeta(map[string]string{
+				"new_key": "new_value",
+			}),
+			wantCode:   -32002,
+			wantReason: "TASK_NOT_CANCELABLE",
+			wantMeta: map[string]string{
+				"new_key": "new_value",
+			},
+			wantBaseErr: a2a.ErrTaskNotCancelable,
+			wantMessage: "task not cancelable",
+		},
+		{
+			name:        "PushNotificationNotSupported",
+			inputError:  a2a.NewError(a2a.ErrPushNotificationNotSupported, "push notification not supported"),
+			wantCode:    -32003,
+			wantReason:  "PUSH_NOTIFICATION_NOT_SUPPORTED",
+			wantBaseErr: a2a.ErrPushNotificationNotSupported,
+			wantMessage: "push notification not supported",
+		},
+		{
+			name:        "UnsupportedOperation",
+			inputError:  a2a.NewError(a2a.ErrUnsupportedOperation, "unsupported operation"),
+			wantCode:    -32004,
+			wantReason:  "UNSUPPORTED_OPERATION",
+			wantBaseErr: a2a.ErrUnsupportedOperation,
+			wantMessage: "unsupported operation",
+		},
+		{
+			name:        "UnsupportedContentType",
+			inputError:  a2a.NewError(a2a.ErrUnsupportedContentType, "unsupported content type"),
+			wantCode:    -32005,
+			wantReason:  "CONTENT_TYPE_NOT_SUPPORTED",
+			wantBaseErr: a2a.ErrUnsupportedContentType,
+			wantMessage: "unsupported content type",
+		},
+		{
+			name:        "InvalidAgentResponse",
+			inputError:  a2a.NewError(a2a.ErrInvalidAgentResponse, "invalid agent response"),
+			wantCode:    -32006,
+			wantReason:  "INVALID_AGENT_RESPONSE",
+			wantBaseErr: a2a.ErrInvalidAgentResponse,
+			wantMessage: "invalid agent response",
+		},
+		{
+			name:        "ExtendedCardNotConfigured",
+			inputError:  a2a.NewError(a2a.ErrExtendedCardNotConfigured, "extended card not configured"),
+			wantCode:    -32007,
+			wantReason:  "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
+			wantBaseErr: a2a.ErrExtendedCardNotConfigured,
+			wantMessage: "extended card not configured",
+		},
+		{
+			name:        "VersionNotSupported",
+			inputError:  a2a.NewError(a2a.ErrVersionNotSupported, "version not supported"),
+			wantCode:    -32009,
+			wantReason:  "VERSION_NOT_SUPPORTED",
+			wantBaseErr: a2a.ErrVersionNotSupported,
+			wantMessage: "version not supported",
+		},
+		{
+			name:        "Unauthenticated",
+			inputError:  a2a.NewError(a2a.ErrUnauthenticated, "unauthenticated"),
+			wantCode:    -31401,
+			wantReason:  "UNAUTHENTICATED",
+			wantBaseErr: a2a.ErrUnauthenticated,
+			wantMessage: "unauthenticated",
+		},
+		{
+			name:        "Unauthorized",
+			inputError:  a2a.NewError(a2a.ErrUnauthorized, "unauthorized"),
+			wantCode:    -31403,
+			wantReason:  "UNAUTHORIZED",
+			wantBaseErr: a2a.ErrUnauthorized,
+			wantMessage: "unauthorized",
+		},
+		{
+			name:        "InternalError",
+			inputError:  a2a.NewError(a2a.ErrInternalError, "internal error"),
+			wantCode:    -32603,
+			wantReason:  "INTERNAL_ERROR",
+			wantBaseErr: a2a.ErrInternalError,
+			wantMessage: "internal error",
+		},
+		{
+			name:        "UnknownError roundtrips to Internal",
+			inputError:  a2a.NewError(errors.New("unknown error"), "unknown error"),
+			wantCode:    -32603,
+			wantReason:  "INTERNAL_ERROR",
+			wantBaseErr: a2a.ErrInternalError,
+			wantMessage: "unknown error",
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := tt.err.ToA2AError()
-
-			if !errors.Is(got, tt.wantErr.Unwrap()) {
-				t.Errorf("ToA2AError() error = %v, wantErr %v", got, tt.wantErr)
+			if tc.typedDetails != nil {
+				tc.inputError.TypedDetails = append(tc.inputError.TypedDetails, tc.typedDetails...)
 			}
 
-			if got.Error() != tt.wantErr.Error() {
-				t.Errorf("ToA2AError() message = %q, want %q", got.Error(), tt.wantErr.Error())
+			if tc.checkNil {
+				if err := ToJSONRPCError(nil); err != nil {
+					t.Errorf("ToJSONRPCError(nil) = %v, want nil", err)
+				}
+				return
 			}
 
-			if len(tt.err.Data) > 1 {
-				var a2aErr *a2a.Error
-				if errors.As(got, &a2aErr) {
-					if diff := cmp.Diff(tt.err.Data, a2aErr.Details); diff != "" {
-						t.Errorf("ToA2AError() details mismatch (-want +got):\n%s", diff)
+			got := ToJSONRPCError(tc.inputError)
+			if got.Code != tc.wantCode {
+				t.Fatalf("ToJSONRPCError() Code = %v, want %v", got.Code, tc.wantCode)
+			}
+			if got.Message != tc.wantMessage {
+				t.Errorf("ToJSONRPCError() Message = %v, want %v", got.Message, tc.wantMessage)
+			}
+
+			var foundErrorInfo bool
+			for _, typed := range got.Data {
+				if typed.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
+					foundErrorInfo = true
+					if typed.Value["reason"] != tc.wantReason {
+						t.Errorf("ErrorInfo.Reason = %v, want %v", typed.Value["reason"], tc.wantReason)
 					}
+					if typed.Value["domain"] != a2a.PROTOCOL_DOMAIN {
+						t.Errorf("ErrorInfo.Domain = %v, want %v", typed.Value["domain"], a2a.PROTOCOL_DOMAIN)
+					}
+					metadata, ok := typed.Value["metadata"].(map[string]string)
+					if !ok {
+						t.Fatalf("ErrorInfo.Metadata = %v, want %v", typed.Value["metadata"], tc.wantMeta)
+					}
+					if timestamp, ok := metadata["timestamp"]; !ok || timestamp == "" {
+						t.Fatalf("ErrorInfo.Metadata = %v, want %v", metadata, tc.wantMeta)
+					}
+					for key, value := range tc.wantMeta {
+						if metadata[key] != value {
+							t.Errorf("ErrorInfo.Metadata = %v, want %v", metadata, tc.wantMeta)
+						}
+					}
+				}
+			}
+			if !foundErrorInfo {
+				t.Fatalf("ErrorInfo not found in details")
+			}
+
+			back := FromJSONRPCError(got)
+			var a2aBack *a2a.Error
+			if !errors.As(back, &a2aBack) {
+				t.Fatalf("Expected *a2a.Error")
+			}
+			if !errors.Is(a2aBack.Err, tc.wantBaseErr) {
+				t.Errorf("FromJSONRPCError() = %v, want %v", a2aBack.Err, tc.wantBaseErr)
+			}
+			if diff := cmp.Diff(tc.wantDetails, a2aBack.Details); diff != "" {
+				t.Fatalf("Round-trip details mismatch (+got,-want):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantMessage, a2aBack.Message); diff != "" {
+				t.Fatalf("Round-trip message mismatch (+got,-want):\n%s", diff)
+			}
+			errInfo := a2aBack.ErrorInfo()
+			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.PROTOCOL_DOMAIN {
+				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.PROTOCOL_DOMAIN)
+			}
+			if reason, ok := errInfo.Value["reason"].(string); !ok || reason != tc.wantReason {
+				t.Fatalf("Round-trip ErrorInfo reason = %q, want %q", reason, tc.wantReason)
+			}
+			metadata, ok := errInfo.Value["metadata"].(map[string]string)
+			if !ok {
+				t.Fatalf("Round-trip ErrorInfo metadata not found or wrong type: %v", errInfo.Value["metadata"])
+			}
+			if timestamp, ok := metadata["timestamp"]; !ok || timestamp == "" {
+				t.Fatalf("Round-trip ErrorInfo metadata timestamp not found or empty: %v", metadata)
+			}
+			for key, value := range tc.wantMeta {
+				if metadata[key] != value {
+					t.Errorf("Round-trip ErrorInfo metadata = %v, want %v", metadata, tc.wantMeta)
+				}
+			}
+
+			if tc.wantDetails != nil {
+				foundDetailsInTypedDetails := false
+				structCount := 0
+				for _, td := range a2aBack.TypedDetails {
+					if td.TypeURL != "google.protobuf.Struct" {
+						continue
+					}
+					structCount++
+					if cmp.Equal(tc.wantDetails, td.Value) {
+						foundDetailsInTypedDetails = true
+					}
+				}
+				if !foundDetailsInTypedDetails {
+					t.Fatalf("Round-trip TypedDetails missing struct with expected details")
+				}
+				wantStructCount := 1
+				if tc.typedDetails != nil {
+					for _, td := range tc.typedDetails {
+						if td.TypeURL == "google.protobuf.Struct" {
+							wantStructCount++
+						}
+					}
+				}
+				if structCount != wantStructCount {
+					t.Fatalf("Round-trip TypedDetails struct count = %d, want %d", structCount, wantStructCount)
 				}
 			}
 		})

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -15,6 +15,7 @@
 package jsonrpc
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -42,6 +43,7 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 		wantDetails map[string]any
 	}{
 		{
+			name:     "Nil error",
 			checkNil: true,
 		},
 		{
@@ -106,7 +108,7 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 				"num": float64(123),
 			}),
 			typedDetails: []*errordetails.Typed{
-				errordetails.NewTyped("google.protobuf.Struct", map[string]any{
+				errordetails.NewFromStruct(map[string]any{
 					"extra": "should not leak into details",
 				}),
 			},
@@ -277,13 +279,13 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 
 			var foundErrorInfo bool
 			for _, typed := range got.Data {
-				if typed.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
+				if typed.TypeURL == errordetails.ErrorInfoType {
 					foundErrorInfo = true
 					if typed.Value["reason"] != tc.wantReason {
 						t.Errorf("ErrorInfo.Reason = %v, want %v", typed.Value["reason"], tc.wantReason)
 					}
-					if typed.Value["domain"] != a2a.PROTOCOL_DOMAIN {
-						t.Errorf("ErrorInfo.Domain = %v, want %v", typed.Value["domain"], a2a.PROTOCOL_DOMAIN)
+					if typed.Value["domain"] != a2a.ProtocolDomain {
+						t.Errorf("ErrorInfo.Domain = %v, want %v", typed.Value["domain"], a2a.ProtocolDomain)
 					}
 					metadata, ok := typed.Value["metadata"].(map[string]string)
 					if !ok {
@@ -303,7 +305,16 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 				t.Fatalf("ErrorInfo not found in details")
 			}
 
-			back := FromJSONRPCError(got)
+			jsonBytes, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("json.Marshal() = %v, want nil", err)
+			}
+			var unmarshalled Error
+			if err := json.Unmarshal(jsonBytes, &unmarshalled); err != nil {
+				t.Fatalf("json.Unmarshal() = %v, want nil", err)
+			}
+
+			back := FromJSONRPCError(&unmarshalled)
 			var a2aBack *a2a.Error
 			if !errors.As(back, &a2aBack) {
 				t.Fatalf("Expected *a2a.Error")
@@ -318,8 +329,8 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 				t.Fatalf("Round-trip message mismatch (+got,-want):\n%s", diff)
 			}
 			errInfo := a2aBack.ErrorInfo()
-			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.PROTOCOL_DOMAIN {
-				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.PROTOCOL_DOMAIN)
+			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.ProtocolDomain {
+				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.ProtocolDomain)
 			}
 			if reason, ok := errInfo.Value["reason"].(string); !ok || reason != tc.wantReason {
 				t.Fatalf("Round-trip ErrorInfo reason = %q, want %q", reason, tc.wantReason)
@@ -341,7 +352,7 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 				foundDetailsInTypedDetails := false
 				structCount := 0
 				for _, td := range a2aBack.TypedDetails {
-					if td.TypeURL != "google.protobuf.Struct" {
+					if td.TypeURL != errordetails.StructType {
 						continue
 					}
 					structCount++
@@ -355,7 +366,7 @@ func TestJSONRPCError_RoundTrip(t *testing.T) {
 				wantStructCount := 1
 				if tc.typedDetails != nil {
 					for _, td := range tc.typedDetails {
-						if td.TypeURL == "google.protobuf.Struct" {
+						if td.TypeURL == errordetails.StructType {
 							wantStructCount++
 						}
 					}

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -201,7 +201,8 @@ func ConvertErrorBody(body *ErrorBodyJSON) error {
 }
 
 // FromRESTError converts an HTTP error response in google.rpc.Status format to an a2a error.
-func FromRESTError(resp *http.Response) error {	contentType := resp.Header.Get("Content-Type")
+func FromRESTError(resp *http.Response) error {
+	contentType := resp.Header.Get("Content-Type")
 	if !strings.HasPrefix(contentType, "application/json") {
 		return a2a.ErrServerError
 	}

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -85,11 +85,6 @@ func MakeDeletePushConfigPath(taskID, configID string) string {
 	return "/tasks/" + taskID + "/pushNotificationConfigs/" + configID
 }
 
-const (
-	errorInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
-	structType    = "type.googleapis.com/google.protobuf.Struct"
-)
-
 // ErrorInfo represents a google.rpc.ErrorInfo message in the details array.
 type ErrorInfo struct {
 	Type     string            `json:"@type"`
@@ -164,7 +159,7 @@ func ConvertErrorBody(body *ErrorBodyJSON) error {
 		var hint struct {
 			Type string `json:"@type"`
 		}
-		if json.Unmarshal(raw, &hint) == nil && hint.Type == errorInfoType {
+		if json.Unmarshal(raw, &hint) == nil && hint.Type == errordetails.ErrorInfoType {
 			var info ErrorInfo
 			if json.Unmarshal(raw, &info) != nil || info.Domain != a2a.ProtocolDomain {
 				continue
@@ -305,7 +300,7 @@ func ToRESTError(err error, taskID a2a.TaskID) *Error {
 			details = append(details, errordetails.NewFromStruct(a2aErr.Details))
 		}
 		for _, d := range a2aErr.TypedDetails {
-			if d.TypeURL == errorInfoType {
+			if d.TypeURL == errordetails.ErrorInfoType {
 				if rawMeta, ok := d.Value["metadata"]; ok {
 					if m, ok := utils.ToStringMap(rawMeta); ok {
 						maps.Copy(metadata, m)

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -16,6 +16,7 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/errordetails"
 )
 
 // MakeListTasksPath returns the REST path for listing tasks.
@@ -82,10 +84,7 @@ func MakeDeletePushConfigPath(taskID, configID string) string {
 	return "/tasks/" + taskID + "/pushNotificationConfigs/" + configID
 }
 
-const (
-	errorInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
-	errorDomain   = "a2a-protocol.org"
-)
+const errorInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
 
 // ErrorInfo represents a google.rpc.ErrorInfo message in the details array.
 type ErrorInfo struct {
@@ -97,10 +96,10 @@ type ErrorInfo struct {
 
 // StatusError represents the inner error object in a google.rpc.Status response.
 type StatusError struct {
-	Code    int    `json:"code"`
-	Status  string `json:"status"`
-	Message string `json:"message"`
-	Details []any  `json:"details,omitempty"`
+	Code    int                   `json:"code"`
+	Status  string                `json:"status"`
+	Message string                `json:"message"`
+	Details []*errordetails.Typed `json:"details,omitempty"`
 }
 
 // Error represents a google.rpc.Status error response per AIP-193.
@@ -114,72 +113,35 @@ func (e *Error) HTTPStatus() int {
 	return e.httpStatus
 }
 
-type errorDetails struct {
+var errorMappings = []struct {
+	err        error
 	httpStatus int
 	grpcStatus string
-	reason     string
+}{
+	{a2a.ErrParseError, http.StatusBadRequest, "INVALID_ARGUMENT"},
+	{a2a.ErrInvalidRequest, http.StatusBadRequest, "INVALID_ARGUMENT"},
+	{a2a.ErrMethodNotFound, http.StatusNotImplemented, "UNIMPLEMENTED"},
+	{a2a.ErrInvalidParams, http.StatusBadRequest, "INVALID_ARGUMENT"},
+	{a2a.ErrInternalError, http.StatusInternalServerError, "INTERNAL"},
+	{a2a.ErrServerError, http.StatusInternalServerError, "INTERNAL"},
+	{a2a.ErrTaskNotFound, http.StatusNotFound, "NOT_FOUND"},
+	{a2a.ErrTaskNotCancelable, http.StatusBadRequest, "FAILED_PRECONDITION"},
+	{a2a.ErrPushNotificationNotSupported, http.StatusBadRequest, "FAILED_PRECONDITION"},
+	{a2a.ErrUnsupportedOperation, http.StatusBadRequest, "FAILED_PRECONDITION"},
+	{a2a.ErrUnsupportedContentType, http.StatusBadRequest, "INVALID_ARGUMENT"},
+	{a2a.ErrInvalidAgentResponse, http.StatusInternalServerError, "INTERNAL"},
+	{a2a.ErrExtendedCardNotConfigured, http.StatusBadRequest, "FAILED_PRECONDITION"},
+	{a2a.ErrExtensionSupportRequired, http.StatusBadRequest, "FAILED_PRECONDITION"},
+	{a2a.ErrVersionNotSupported, http.StatusBadRequest, "FAILED_PRECONDITION"},
+	{a2a.ErrUnauthenticated, http.StatusUnauthorized, "UNAUTHENTICATED"},
+	{a2a.ErrUnauthorized, http.StatusForbidden, "PERMISSION_DENIED"},
+
+	{context.Canceled, 499, "CANCELLED"},
+	{context.DeadlineExceeded, http.StatusGatewayTimeout, "DEADLINE_EXCEEDED"},
 }
 
-var errToDetails = map[error]errorDetails{
-	a2a.ErrTaskNotFound: {
-		httpStatus: http.StatusNotFound,
-		grpcStatus: "NOT_FOUND",
-		reason:     "TASK_NOT_FOUND",
-	},
-	a2a.ErrTaskNotCancelable: {
-		httpStatus: http.StatusBadRequest,
-		grpcStatus: "FAILED_PRECONDITION",
-		reason:     "TASK_NOT_CANCELABLE",
-	},
-	a2a.ErrPushNotificationNotSupported: {
-		httpStatus: http.StatusNotImplemented,
-		grpcStatus: "UNIMPLEMENTED",
-		reason:     "PUSH_NOTIFICATION_NOT_SUPPORTED",
-	},
-	a2a.ErrUnsupportedOperation: {
-		httpStatus: http.StatusNotImplemented,
-		grpcStatus: "UNIMPLEMENTED",
-		reason:     "UNSUPPORTED_OPERATION",
-	},
-	a2a.ErrUnsupportedContentType: {
-		httpStatus: http.StatusBadRequest,
-		grpcStatus: "INVALID_ARGUMENT",
-		reason:     "UNSUPPORTED_CONTENT_TYPE",
-	},
-	a2a.ErrInvalidAgentResponse: {
-		httpStatus: http.StatusInternalServerError,
-		grpcStatus: "INTERNAL",
-		reason:     "INVALID_AGENT_RESPONSE",
-	},
-	a2a.ErrExtendedCardNotConfigured: {
-		httpStatus: http.StatusBadRequest,
-		grpcStatus: "FAILED_PRECONDITION",
-		reason:     "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
-	},
-	a2a.ErrExtensionSupportRequired: {
-		httpStatus: http.StatusBadRequest,
-		grpcStatus: "FAILED_PRECONDITION",
-		reason:     "EXTENSION_SUPPORT_REQUIRED",
-	},
-	a2a.ErrVersionNotSupported: {
-		httpStatus: http.StatusNotImplemented,
-		grpcStatus: "UNIMPLEMENTED",
-		reason:     "VERSION_NOT_SUPPORTED",
-	},
-	a2a.ErrParseError: {
-		httpStatus: http.StatusBadRequest,
-		grpcStatus: "INVALID_ARGUMENT",
-		reason:     "PARSE_ERROR",
-	},
-	a2a.ErrInvalidRequest: {
-		httpStatus: http.StatusBadRequest,
-		grpcStatus: "INVALID_ARGUMENT",
-		reason:     "INVALID_REQUEST",
-	},
-}
-
-// ToA2AError converts an HTTP error response in google.rpc.Status format to an a2a error.
-func ToA2AError(resp *http.Response) error {
+// FromRESTError converts an HTTP error response in google.rpc.Status format to an a2a error.
+func FromRESTError(resp *http.Response) error {
 	contentType := resp.Header.Get("Content-Type")
 	if !strings.HasPrefix(contentType, "application/json") {
 		return a2a.ErrServerError
@@ -194,55 +156,75 @@ func ToA2AError(resp *http.Response) error {
 		} `json:"error"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return fmt.Errorf("failed to decode error response: %w", err)
+		return fmt.Errorf("failed to decode error response: %w: %w", a2a.ErrParseError, err)
 	}
 
-	baseErr := a2a.ErrInternalError
-	details := map[string]any{}
+	var reason string
+	var typedDetails []*errordetails.Typed
+	errInfoMeta := make(map[string]string)
+	details := make(map[string]any)
+	firstStruct := true
+
 	for _, raw := range body.Error.Details {
 		var hint struct {
 			Type string `json:"@type"`
 		}
 		if json.Unmarshal(raw, &hint) == nil && hint.Type == errorInfoType {
 			var info ErrorInfo
-			if json.Unmarshal(raw, &info) != nil || info.Domain != errorDomain {
+			if json.Unmarshal(raw, &info) != nil || info.Domain != a2a.PROTOCOL_DOMAIN {
 				continue
 			}
-			for k, v := range info.Metadata {
-				details[k] = v
-			}
-			for err, d := range errToDetails {
-				if d.reason == info.Reason {
-					baseErr = err
-					break
-				}
-			}
+			reason = info.Reason
+			maps.Copy(errInfoMeta, info.Metadata)
 			continue
 		}
-		var extra map[string]any
+		var extra errordetails.Typed
 		if json.Unmarshal(raw, &extra) == nil {
-			maps.Copy(details, extra)
+			// Add the first struct to details
+			if firstStruct {
+				maps.Copy(details, extra.Value)
+				firstStruct = false
+			}
+			// Add all structs to typedDetails
+			typedDetails = append(typedDetails, &extra)
+		}
+	}
+
+	baseErr := a2a.ErrInternalError
+	for _, mapping := range errorMappings {
+		if r, ok := a2a.ErrorReason(mapping.err); ok && r == reason {
+			baseErr = mapping.err
+			break
 		}
 	}
 
 	out := a2a.NewError(baseErr, body.Error.Message)
+	if len(errInfoMeta) > 0 {
+		out = out.WithErrorInfoMeta(errInfoMeta)
+	}
 	if len(details) > 0 {
 		out = out.WithDetails(details)
 	}
+	out.TypedDetails = append(out.TypedDetails, typedDetails...)
 	return out
 }
 
 // ToRESTError converts an error and a [a2a.TaskID] to a REST [Error] in google.rpc.Status format.
 func ToRESTError(err error, taskID a2a.TaskID) *Error {
+	if err == nil {
+		return nil
+	}
 	httpStatus := http.StatusInternalServerError
 	grpcStatus := "INTERNAL"
 	reason := "INTERNAL_ERROR"
 
-	for sentinel, details := range errToDetails {
-		if errors.Is(err, sentinel) {
-			httpStatus = details.httpStatus
-			grpcStatus = details.grpcStatus
-			reason = details.reason
+	for _, mapping := range errorMappings {
+		if errors.Is(err, mapping.err) {
+			httpStatus = mapping.httpStatus
+			grpcStatus = mapping.grpcStatus
+			if r, ok := a2a.ErrorReason(mapping.err); ok {
+				reason = r
+			}
 			break
 		}
 	}
@@ -254,29 +236,29 @@ func ToRESTError(err error, taskID a2a.TaskID) *Error {
 		metadata["taskId"] = string(taskID)
 	}
 
-	additionalMeta := map[string]any{}
 	var a2aErr *a2a.Error
+	var details []*errordetails.Typed
+
 	if errors.As(err, &a2aErr) {
-		for k, v := range a2aErr.Details {
-			if s, ok := v.(string); ok {
-				metadata[k] = s
+		if len(a2aErr.Details) > 0 {
+			details = append(details, errordetails.NewTyped("google.protobuf.Struct", a2aErr.Details))
+		}
+		for _, d := range a2aErr.TypedDetails {
+			if d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
+				if m, ok := d.Value["metadata"].(map[string]string); ok {
+					maps.Copy(metadata, m)
+				}
 			} else {
-				additionalMeta[k] = v
+				details = append(details, d)
 			}
 		}
 	}
 
-	details := []any{
-		ErrorInfo{
-			Type:     errorInfoType,
-			Reason:   reason,
-			Domain:   errorDomain,
-			Metadata: metadata,
-		},
-	}
-	if len(additionalMeta) > 0 {
-		details = append(details, additionalMeta)
-	}
+	details = append(details, errordetails.NewTyped(errorInfoType, map[string]any{
+		"reason":   reason,
+		"domain":   a2a.PROTOCOL_DOMAIN,
+		"metadata": metadata,
+	}))
 
 	return &Error{
 		httpStatus: httpStatus,

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
+	"github.com/a2aproject/a2a-go/v2/internal/utils"
 )
 
 // MakeListTasksPath returns the REST path for listing tasks.
@@ -84,7 +85,10 @@ func MakeDeletePushConfigPath(taskID, configID string) string {
 	return "/tasks/" + taskID + "/pushNotificationConfigs/" + configID
 }
 
-const errorInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
+const (
+	errorInfoType = "type.googleapis.com/google.rpc.ErrorInfo"
+	structType    = "type.googleapis.com/google.protobuf.Struct"
+)
 
 // ErrorInfo represents a google.rpc.ErrorInfo message in the details array.
 type ErrorInfo struct {
@@ -162,7 +166,7 @@ func ConvertErrorBody(body *ErrorBodyJSON) error {
 		}
 		if json.Unmarshal(raw, &hint) == nil && hint.Type == errorInfoType {
 			var info ErrorInfo
-			if json.Unmarshal(raw, &info) != nil || info.Domain != a2a.PROTOCOL_DOMAIN {
+			if json.Unmarshal(raw, &info) != nil || info.Domain != a2a.ProtocolDomain {
 				continue
 			}
 			reason = info.Reason
@@ -183,7 +187,7 @@ func ConvertErrorBody(body *ErrorBodyJSON) error {
 
 	baseErr := a2a.ErrInternalError
 	for _, mapping := range errorMappings {
-		if r, ok := a2a.ErrorReason(mapping.err); ok && r == reason {
+		if a2a.ErrorReason(mapping.err) == reason {
 			baseErr = mapping.err
 			break
 		}
@@ -281,9 +285,7 @@ func ToRESTError(err error, taskID a2a.TaskID) *Error {
 		if errors.Is(err, mapping.err) {
 			httpStatus = mapping.httpStatus
 			grpcStatus = mapping.grpcStatus
-			if r, ok := a2a.ErrorReason(mapping.err); ok {
-				reason = r
-			}
+			reason = a2a.ErrorReason(mapping.err)
 			break
 		}
 	}
@@ -300,12 +302,14 @@ func ToRESTError(err error, taskID a2a.TaskID) *Error {
 
 	if errors.As(err, &a2aErr) {
 		if len(a2aErr.Details) > 0 {
-			details = append(details, errordetails.NewTyped("google.protobuf.Struct", a2aErr.Details))
+			details = append(details, errordetails.NewFromStruct(a2aErr.Details))
 		}
 		for _, d := range a2aErr.TypedDetails {
-			if d.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
-				if m, ok := d.Value["metadata"].(map[string]string); ok {
-					maps.Copy(metadata, m)
+			if d.TypeURL == errorInfoType {
+				if rawMeta, ok := d.Value["metadata"]; ok {
+					if m, ok := utils.ToStringMap(rawMeta); ok {
+						maps.Copy(metadata, m)
+					}
 				}
 			} else {
 				details = append(details, d)
@@ -313,11 +317,8 @@ func ToRESTError(err error, taskID a2a.TaskID) *Error {
 		}
 	}
 
-	details = append(details, errordetails.NewTyped(errorInfoType, map[string]any{
-		"reason":   reason,
-		"domain":   a2a.PROTOCOL_DOMAIN,
-		"metadata": metadata,
-	}))
+	errorInfo := errordetails.NewErrorInfo(reason, a2a.ProtocolDomain, metadata)
+	details = append(details, errorInfo)
 
 	return &Error{
 		httpStatus: httpStatus,

--- a/internal/rest/rest_test.go
+++ b/internal/rest/rest_test.go
@@ -16,6 +16,7 @@ package rest
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,34 +26,378 @@ import (
 	"testing"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/errordetails"
+	"github.com/google/go-cmp/cmp"
 )
 
-func makeStatusBody(code int, status, message, reason string) string {
-	return fmt.Sprintf(`{
-		"error": {
-			"code": %d,
-			"status": %q,
-			"message": %s,
-			"details": [
-				{
-					"@type": "type.googleapis.com/google.rpc.ErrorInfo",
-					"reason": %q,
-					"domain": "a2a-protocol.org"
-				}
-			]
-		}
-	}`, code, status, mustJSON(message), reason)
-}
+func TestRESTError_RoundTrip(t *testing.T) {
+	t.Parallel()
 
-func mustJSON(v any) string {
-	b, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
+	tests := []struct {
+		name         string
+		inputError   *a2a.Error
+		taskID       a2a.TaskID
+		typedDetails []*errordetails.Typed
+		// midpoint (REST response) assertions
+		wantHTTPStatus int
+		wantGRPCStatus string
+		wantReason     string
+		wantMeta       map[string]string
+		// final (A2A error) assertions
+		wantBaseErr error
+		wantMessage string
+		wantDetails map[string]any
+	}{
+		{
+			name: "TaskNotFound with details and metadata",
+			inputError: a2a.NewError(a2a.ErrTaskNotFound, "not found").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantHTTPStatus: http.StatusNotFound,
+			wantGRPCStatus: "NOT_FOUND",
+			wantReason:     "TASK_NOT_FOUND",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrTaskNotFound,
+			wantMessage: "not found",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "Wrapped ParseError with details and metadata",
+			inputError: a2a.NewError(fmt.Errorf("wrapped error: %w", a2a.ErrParseError), "wrapped parse error").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "INVALID_ARGUMENT",
+			wantReason:     "PARSE_ERROR",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrParseError,
+			wantMessage: "wrapped parse error",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "InvalidParams with details and metadata",
+			inputError: a2a.NewError(a2a.ErrInvalidParams, "invalid params").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "INVALID_ARGUMENT",
+			wantReason:     "INVALID_PARAMS",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrInvalidParams,
+			wantMessage: "invalid params",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "ExtensionSupportRequired with details, typed details and metadata",
+			inputError: a2a.NewError(a2a.ErrExtensionSupportRequired, "extension support required").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			typedDetails: []*errordetails.Typed{
+				errordetails.NewTyped("google.protobuf.Struct", map[string]any{
+					"extra": "should not leak into details",
+				}),
+			},
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "FAILED_PRECONDITION",
+			wantReason:     "EXTENSION_SUPPORT_REQUIRED",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrExtensionSupportRequired,
+			wantMessage: "extension support required",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name:           "InvalidRequest without extra details",
+			inputError:     a2a.NewError(a2a.ErrInvalidRequest, "invalid request"),
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "INVALID_ARGUMENT",
+			wantReason:     "INVALID_REQUEST",
+			wantBaseErr:    a2a.ErrInvalidRequest,
+			wantMessage:    "invalid request",
+		},
+		{
+			name: "MethodNotFound with details only",
+			inputError: a2a.NewError(a2a.ErrMethodNotFound, "method not found").WithDetails(map[string]any{
+				"num": float64(123),
+			}),
+			wantHTTPStatus: http.StatusNotImplemented,
+			wantGRPCStatus: "UNIMPLEMENTED",
+			wantReason:     "METHOD_NOT_FOUND",
+			wantBaseErr:    a2a.ErrMethodNotFound,
+			wantMessage:    "method not found",
+			wantDetails: map[string]any{
+				"num": float64(123),
+			},
+		},
+		{
+			name: "ServerError with ErrorInfo only",
+			inputError: a2a.NewError(a2a.ErrServerError, "server error").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}),
+			wantHTTPStatus: http.StatusInternalServerError,
+			wantGRPCStatus: "INTERNAL",
+			wantReason:     "SERVER_ERROR",
+			wantMeta: map[string]string{
+				"foo": "bar",
+			},
+			wantBaseErr: a2a.ErrServerError,
+			wantMessage: "server error",
+		},
+		{
+			name: "TaskNotCancelable ErrorInfo override",
+			inputError: a2a.NewError(a2a.ErrTaskNotCancelable, "task not cancelable").WithErrorInfoMeta(map[string]string{
+				"foo": "bar",
+			}).WithErrorInfoMeta(map[string]string{
+				"new_key": "new_value",
+			}),
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "FAILED_PRECONDITION",
+			wantReason:     "TASK_NOT_CANCELABLE",
+			wantMeta: map[string]string{
+				"new_key": "new_value",
+			},
+			wantBaseErr: a2a.ErrTaskNotCancelable,
+			wantMessage: "task not cancelable",
+		},
+		{
+			name:           "PushNotificationNotSupported with task id",
+			inputError:     a2a.NewError(a2a.ErrPushNotificationNotSupported, "push notification not supported"),
+			taskID:         a2a.TaskID("task-id"),
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "FAILED_PRECONDITION",
+			wantReason:     "PUSH_NOTIFICATION_NOT_SUPPORTED",
+			wantMeta: map[string]string{
+				"taskId": "task-id",
+			},
+			wantBaseErr: a2a.ErrPushNotificationNotSupported,
+			wantMessage: "push notification not supported",
+		},
+		{
+			name:           "UnsupportedOperation",
+			inputError:     a2a.NewError(a2a.ErrUnsupportedOperation, "unsupported operation"),
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "FAILED_PRECONDITION",
+			wantReason:     "UNSUPPORTED_OPERATION",
+			wantBaseErr:    a2a.ErrUnsupportedOperation,
+			wantMessage:    "unsupported operation",
+		},
+		{
+			name:           "UnsupportedContentType",
+			inputError:     a2a.NewError(a2a.ErrUnsupportedContentType, "unsupported content type"),
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "INVALID_ARGUMENT",
+			wantReason:     "CONTENT_TYPE_NOT_SUPPORTED",
+			wantBaseErr:    a2a.ErrUnsupportedContentType,
+			wantMessage:    "unsupported content type",
+		},
+		{
+			name:           "InvalidAgentResponse",
+			inputError:     a2a.NewError(a2a.ErrInvalidAgentResponse, "invalid agent response"),
+			wantHTTPStatus: http.StatusInternalServerError,
+			wantGRPCStatus: "INTERNAL",
+			wantReason:     "INVALID_AGENT_RESPONSE",
+			wantBaseErr:    a2a.ErrInvalidAgentResponse,
+			wantMessage:    "invalid agent response",
+		},
+		{
+			name:           "ExtendedCardNotConfigured",
+			inputError:     a2a.NewError(a2a.ErrExtendedCardNotConfigured, "extended card not configured"),
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "FAILED_PRECONDITION",
+			wantReason:     "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
+			wantBaseErr:    a2a.ErrExtendedCardNotConfigured,
+			wantMessage:    "extended card not configured",
+		},
+		{
+			name:           "VersionNotSupported",
+			inputError:     a2a.NewError(a2a.ErrVersionNotSupported, "version not supported"),
+			wantHTTPStatus: http.StatusBadRequest,
+			wantGRPCStatus: "FAILED_PRECONDITION",
+			wantReason:     "VERSION_NOT_SUPPORTED",
+			wantBaseErr:    a2a.ErrVersionNotSupported,
+			wantMessage:    "version not supported",
+		},
+		{
+			name:           "Unauthenticated",
+			inputError:     a2a.NewError(a2a.ErrUnauthenticated, "unauthenticated"),
+			wantHTTPStatus: http.StatusUnauthorized,
+			wantGRPCStatus: "UNAUTHENTICATED",
+			wantReason:     "UNAUTHENTICATED",
+			wantBaseErr:    a2a.ErrUnauthenticated,
+			wantMessage:    "unauthenticated",
+		},
+		{
+			name:           "Unauthorized",
+			inputError:     a2a.NewError(a2a.ErrUnauthorized, "unauthorized"),
+			wantHTTPStatus: http.StatusForbidden,
+			wantGRPCStatus: "PERMISSION_DENIED",
+			wantReason:     "UNAUTHORIZED",
+			wantBaseErr:    a2a.ErrUnauthorized,
+			wantMessage:    "unauthorized",
+		},
+		{
+			name:           "	",
+			inputError:     a2a.NewError(a2a.ErrInternalError, "internal error"),
+			wantHTTPStatus: http.StatusInternalServerError,
+			wantGRPCStatus: "INTERNAL",
+			wantReason:     "INTERNAL_ERROR",
+			wantBaseErr:    a2a.ErrInternalError,
+			wantMessage:    "internal error",
+		},
+		{
+			name:           "UnknownError roundtrips to Internal",
+			inputError:     a2a.NewError(errors.New("unknown error"), "unknown error"),
+			wantHTTPStatus: http.StatusInternalServerError,
+			wantGRPCStatus: "INTERNAL",
+			wantReason:     "INTERNAL_ERROR",
+			wantBaseErr:    a2a.ErrInternalError,
+			wantMessage:    "unknown error",
+		},
 	}
-	return string(b)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tc.typedDetails != nil {
+				tc.inputError.TypedDetails = append(tc.inputError.TypedDetails, tc.typedDetails...)
+			}
+
+			restErr := ToRESTError(tc.inputError, tc.taskID)
+			if restErr.HTTPStatus() != tc.wantHTTPStatus {
+				t.Fatalf("ToRESTError() HTTPStatus = %v, want %v", restErr.HTTPStatus(), tc.wantHTTPStatus)
+			}
+			if restErr.Err.Code != tc.wantHTTPStatus {
+				t.Fatalf("ToRESTError() Err.Code = %v, want %v", restErr.Err.Code, tc.wantHTTPStatus)
+			}
+			if restErr.Err.Status != tc.wantGRPCStatus {
+				t.Fatalf("ToRESTError() Err.Status = %v, want %v", restErr.Err.Status, tc.wantGRPCStatus)
+			}
+			if restErr.Err.Message != tc.wantMessage {
+				t.Fatalf("ToRESTError() Err.Message = %v, want %v", restErr.Err.Message, tc.wantMessage)
+			}
+
+			var foundErrorInfo bool
+			for _, typed := range restErr.Err.Details {
+				if typed.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
+					foundErrorInfo = true
+					if typed.Value["reason"] != tc.wantReason {
+						t.Errorf("ErrorInfo.Reason = %v, want %v", typed.Value["reason"], tc.wantReason)
+					}
+					if typed.Value["domain"] != a2a.PROTOCOL_DOMAIN {
+						t.Errorf("ErrorInfo.Domain = %v, want %v", typed.Value["domain"], a2a.PROTOCOL_DOMAIN)
+					}
+					metadata, ok := typed.Value["metadata"].(map[string]string)
+					if !ok {
+						t.Fatalf("ErrorInfo.Metadata = %v, want %v", typed.Value["metadata"], tc.wantMeta)
+					}
+					if timestamp, ok := metadata["timestamp"]; !ok || timestamp == "" {
+						t.Fatalf("ErrorInfo.Metadata = %v, want %v", metadata, tc.wantMeta)
+					}
+					for key, value := range tc.wantMeta {
+						if metadata[key] != value {
+							t.Errorf("ErrorInfo.Metadata = %v, want %v", metadata, tc.wantMeta)
+						}
+					}
+				}
+			}
+			if !foundErrorInfo {
+				t.Errorf("ErrorInfo not found in details")
+			}
+
+			restResp := toHTTPResponse(t, restErr)
+			back := FromRESTError(restResp)
+
+			var a2aBack *a2a.Error
+			if !errors.As(back, &a2aBack) {
+				t.Fatalf("Expected *a2a.Error")
+			}
+			if !errors.Is(a2aBack.Err, tc.wantBaseErr) {
+				t.Fatalf("Round-trip error = %v, want %v", a2aBack.Err, tc.wantBaseErr)
+			}
+			if diff := cmp.Diff(tc.wantDetails, a2aBack.Details); diff != "" {
+				t.Fatalf("Round-trip details mismatch (+got,-want):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantMessage, a2aBack.Message); diff != "" {
+				t.Fatalf("Round-trip message mismatch (+got,-want):\n%s", diff)
+			}
+			errInfo := a2aBack.ErrorInfo()
+			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.PROTOCOL_DOMAIN {
+				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.PROTOCOL_DOMAIN)
+			}
+			if reason, ok := errInfo.Value["reason"].(string); !ok || reason != tc.wantReason {
+				t.Fatalf("Round-trip ErrorInfo reason = %q, want %q", reason, tc.wantReason)
+			}
+			metadata, ok := errInfo.Value["metadata"].(map[string]string)
+			if !ok {
+				t.Fatalf("Round-trip ErrorInfo metadata not found or wrong type: %v", errInfo.Value["metadata"])
+			}
+			if timestamp, ok := metadata["timestamp"]; !ok || timestamp == "" {
+				t.Fatalf("Round-trip ErrorInfo metadata mismatch: key=%s, got=%q, want=%q", "timestamp", timestamp, "")
+			}
+			for key, value := range tc.wantMeta {
+				if metadata[key] != value {
+					t.Fatalf("Round-trip ErrorInfo metadata mismatch: key=%s, got=%q, want=%q", key, metadata[key], value)
+				}
+			}
+
+			if tc.wantDetails != nil {
+				foundDetailsInTypedDetails := false
+				structCount := 0
+				for _, td := range a2aBack.TypedDetails {
+					if td.TypeURL != "google.protobuf.Struct" {
+						continue
+					}
+					structCount++
+					if cmp.Equal(tc.wantDetails, td.Value) {
+						foundDetailsInTypedDetails = true
+					}
+				}
+				if !foundDetailsInTypedDetails {
+					t.Fatalf("Round-trip TypedDetails missing struct with expected details")
+				}
+				wantStructCount := 1
+				if tc.typedDetails != nil {
+					for _, td := range tc.typedDetails {
+						if td.TypeURL == "google.protobuf.Struct" {
+							wantStructCount++
+						}
+					}
+				}
+				if structCount != wantStructCount {
+					t.Fatalf("Round-trip TypedDetails struct count = %d, want %d", structCount, wantStructCount)
+				}
+			}
+		})
+	}
 }
 
-func TestError_ToA2AError(t *testing.T) {
+func TestFromRESTErrorEdgeCases(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		contentType  string
@@ -61,343 +406,121 @@ func TestError_ToA2AError(t *testing.T) {
 		wantMessage  string
 	}{
 		{
-			name:         "Task Not Found",
-			contentType:  "application/json",
-			responseBody: makeStatusBody(404, "NOT_FOUND", "The specified task ID does not exist", "TASK_NOT_FOUND"),
-			wantError:    a2a.ErrTaskNotFound,
-			wantMessage:  "The specified task ID does not exist",
-		},
-		{
-			name:         "Task Not Cancelable",
-			contentType:  "application/json",
-			responseBody: makeStatusBody(400, "FAILED_PRECONDITION", "The specified task is not cancelable", "TASK_NOT_CANCELABLE"),
-			wantError:    a2a.ErrTaskNotCancelable,
-			wantMessage:  "The specified task is not cancelable",
-		},
-		{
-			name:         "Push Notification Not Supported",
-			contentType:  "application/json",
-			responseBody: makeStatusBody(501, "UNIMPLEMENTED", "This agent does not support push notifications", "PUSH_NOTIFICATION_NOT_SUPPORTED"),
-			wantError:    a2a.ErrPushNotificationNotSupported,
-			wantMessage:  "This agent does not support push notifications",
-		},
-		{
-			name:         "Unsupported Operation",
-			contentType:  "application/json",
-			responseBody: makeStatusBody(501, "UNIMPLEMENTED", "Operation not allowed", "UNSUPPORTED_OPERATION"),
-			wantError:    a2a.ErrUnsupportedOperation,
-			wantMessage:  "Operation not allowed",
-		},
-		{
-			name:         "Unsupported Content Type",
-			contentType:  "application/json",
-			responseBody: makeStatusBody(400, "INVALID_ARGUMENT", "Content type not allowed", "UNSUPPORTED_CONTENT_TYPE"),
-			wantError:    a2a.ErrUnsupportedContentType,
-			wantMessage:  "Content type not allowed",
-		},
-		{
-			name:         "Invalid Agent Response",
-			contentType:  "application/json",
-			responseBody: makeStatusBody(500, "INTERNAL", "The agent response is not valid", "INVALID_AGENT_RESPONSE"),
-			wantError:    a2a.ErrInvalidAgentResponse,
-			wantMessage:  "The agent response is not valid",
-		},
-		{
-			name:         "Extended Agent Card not configured",
-			contentType:  "application/json",
-			responseBody: makeStatusBody(400, "FAILED_PRECONDITION", "The Extended Agent Card for this agent is not configured", "EXTENDED_AGENT_CARD_NOT_CONFIGURED"),
-			wantError:    a2a.ErrExtendedCardNotConfigured,
-			wantMessage:  "The Extended Agent Card for this agent is not configured",
-		},
-		{
-			name:         "Extension support required",
-			contentType:  "application/json",
-			responseBody: makeStatusBody(400, "FAILED_PRECONDITION", "Extension support is required for this agent", "EXTENSION_SUPPORT_REQUIRED"),
-			wantError:    a2a.ErrExtensionSupportRequired,
-			wantMessage:  "Extension support is required for this agent",
-		},
-		{
-			name:         "Version not supported",
-			contentType:  "application/json",
-			responseBody: makeStatusBody(501, "UNIMPLEMENTED", "This version is not supported", "VERSION_NOT_SUPPORTED"),
-			wantError:    a2a.ErrVersionNotSupported,
-			wantMessage:  "This version is not supported",
-		},
-		{
-			name:        "Unknown reason defaults to InternalError",
-			contentType: "application/json",
-			responseBody: `{
-				"error": {
-					"code": 500,
-					"status": "INTERNAL",
-					"message": "Something unexpected happened",
-					"details": [
-						{
-							"@type": "type.googleapis.com/google.rpc.ErrorInfo",
-							"reason": "UNKNOWN_REASON",
-							"domain": "a2a-protocol.org"
-						}
-					]
-				}
-			}`,
-			wantError:   a2a.ErrInternalError,
-			wantMessage: "Something unexpected happened",
-		},
-		{
 			name:         "Invalid Content-Type",
 			contentType:  "text/plain",
 			responseBody: `not json`,
 			wantError:    a2a.ErrServerError,
 		},
+		{
+			name:         "Invalid JSON",
+			contentType:  "application/json",
+			responseBody: `not json`,
+			wantError:    a2a.ErrParseError,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			resp := &http.Response{
 				Header: http.Header{"Content-Type": []string{tt.contentType}},
 				Body:   io.NopCloser(bytes.NewBufferString(tt.responseBody)),
 			}
 
-			gotErr := ToA2AError(resp)
+			gotErr := FromRESTError(resp)
 
 			if !errors.Is(gotErr, tt.wantError) {
-				t.Fatalf("ToA2AError() error = %v, want %v", gotErr, tt.wantError)
+				t.Fatalf("FromRESTError() error = %v, want %v", gotErr, tt.wantError)
 			}
 
 			if tt.wantMessage != "" {
 				if !strings.Contains(gotErr.Error(), tt.wantMessage) {
-					t.Fatalf("ToA2AError() error message %q does not contain %q", gotErr.Error(), tt.wantMessage)
+					t.Fatalf("FromRESTError() error message %q does not contain %q", gotErr.Error(), tt.wantMessage)
 				}
 			}
 		})
 	}
 }
 
-func TestToRESTError(t *testing.T) {
+func TestToRESTErrorEdgeCases(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
-		name           string
-		err            error
-		taskID         string
-		wantHTTPStatus int
-		wantGRPCStatus string
-		wantReason     string
+		name    string
+		err     error
+		want    *Error
+		wantNil bool
 	}{
 		{
-			name:           "Task Not Found",
-			err:            a2a.ErrTaskNotFound,
-			taskID:         "task-123",
-			wantHTTPStatus: http.StatusNotFound,
-			wantGRPCStatus: "NOT_FOUND",
-			wantReason:     "TASK_NOT_FOUND",
+			name:    "nil error",
+			err:     nil,
+			wantNil: true,
 		},
 		{
-			name:           "Task Not Cancelable",
-			err:            a2a.ErrTaskNotCancelable,
-			taskID:         "task-123",
-			wantHTTPStatus: http.StatusBadRequest,
-			wantGRPCStatus: "FAILED_PRECONDITION",
-			wantReason:     "TASK_NOT_CANCELABLE",
+			name: "plain sentinel error",
+			err:  a2a.ErrTaskNotFound,
+			want: &Error{httpStatus: http.StatusNotFound, Err: StatusError{Code: http.StatusNotFound, Status: "NOT_FOUND", Message: "task not found"}},
 		},
 		{
-			name:           "Push Notification Not Supported",
-			err:            a2a.ErrPushNotificationNotSupported,
-			taskID:         "task-123",
-			wantHTTPStatus: http.StatusNotImplemented,
-			wantGRPCStatus: "UNIMPLEMENTED",
-			wantReason:     "PUSH_NOTIFICATION_NOT_SUPPORTED",
+			name: "wrapped sentinel error",
+			err:  fmt.Errorf("wrapping: %w", a2a.ErrParseError),
+			want: &Error{httpStatus: http.StatusBadRequest, Err: StatusError{Code: http.StatusBadRequest, Status: "INVALID_ARGUMENT", Message: "wrapping: parse error"}},
 		},
 		{
-			name:           "Unsupported Operation",
-			err:            a2a.ErrUnsupportedOperation,
-			taskID:         "task-123",
-			wantHTTPStatus: http.StatusNotImplemented,
-			wantGRPCStatus: "UNIMPLEMENTED",
-			wantReason:     "UNSUPPORTED_OPERATION",
+			name: "context canceled",
+			err:  context.Canceled,
+			want: &Error{httpStatus: 499, Err: StatusError{Code: 499, Status: "CANCELLED", Message: "context canceled"}},
 		},
 		{
-			name:           "Content Type Not Supported",
-			err:            a2a.ErrUnsupportedContentType,
-			taskID:         "task-123",
-			wantHTTPStatus: http.StatusBadRequest,
-			wantGRPCStatus: "INVALID_ARGUMENT",
-			wantReason:     "UNSUPPORTED_CONTENT_TYPE",
+			name: "context deadline exceeded",
+			err:  context.DeadlineExceeded,
+			want: &Error{httpStatus: http.StatusGatewayTimeout, Err: StatusError{Code: http.StatusGatewayTimeout, Status: "DEADLINE_EXCEEDED", Message: "context deadline exceeded"}},
 		},
 		{
-			name:           "Invalid Agent Response",
-			err:            a2a.ErrInvalidAgentResponse,
-			wantHTTPStatus: http.StatusInternalServerError,
-			wantGRPCStatus: "INTERNAL",
-			wantReason:     "INVALID_AGENT_RESPONSE",
-		},
-		{
-			name:           "Extended Agent Card Not Configured",
-			err:            a2a.ErrExtendedCardNotConfigured,
-			wantHTTPStatus: http.StatusBadRequest,
-			wantGRPCStatus: "FAILED_PRECONDITION",
-			wantReason:     "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
-		},
-		{
-			name:           "Extension Support Required",
-			err:            a2a.ErrExtensionSupportRequired,
-			wantHTTPStatus: http.StatusBadRequest,
-			wantGRPCStatus: "FAILED_PRECONDITION",
-			wantReason:     "EXTENSION_SUPPORT_REQUIRED",
-		},
-		{
-			name:           "Version Not Supported",
-			err:            a2a.ErrVersionNotSupported,
-			wantHTTPStatus: http.StatusNotImplemented,
-			wantGRPCStatus: "UNIMPLEMENTED",
-			wantReason:     "VERSION_NOT_SUPPORTED",
-		},
-		{
-			name:           "Parse Error",
-			err:            a2a.ErrParseError,
-			wantHTTPStatus: http.StatusBadRequest,
-			wantGRPCStatus: "INVALID_ARGUMENT",
-			wantReason:     "PARSE_ERROR",
-		},
-		{
-			name:           "Invalid Request",
-			err:            a2a.ErrInvalidRequest,
-			wantHTTPStatus: http.StatusBadRequest,
-			wantGRPCStatus: "INVALID_ARGUMENT",
-			wantReason:     "INVALID_REQUEST",
+			name: "unknown error",
+			err:  errors.New("some unknown error"),
+			want: &Error{httpStatus: http.StatusInternalServerError, Err: StatusError{Code: http.StatusInternalServerError, Status: "INTERNAL", Message: "some unknown error"}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ToRESTError(tt.err, a2a.TaskID(tt.taskID))
-
-			if got.HTTPStatus() != tt.wantHTTPStatus {
-				t.Fatalf("ToRESTError() HTTPStatus() = %v, want %v", got.HTTPStatus(), tt.wantHTTPStatus)
-			}
-			if got.Err.Code != tt.wantHTTPStatus {
-				t.Fatalf("ToRESTError() Err.Code = %v, want %v", got.Err.Code, tt.wantHTTPStatus)
-			}
-			if got.Err.Status != tt.wantGRPCStatus {
-				t.Fatalf("ToRESTError() Err.Status = %v, want %v", got.Err.Status, tt.wantGRPCStatus)
-			}
-			if got.Err.Message == "" {
-				t.Fatal("ToRESTError() Err.Message is empty")
-			}
-			if len(got.Err.Details) == 0 {
-				t.Fatal("ToRESTError() Err.Details is empty")
-			}
-			info, ok := got.Err.Details[0].(ErrorInfo)
-			if !ok {
-				t.Fatalf("ToRESTError() first detail is %T, want ErrorInfo", got.Err.Details[0])
-			}
-			if info.Reason != tt.wantReason {
-				t.Fatalf("ToRESTError() ErrorInfo.Reason = %v, want %v", info.Reason, tt.wantReason)
-			}
-			if info.Domain != "a2a-protocol.org" {
-				t.Fatalf("ToRESTError() ErrorInfo.Domain = %v, want a2a-protocol.org", info.Domain)
-			}
-			if tt.taskID != "" {
-				if info.Metadata["taskId"] != tt.taskID {
-					t.Fatalf("ToRESTError() ErrorInfo.Metadata[taskId] = %v, want %v", info.Metadata["taskId"], tt.taskID)
-				}
-			}
-		})
-	}
-}
-
-func TestToRESTError_RoundTrip(t *testing.T) {
-	errs := []error{
-		a2a.ErrTaskNotFound,
-		a2a.ErrTaskNotCancelable,
-		a2a.ErrPushNotificationNotSupported,
-		a2a.ErrUnsupportedOperation,
-		a2a.ErrUnsupportedContentType,
-		a2a.ErrInvalidAgentResponse,
-		a2a.ErrExtendedCardNotConfigured,
-		a2a.ErrExtensionSupportRequired,
-		a2a.ErrVersionNotSupported,
-		a2a.ErrParseError,
-		a2a.ErrInvalidRequest,
-	}
-
-	for _, sentinel := range errs {
-		t.Run(sentinel.Error(), func(t *testing.T) {
 			t.Parallel()
 
-			restErr := ToRESTError(sentinel, "task-rt")
-			body, err := json.Marshal(restErr)
-			if err != nil {
-				t.Fatalf("json.Marshal() error = %v", err)
+			got := ToRESTError(tt.err, "")
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("ToRESTError() = %v, want nil", got)
+				}
+				return
 			}
 
-			resp := &http.Response{
-				Header: http.Header{"Content-Type": []string{"application/json"}},
-				Body:   io.NopCloser(bytes.NewBuffer(body)),
+			if got.HTTPStatus() != tt.want.HTTPStatus() {
+				t.Fatalf("ToRESTError() HTTPStatus() = %v, want %v", got.HTTPStatus(), tt.want.HTTPStatus())
 			}
-			got := ToA2AError(resp)
-			if !errors.Is(got, sentinel) {
-				t.Fatalf("ToA2AError(ToRESTError(%v)) = %v, want errors.Is to match", sentinel, got)
+			if got.Err.Code != tt.want.Err.Code {
+				t.Fatalf("ToRESTError() Err.Code = %v, want %v", got.Err.Code, tt.want.Err.Code)
 			}
-
-			var a2aErr *a2a.Error
-			if !errors.As(got, &a2aErr) {
-				t.Fatalf("ToA2AError() returned %T, want *a2a.Error", got)
+			if got.Err.Status != tt.want.Err.Status {
+				t.Fatalf("ToRESTError() Err.Status = %v, want %v", got.Err.Status, tt.want.Err.Status)
 			}
-			if a2aErr.Details["taskId"] != "task-rt" {
-				t.Fatalf("ToA2AError() Details[taskId] = %v, want task-rt", a2aErr.Details["taskId"])
-			}
-			if _, ok := a2aErr.Details["timestamp"]; !ok {
-				t.Fatal("ToA2AError() Details[timestamp] is missing")
+			if got.Err.Message != tt.want.Err.Message {
+				t.Fatalf("ToRESTError() Err.Message = %v, want %v", got.Err.Message, tt.want.Err.Message)
 			}
 		})
 	}
 }
 
-func TestToRESTError_NonStringDetails(t *testing.T) {
-	t.Parallel()
-
-	src := a2a.NewError(a2a.ErrTaskNotFound, "not found").WithDetails(map[string]any{
-		"foo": "bar",
-		"num": 123,
-	})
-
-	restErr := ToRESTError(src, "task-x")
-
-	if len(restErr.Err.Details) != 2 {
-		t.Fatalf("ToRESTError() len(Details) = %d, want 2", len(restErr.Err.Details))
-	}
-	info, ok := restErr.Err.Details[0].(ErrorInfo)
-	if !ok {
-		t.Fatalf("ToRESTError() Details[0] is %T, want ErrorInfo", restErr.Err.Details[0])
-	}
-	if info.Metadata["foo"] != "bar" {
-		t.Fatalf("ErrorInfo.Metadata[foo] = %v, want bar", info.Metadata["foo"])
-	}
-	extra, ok := restErr.Err.Details[1].(map[string]any)
-	if !ok {
-		t.Fatalf("ToRESTError() Details[1] is %T, want map[string]any", restErr.Err.Details[1])
-	}
-	if extra["num"] != 123 {
-		t.Fatalf("Details[1][num] = %v, want 123", extra["num"])
-	}
-
+func toHTTPResponse(t *testing.T, restErr *Error) *http.Response {
+	t.Helper()
 	body, err := json.Marshal(restErr)
 	if err != nil {
-		t.Fatalf("json.Marshal() error = %v", err)
+		t.Fatalf("failed to marshal RESTError: %v", err)
 	}
-	resp := &http.Response{
-		Header: http.Header{"Content-Type": []string{"application/json"}},
-		Body:   io.NopCloser(bytes.NewBuffer(body)),
-	}
-	got := ToA2AError(resp)
-
-	var a2aErr *a2a.Error
-	if !errors.As(got, &a2aErr) {
-		t.Fatalf("ToA2AError() returned %T, want *a2a.Error", got)
-	}
-	if a2aErr.Details["foo"] != "bar" {
-		t.Fatalf("ToA2AError() Details[foo] = %v, want bar", a2aErr.Details["foo"])
-	}
-	if a2aErr.Details["num"].(float64) != 123 {
-		t.Fatalf("ToA2AError() Details[num] = %v, want 123", a2aErr.Details["num"])
+	return &http.Response{
+		StatusCode: restErr.HTTPStatus(),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBuffer(body)),
 	}
 }

--- a/internal/rest/rest_test.go
+++ b/internal/rest/rest_test.go
@@ -113,7 +113,7 @@ func TestRESTError_RoundTrip(t *testing.T) {
 				"num": float64(123),
 			}),
 			typedDetails: []*errordetails.Typed{
-				errordetails.NewTyped("google.protobuf.Struct", map[string]any{
+				errordetails.NewFromStruct(map[string]any{
 					"extra": "should not leak into details",
 				}),
 			},
@@ -296,19 +296,16 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			if restErr.Err.Status != tc.wantGRPCStatus {
 				t.Fatalf("ToRESTError() Err.Status = %v, want %v", restErr.Err.Status, tc.wantGRPCStatus)
 			}
-			if restErr.Err.Message != tc.wantMessage {
-				t.Fatalf("ToRESTError() Err.Message = %v, want %v", restErr.Err.Message, tc.wantMessage)
-			}
 
 			var foundErrorInfo bool
 			for _, typed := range restErr.Err.Details {
-				if typed.TypeURL == "type.googleapis.com/google.rpc.ErrorInfo" {
+				if typed.TypeURL == errorInfoType {
 					foundErrorInfo = true
 					if typed.Value["reason"] != tc.wantReason {
 						t.Errorf("ErrorInfo.Reason = %v, want %v", typed.Value["reason"], tc.wantReason)
 					}
-					if typed.Value["domain"] != a2a.PROTOCOL_DOMAIN {
-						t.Errorf("ErrorInfo.Domain = %v, want %v", typed.Value["domain"], a2a.PROTOCOL_DOMAIN)
+					if typed.Value["domain"] != a2a.ProtocolDomain {
+						t.Errorf("ErrorInfo.Domain = %v, want %v", typed.Value["domain"], a2a.ProtocolDomain)
 					}
 					metadata, ok := typed.Value["metadata"].(map[string]string)
 					if !ok {
@@ -328,7 +325,16 @@ func TestRESTError_RoundTrip(t *testing.T) {
 				t.Errorf("ErrorInfo not found in details")
 			}
 
-			restResp := toHTTPResponse(t, restErr)
+			jsonBytes, err := json.Marshal(restErr)
+			if err != nil {
+				t.Fatalf("json.Marshal() = %v, want nil", err)
+			}
+			var unmarshalled Error
+			if err := json.Unmarshal(jsonBytes, &unmarshalled); err != nil {
+				t.Fatalf("json.Unmarshal() = %v, want nil", err)
+			}
+
+			restResp := toHTTPResponse(t, &unmarshalled)
 			back := FromRESTError(restResp)
 
 			var a2aBack *a2a.Error
@@ -345,8 +351,8 @@ func TestRESTError_RoundTrip(t *testing.T) {
 				t.Fatalf("Round-trip message mismatch (+got,-want):\n%s", diff)
 			}
 			errInfo := a2aBack.ErrorInfo()
-			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.PROTOCOL_DOMAIN {
-				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.PROTOCOL_DOMAIN)
+			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.ProtocolDomain {
+				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.ProtocolDomain)
 			}
 			if reason, ok := errInfo.Value["reason"].(string); !ok || reason != tc.wantReason {
 				t.Fatalf("Round-trip ErrorInfo reason = %q, want %q", reason, tc.wantReason)
@@ -368,7 +374,7 @@ func TestRESTError_RoundTrip(t *testing.T) {
 				foundDetailsInTypedDetails := false
 				structCount := 0
 				for _, td := range a2aBack.TypedDetails {
-					if td.TypeURL != "google.protobuf.Struct" {
+					if td.TypeURL != errordetails.StructType {
 						continue
 					}
 					structCount++
@@ -382,7 +388,7 @@ func TestRESTError_RoundTrip(t *testing.T) {
 				wantStructCount := 1
 				if tc.typedDetails != nil {
 					for _, td := range tc.typedDetails {
-						if td.TypeURL == "google.protobuf.Struct" {
+						if td.TypeURL == errordetails.StructType {
 							wantStructCount++
 						}
 					}
@@ -564,7 +570,7 @@ func TestParseStreamResponse(t *testing.T) {
 	})
 
 	t.Run("error event", func(t *testing.T) {
-		data := []byte(makeStatusBody(400, "INVALID_ARGUMENT", "bad request", "INVALID_REQUEST"))
+		data := []byte(makeStatusBody(t, 400, "INVALID_ARGUMENT", "bad request", "INVALID_REQUEST"))
 		event, err := ParseStreamResponse(data)
 		if event != nil {
 			t.Fatalf("got event %v, want nil", event)
@@ -620,7 +626,8 @@ func toHTTPResponse(t *testing.T, restErr *Error) *http.Response {
 	}
 }
 
-func makeStatusBody(code int, status, message, reason string) string {
+func makeStatusBody(t *testing.T, code int, status, message, reason string) string {
+	t.Helper()
 	return fmt.Sprintf(`{
 		"error": {
 			"code": %d,
@@ -634,13 +641,14 @@ func makeStatusBody(code int, status, message, reason string) string {
 				}
 			]
 		}
-	}`, code, status, mustJSON(message), reason)
+	}`, code, status, mustJSON(t, message), reason)
 }
 
-func mustJSON(v any) string {
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
 	b, err := json.Marshal(v)
 	if err != nil {
-		panic(err)
+		t.Fatalf("failed to marshal: %v", err)
 	}
 	return string(b)
 }

--- a/internal/rest/rest_test.go
+++ b/internal/rest/rest_test.go
@@ -28,25 +28,20 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestRESTError_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		inputError   *a2a.Error
-		taskID       a2a.TaskID
-		typedDetails []*errordetails.Typed
-		// midpoint (REST response) assertions
+		name           string
+		inputError     *a2a.Error
+		taskID         a2a.TaskID
+		typedDetails   []*errordetails.Typed
 		wantHTTPStatus int
 		wantGRPCStatus string
-		wantReason     string
-		wantMeta       map[string]string
-		// final (A2A error) assertions
-		wantBaseErr error
-		wantMessage string
-		wantDetails map[string]any
+		want           *a2a.Error
 	}{
 		{
 			name: "TaskNotFound with details and metadata",
@@ -57,14 +52,20 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			}),
 			wantHTTPStatus: http.StatusNotFound,
 			wantGRPCStatus: "NOT_FOUND",
-			wantReason:     "TASK_NOT_FOUND",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrTaskNotFound,
-			wantMessage: "not found",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			want: &a2a.Error{
+				Err:     a2a.ErrTaskNotFound,
+				Message: "not found",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("TASK_NOT_FOUND", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -76,14 +77,20 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			}),
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "INVALID_ARGUMENT",
-			wantReason:     "PARSE_ERROR",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrParseError,
-			wantMessage: "wrapped parse error",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			want: &a2a.Error{
+				Err:     a2a.ErrParseError,
+				Message: "wrapped parse error",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("PARSE_ERROR", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -95,14 +102,20 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			}),
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "INVALID_ARGUMENT",
-			wantReason:     "INVALID_PARAMS",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrInvalidParams,
-			wantMessage: "invalid params",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			want: &a2a.Error{
+				Err:     a2a.ErrInvalidParams,
+				Message: "invalid params",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("INVALID_PARAMS", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -119,14 +132,23 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			},
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "FAILED_PRECONDITION",
-			wantReason:     "EXTENSION_SUPPORT_REQUIRED",
-			wantMeta: map[string]string{
-				"foo": "bar",
-			},
-			wantBaseErr: a2a.ErrExtensionSupportRequired,
-			wantMessage: "extension support required",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			want: &a2a.Error{
+				Err:     a2a.ErrExtensionSupportRequired,
+				Message: "extension support required",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("EXTENSION_SUPPORT_REQUIRED", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"extra": "should not leak into details",
+					}),
+				},
 			},
 		},
 		{
@@ -134,9 +156,7 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			inputError:     a2a.NewError(a2a.ErrInvalidRequest, "invalid request"),
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "INVALID_ARGUMENT",
-			wantReason:     "INVALID_REQUEST",
-			wantBaseErr:    a2a.ErrInvalidRequest,
-			wantMessage:    "invalid request",
+			want:           errorWithErrorInfo(t, "invalid request", a2a.ErrInvalidRequest, "INVALID_REQUEST"),
 		},
 		{
 			name: "MethodNotFound with details only",
@@ -145,11 +165,22 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			}),
 			wantHTTPStatus: http.StatusNotImplemented,
 			wantGRPCStatus: "UNIMPLEMENTED",
-			wantReason:     "METHOD_NOT_FOUND",
-			wantBaseErr:    a2a.ErrMethodNotFound,
-			wantMessage:    "method not found",
-			wantDetails: map[string]any{
-				"num": float64(123),
+			want: &a2a.Error{
+				Err:     a2a.ErrMethodNotFound,
+				Message: "method not found",
+				Details: map[string]any{
+					"num": float64(123),
+				},
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewTyped(errordetails.ErrorInfoType, map[string]any{
+						"reason":   "METHOD_NOT_FOUND",
+						"domain":   a2a.ProtocolDomain,
+						"metadata": map[string]string{},
+					}),
+					errordetails.NewFromStruct(map[string]any{
+						"num": float64(123),
+					}),
+				},
 			},
 		},
 		{
@@ -159,12 +190,15 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			}),
 			wantHTTPStatus: http.StatusInternalServerError,
 			wantGRPCStatus: "INTERNAL",
-			wantReason:     "SERVER_ERROR",
-			wantMeta: map[string]string{
-				"foo": "bar",
+			want: &a2a.Error{
+				Err:     a2a.ErrServerError,
+				Message: "server error",
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("SERVER_ERROR", a2a.ProtocolDomain, map[string]string{
+						"foo": "bar",
+					}),
+				},
 			},
-			wantBaseErr: a2a.ErrServerError,
-			wantMessage: "server error",
 		},
 		{
 			name: "TaskNotCancelable ErrorInfo override",
@@ -175,12 +209,15 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			}),
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "FAILED_PRECONDITION",
-			wantReason:     "TASK_NOT_CANCELABLE",
-			wantMeta: map[string]string{
-				"new_key": "new_value",
+			want: &a2a.Error{
+				Err:     a2a.ErrTaskNotCancelable,
+				Message: "task not cancelable",
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("TASK_NOT_CANCELABLE", a2a.ProtocolDomain, map[string]string{
+						"new_key": "new_value",
+					}),
+				},
 			},
-			wantBaseErr: a2a.ErrTaskNotCancelable,
-			wantMessage: "task not cancelable",
 		},
 		{
 			name:           "PushNotificationNotSupported with task id",
@@ -188,93 +225,78 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			taskID:         a2a.TaskID("task-id"),
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "FAILED_PRECONDITION",
-			wantReason:     "PUSH_NOTIFICATION_NOT_SUPPORTED",
-			wantMeta: map[string]string{
-				"taskId": "task-id",
+			want: &a2a.Error{
+				Err:     a2a.ErrPushNotificationNotSupported,
+				Message: "push notification not supported",
+				TypedDetails: []*errordetails.Typed{
+					errordetails.NewErrorInfo("PUSH_NOTIFICATION_NOT_SUPPORTED", a2a.ProtocolDomain, map[string]string{
+						"taskId": "task-id",
+					}),
+				},
 			},
-			wantBaseErr: a2a.ErrPushNotificationNotSupported,
-			wantMessage: "push notification not supported",
 		},
 		{
 			name:           "UnsupportedOperation",
 			inputError:     a2a.NewError(a2a.ErrUnsupportedOperation, "unsupported operation"),
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "FAILED_PRECONDITION",
-			wantReason:     "UNSUPPORTED_OPERATION",
-			wantBaseErr:    a2a.ErrUnsupportedOperation,
-			wantMessage:    "unsupported operation",
+			want:           errorWithErrorInfo(t, "unsupported operation", a2a.ErrUnsupportedOperation, "UNSUPPORTED_OPERATION"),
 		},
 		{
 			name:           "UnsupportedContentType",
 			inputError:     a2a.NewError(a2a.ErrUnsupportedContentType, "unsupported content type"),
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "INVALID_ARGUMENT",
-			wantReason:     "CONTENT_TYPE_NOT_SUPPORTED",
-			wantBaseErr:    a2a.ErrUnsupportedContentType,
-			wantMessage:    "unsupported content type",
+			want:           errorWithErrorInfo(t, "unsupported content type", a2a.ErrUnsupportedContentType, "CONTENT_TYPE_NOT_SUPPORTED"),
 		},
 		{
 			name:           "InvalidAgentResponse",
 			inputError:     a2a.NewError(a2a.ErrInvalidAgentResponse, "invalid agent response"),
 			wantHTTPStatus: http.StatusInternalServerError,
 			wantGRPCStatus: "INTERNAL",
-			wantReason:     "INVALID_AGENT_RESPONSE",
-			wantBaseErr:    a2a.ErrInvalidAgentResponse,
-			wantMessage:    "invalid agent response",
+			want:           errorWithErrorInfo(t, "invalid agent response", a2a.ErrInvalidAgentResponse, "INVALID_AGENT_RESPONSE"),
 		},
 		{
 			name:           "ExtendedCardNotConfigured",
 			inputError:     a2a.NewError(a2a.ErrExtendedCardNotConfigured, "extended card not configured"),
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "FAILED_PRECONDITION",
-			wantReason:     "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
-			wantBaseErr:    a2a.ErrExtendedCardNotConfigured,
-			wantMessage:    "extended card not configured",
+			want:           errorWithErrorInfo(t, "extended card not configured", a2a.ErrExtendedCardNotConfigured, "EXTENDED_AGENT_CARD_NOT_CONFIGURED"),
 		},
 		{
 			name:           "VersionNotSupported",
 			inputError:     a2a.NewError(a2a.ErrVersionNotSupported, "version not supported"),
 			wantHTTPStatus: http.StatusBadRequest,
 			wantGRPCStatus: "FAILED_PRECONDITION",
-			wantReason:     "VERSION_NOT_SUPPORTED",
-			wantBaseErr:    a2a.ErrVersionNotSupported,
-			wantMessage:    "version not supported",
+			want:           errorWithErrorInfo(t, "version not supported", a2a.ErrVersionNotSupported, "VERSION_NOT_SUPPORTED"),
 		},
 		{
 			name:           "Unauthenticated",
 			inputError:     a2a.NewError(a2a.ErrUnauthenticated, "unauthenticated"),
 			wantHTTPStatus: http.StatusUnauthorized,
 			wantGRPCStatus: "UNAUTHENTICATED",
-			wantReason:     "UNAUTHENTICATED",
-			wantBaseErr:    a2a.ErrUnauthenticated,
-			wantMessage:    "unauthenticated",
+			want:           errorWithErrorInfo(t, "unauthenticated", a2a.ErrUnauthenticated, "UNAUTHENTICATED"),
 		},
 		{
 			name:           "Unauthorized",
 			inputError:     a2a.NewError(a2a.ErrUnauthorized, "unauthorized"),
 			wantHTTPStatus: http.StatusForbidden,
 			wantGRPCStatus: "PERMISSION_DENIED",
-			wantReason:     "UNAUTHORIZED",
-			wantBaseErr:    a2a.ErrUnauthorized,
-			wantMessage:    "unauthorized",
+			want:           errorWithErrorInfo(t, "unauthorized", a2a.ErrUnauthorized, "UNAUTHORIZED"),
 		},
 		{
-			name:           "	",
+			name:           "InternalError",
 			inputError:     a2a.NewError(a2a.ErrInternalError, "internal error"),
 			wantHTTPStatus: http.StatusInternalServerError,
 			wantGRPCStatus: "INTERNAL",
-			wantReason:     "INTERNAL_ERROR",
-			wantBaseErr:    a2a.ErrInternalError,
-			wantMessage:    "internal error",
+			want:           errorWithErrorInfo(t, "internal error", a2a.ErrInternalError, "INTERNAL_ERROR"),
 		},
 		{
 			name:           "UnknownError roundtrips to Internal",
 			inputError:     a2a.NewError(errors.New("unknown error"), "unknown error"),
 			wantHTTPStatus: http.StatusInternalServerError,
 			wantGRPCStatus: "INTERNAL",
-			wantReason:     "INTERNAL_ERROR",
-			wantBaseErr:    a2a.ErrInternalError,
-			wantMessage:    "unknown error",
+			want:           errorWithErrorInfo(t, "unknown error", a2a.ErrInternalError, "INTERNAL_ERROR"),
 		},
 	}
 
@@ -297,34 +319,6 @@ func TestRESTError_RoundTrip(t *testing.T) {
 				t.Fatalf("ToRESTError() Err.Status = %v, want %v", restErr.Err.Status, tc.wantGRPCStatus)
 			}
 
-			var foundErrorInfo bool
-			for _, typed := range restErr.Err.Details {
-				if typed.TypeURL == errorInfoType {
-					foundErrorInfo = true
-					if typed.Value["reason"] != tc.wantReason {
-						t.Errorf("ErrorInfo.Reason = %v, want %v", typed.Value["reason"], tc.wantReason)
-					}
-					if typed.Value["domain"] != a2a.ProtocolDomain {
-						t.Errorf("ErrorInfo.Domain = %v, want %v", typed.Value["domain"], a2a.ProtocolDomain)
-					}
-					metadata, ok := typed.Value["metadata"].(map[string]string)
-					if !ok {
-						t.Fatalf("ErrorInfo.Metadata = %v, want %v", typed.Value["metadata"], tc.wantMeta)
-					}
-					if timestamp, ok := metadata["timestamp"]; !ok || timestamp == "" {
-						t.Fatalf("ErrorInfo.Metadata = %v, want %v", metadata, tc.wantMeta)
-					}
-					for key, value := range tc.wantMeta {
-						if metadata[key] != value {
-							t.Errorf("ErrorInfo.Metadata = %v, want %v", metadata, tc.wantMeta)
-						}
-					}
-				}
-			}
-			if !foundErrorInfo {
-				t.Errorf("ErrorInfo not found in details")
-			}
-
 			jsonBytes, err := json.Marshal(restErr)
 			if err != nil {
 				t.Fatalf("json.Marshal() = %v, want nil", err)
@@ -341,61 +335,13 @@ func TestRESTError_RoundTrip(t *testing.T) {
 			if !errors.As(back, &a2aBack) {
 				t.Fatalf("Expected *a2a.Error")
 			}
-			if !errors.Is(a2aBack.Err, tc.wantBaseErr) {
-				t.Fatalf("Round-trip error = %v, want %v", a2aBack.Err, tc.wantBaseErr)
-			}
-			if diff := cmp.Diff(tc.wantDetails, a2aBack.Details); diff != "" {
-				t.Fatalf("Round-trip details mismatch (+got,-want):\n%s", diff)
-			}
-			if diff := cmp.Diff(tc.wantMessage, a2aBack.Message); diff != "" {
-				t.Fatalf("Round-trip message mismatch (+got,-want):\n%s", diff)
-			}
-			errInfo := a2aBack.ErrorInfo()
-			if domain, ok := errInfo.Value["domain"].(string); !ok || domain != a2a.ProtocolDomain {
-				t.Fatalf("Round-trip ErrorInfo domain = %q, want %q", domain, a2a.ProtocolDomain)
-			}
-			if reason, ok := errInfo.Value["reason"].(string); !ok || reason != tc.wantReason {
-				t.Fatalf("Round-trip ErrorInfo reason = %q, want %q", reason, tc.wantReason)
-			}
-			metadata, ok := errInfo.Value["metadata"].(map[string]string)
-			if !ok {
-				t.Fatalf("Round-trip ErrorInfo metadata not found or wrong type: %v", errInfo.Value["metadata"])
-			}
-			if timestamp, ok := metadata["timestamp"]; !ok || timestamp == "" {
-				t.Fatalf("Round-trip ErrorInfo metadata mismatch: key=%s, got=%q, want=%q", "timestamp", timestamp, "")
-			}
-			for key, value := range tc.wantMeta {
-				if metadata[key] != value {
-					t.Fatalf("Round-trip ErrorInfo metadata mismatch: key=%s, got=%q, want=%q", key, metadata[key], value)
-				}
-			}
-
-			if tc.wantDetails != nil {
-				foundDetailsInTypedDetails := false
-				structCount := 0
-				for _, td := range a2aBack.TypedDetails {
-					if td.TypeURL != errordetails.StructType {
-						continue
-					}
-					structCount++
-					if cmp.Equal(tc.wantDetails, td.Value) {
-						foundDetailsInTypedDetails = true
-					}
-				}
-				if !foundDetailsInTypedDetails {
-					t.Fatalf("Round-trip TypedDetails missing struct with expected details")
-				}
-				wantStructCount := 1
-				if tc.typedDetails != nil {
-					for _, td := range tc.typedDetails {
-						if td.TypeURL == errordetails.StructType {
-							wantStructCount++
-						}
-					}
-				}
-				if structCount != wantStructCount {
-					t.Fatalf("Round-trip TypedDetails struct count = %d, want %d", structCount, wantStructCount)
-				}
+			if diff := cmp.Diff(*tc.want, *a2aBack,
+				cmpopts.EquateErrors(),
+				cmpopts.IgnoreMapEntries(func(k string, _ string) bool {
+					return k == "timestamp"
+				}),
+			); diff != "" {
+				t.Fatalf("Round-trip error mismatch (+got, -want):\n%s", diff)
 			}
 		})
 	}
@@ -651,4 +597,19 @@ func mustJSON(t *testing.T, v any) string {
 		t.Fatalf("failed to marshal: %v", err)
 	}
 	return string(b)
+}
+
+func errorWithErrorInfo(t *testing.T, message string, err error, reason string) *a2a.Error {
+	t.Helper()
+	return &a2a.Error{
+		Err:     err,
+		Message: message,
+		TypedDetails: []*errordetails.Typed{
+			errordetails.NewTyped(errordetails.ErrorInfoType, map[string]any{
+				"reason":   reason,
+				"domain":   a2a.ProtocolDomain,
+				"metadata": map[string]string{},
+			}),
+		},
+	}
 }

--- a/internal/rest/rest_test.go
+++ b/internal/rest/rest_test.go
@@ -644,4 +644,3 @@ func mustJSON(v any) string {
 	}
 	return string(b)
 }
-

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -17,7 +17,10 @@ package utils
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
+
+	"github.com/a2aproject/a2a-go/v2/log"
 )
 
 // Ptr returns a pointer to the argument simplifying pointer to primitive literals creation.
@@ -41,4 +44,23 @@ func DeepCopy[T any](task *T) (*T, error) {
 	}
 
 	return &copy, nil
+}
+
+// ToStringMap converts a map[string]any to a map[string]string.
+// It logs a warning if a value cannot be converted to a string.
+func ToStringMap(raw any) (map[string]string, bool) {
+	if m, ok := raw.(map[string]string); ok {
+		return m, true
+	} else if m, ok := raw.(map[string]any); ok {
+		converted := make(map[string]string)
+		for k, v := range m {
+			if s, ok := v.(string); ok {
+				converted[k] = s
+			} else {
+				log.Warn(context.Background(), "failed to convert metadata value to string", "key", k, "value", v)
+			}
+		}
+		return converted, true
+	}
+	return nil, false
 }


### PR DESCRIPTION

closes #323 

- a2a.Error now has a TypedDetails []*errordetails.Typed field and a WithErrorInfoMeta method to attach metadata as a typed ErrorInfo detail.
- Added new top-level errordetails package defining the Typed struct, with tests for JSON marshal/unmarshal (@type handling, round-trip, mutation safety). This package will host helpers for constructing well-known and custom detail types in the future.
- Modified metadata handling in internal/grpcutil and internal/rest to propagate Details, TypedDetails, and ErrorInfo metadata consistently across the forward (To*Error) and backward (From*Error) paths.
- Modified internal/jsonrpc to align metadata handling with the other transports and updated the JSON-RPC error type to match the spec.
- Replaced old per-direction tests with unified round-trip tests covering all combinations of a2a errors (with/without details, metadata, typed details, wrapped errors, unknown errors) plus slim edge case tests for each transport.