### PR TITLE
fix: task push notification configurations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 * Use `t.Parallel()` at the start of test cases.
 * Use `receiver.Operation() error = %v, want %v` as a template for printing test error check failures.
 * Use `receiver.Operation() = %v, want %v` as a template for printing test error check failures.
-* Use `receiver.Operation() wrong result (+got,-want) diff = %s` as a template for printing test errors received when using `cmp.Diff`.
+* Use `receiver.Operation() wrong result (-want +got) diff = %s` as a template for printing test errors received when using `cmp.Diff`.
 * Prefer using `t.Fatalf` over `t.Errorf` unless printing all the failed checks is justified or the method is called not from the main goroutine. 
 
 ### AI learnings

--- a/a2a/core.go
+++ b/a2a/core.go
@@ -774,7 +774,7 @@ type SendMessageConfig struct {
 	HistoryLength *int `json:"historyLength,omitempty" yaml:"historyLength,omitempty" mapstructure:"historyLength,omitempty"`
 
 	// PushConfig is configuration for the agent to send push notifications for updates after the initial response.
-	PushConfig *PushConfig `json:"pushNotificationConfig,omitempty" yaml:"pushNotificationConfig,omitempty" mapstructure:"pushNotificationConfig,omitempty"`
+	PushConfig *PushConfig `json:"taskPushNotificationConfig,omitempty" yaml:"taskPushNotificationConfig,omitempty" mapstructure:"taskPushNotificationConfig,omitempty"`
 }
 
 // SendMessageRequest defines the request to send a message to an agent. This can be used

--- a/a2a/json_test.go
+++ b/a2a/json_test.go
@@ -304,7 +304,7 @@ func TestAgentCardParsing(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("AgentCard codec diff(+got -want):\n%v", diff)
+		t.Errorf("AgentCard codec diff(-want +got):\n%v", diff)
 	}
 }
 

--- a/a2a/push.go
+++ b/a2a/push.go
@@ -14,18 +14,6 @@
 
 package a2a
 
-// TaskPushConfig is a container associating a push notification configuration with a specific task.
-type TaskPushConfig struct {
-	// Tenant is an optional ID of the agent owner.
-	Tenant string `json:"tenant,omitempty" yaml:"tenant,omitempty" mapstructure:"tenant,omitempty"`
-
-	// Config is the push notification configuration for this task.
-	Config PushConfig `json:"config" yaml:"config" mapstructure:"config"`
-
-	// TaskID is the ID of the task.
-	TaskID TaskID `json:"taskId" yaml:"taskId" mapstructure:"taskId"`
-}
-
 // GetTaskPushConfigRequest defines request for fetching a specific push notification configuration for a task.
 type GetTaskPushConfigRequest struct {
 	// Tenant is an optional ID of the agent owner.
@@ -56,7 +44,7 @@ type ListTaskPushConfigRequest struct {
 // ListTaskPushConfigResponse defines the response for a request to list push notification configurations.
 type ListTaskPushConfigResponse struct {
 	// Configs is a list of push notification configurations for the task.
-	Configs []*TaskPushConfig `json:"configs" yaml:"configs" mapstructure:"configs"`
+	Configs []*PushConfig `json:"configs" yaml:"configs" mapstructure:"configs"`
 
 	// NextPageToken is the token to use to retrieve the next page of push notification configurations.
 	NextPageToken string `json:"nextPageToken,omitempty" yaml:"nextPageToken,omitempty" mapstructure:"nextPageToken,omitempty"`
@@ -74,20 +62,14 @@ type DeleteTaskPushConfigRequest struct {
 	ID string `json:"id" yaml:"id" mapstructure:"id"`
 }
 
-// CreateTaskPushConfigRequest defines request for creating a push notification configuration for a task.
-type CreateTaskPushConfigRequest struct {
+// PushConfig defines the configuration for setting up push notifications for task updates.
+type PushConfig struct {
 	// Tenant is an optional ID of the agent owner.
 	Tenant string `json:"tenant,omitempty" yaml:"tenant,omitempty" mapstructure:"tenant,omitempty"`
 
-	// Config is the push notification configuration for this task.
-	Config PushConfig `json:"config" yaml:"config" mapstructure:"config"`
-
 	// TaskID is the ID of the task.
 	TaskID TaskID `json:"taskId" yaml:"taskId" mapstructure:"taskId"`
-}
 
-// PushConfig defines the configuration for setting up push notifications for task updates.
-type PushConfig struct {
 	// ID is an optional unique ID for the push notification configuration, set by the client
 	// to support multiple notification callbacks.
 	ID string `json:"id,omitempty" yaml:"id,omitempty" mapstructure:"id,omitempty"`
@@ -102,6 +84,9 @@ type PushConfig struct {
 	// URL is the callback URL where the agent should send push notifications.
 	URL string `json:"url" yaml:"url" mapstructure:"url"`
 }
+
+// TaskPushConfig is an alias for PushConfig for backward compatibility.
+type TaskPushConfig = PushConfig
 
 // PushAuthInfo defines authentication details for a push notification endpoint.
 type PushAuthInfo struct {

--- a/a2aclient/auth_test.go
+++ b/a2aclient/auth_test.go
@@ -290,7 +290,7 @@ func TestAuthInterceptor(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.want, params); diff != "" {
-				t.Errorf("wrong ServiceParams (+got,-want) diff = %s", diff)
+				t.Errorf("wrong ServiceParams (-want +got) diff = %s", diff)
 			}
 		})
 	}

--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -172,17 +172,17 @@ func (c *Client) SubscribeToTask(ctx context.Context, req *a2a.SubscribeToTaskRe
 }
 
 // GetTaskPushConfig implements the `GetTaskPushNotificationConfig` protocol method.
-func (c *Client) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (c *Client) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	return doCall(ctx, c, "GetTaskPushConfig", req, c.transport.GetTaskPushConfig)
 }
 
 // ListTaskPushConfigs implements the `ListTaskPushNotificationConfig` protocol method.
-func (c *Client) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (c *Client) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	return doCall(ctx, c, "ListTaskPushConfigs", req, c.transport.ListTaskPushConfigs)
 }
 
 // CreateTaskPushConfig implements the `CreateTaskPushNotificationConfig` protocol method.
-func (c *Client) CreateTaskPushConfig(ctx context.Context, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (c *Client) CreateTaskPushConfig(ctx context.Context, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	return doCall(ctx, c, "CreateTaskPushConfig", req, c.transport.CreateTaskPushConfig)
 }
 

--- a/a2aclient/client_test.go
+++ b/a2aclient/client_test.go
@@ -201,14 +201,14 @@ func TestClient_DefaultSendMessageConfig(t *testing.T) {
 			Config: &a2a.SendMessageConfig{AcceptedOutputModes: acceptedModes, PushConfig: pushConfig, ReturnImmediately: false},
 		}
 		if diff := cmp.Diff(want, interceptor.lastReq.Payload); diff != "" {
-			t.Fatalf("client.SendMessage() wrong result (+got,-want) diff = %s", diff)
+			t.Fatalf("client.SendMessage() wrong result (-want +got) diff = %s", diff)
 		}
 		wantReq := &a2a.SendMessageRequest{Config: &a2a.SendMessageConfig{}}
 		if wantNilConfigAfter {
 			wantReq = &a2a.SendMessageRequest{}
 		}
 		if diff := cmp.Diff(wantReq, req); diff != "" {
-			t.Fatalf("client.SendMessage() modified params (+got,-want) diff = %s", diff)
+			t.Fatalf("client.SendMessage() modified params (-want +got) diff = %s", diff)
 		}
 	}
 }
@@ -239,10 +239,10 @@ func TestClient_DefaultSendStreamingMessageConfig(t *testing.T) {
 		Config: &a2a.SendMessageConfig{AcceptedOutputModes: acceptedModes, PushConfig: pushConfig, ReturnImmediately: false},
 	}
 	if diff := cmp.Diff(want, interceptor.lastReq.Payload); diff != "" {
-		t.Fatalf("client.SendStreamingMessage() wrong result (+got,-want) diff = %s", diff)
+		t.Fatalf("client.SendStreamingMessage() wrong result (-want +got) diff = %s", diff)
 	}
 	if diff := cmp.Diff(&a2a.SendMessageRequest{}, req); diff != "" {
-		t.Fatalf("client.SendStreamingMessage() modified params (+got,-want) diff = %s", diff)
+		t.Fatalf("client.SendStreamingMessage() modified params (-want +got) diff = %s", diff)
 	}
 }
 
@@ -408,7 +408,7 @@ func TestClient_GetExtendedAgentCard(t *testing.T) {
 		t.Fatal("lastReq = nil, want GetExtendedAgentCard")
 	}
 	if diff := cmp.Diff(extendedCard, got); diff != "" {
-		t.Fatalf("client.SendStreamingMessage() modified params (+got,-want) diff = %s", diff)
+		t.Fatalf("client.SendStreamingMessage() modified params (-want +got) diff = %s", diff)
 	}
 }
 
@@ -458,13 +458,13 @@ func TestClient_UpdateAgentCard(t *testing.T) {
 		t.Fatalf("client.GetAgentCard() error = %v, want nil", err)
 	}
 	if diff := cmp.Diff(publicCard, interceptor.lastReq.Card); diff != "" {
-		t.Fatalf("wrong interceptor.lastReq.Card (+got,-want) diff = %s", diff)
+		t.Fatalf("wrong interceptor.lastReq.Card (-want +got) diff = %s", diff)
 	}
 	if diff := cmp.Diff(publicCard, interceptor.lastResp.Card); diff != "" {
-		t.Fatalf("wrong interceptor.lastResp.Card (+got,-want) diff = %s", diff)
+		t.Fatalf("wrong interceptor.lastResp.Card (-want +got) diff = %s", diff)
 	}
 	if diff := cmp.Diff(extendedCard, card); diff != "" {
-		t.Fatalf("wrong client.GetExtendedAgentCard() (+got,-want) diff = %s", diff)
+		t.Fatalf("wrong client.GetExtendedAgentCard() (-want +got) diff = %s", diff)
 	}
 }
 
@@ -501,7 +501,7 @@ func TestClient_FallbackToNonStreamingSend(t *testing.T) {
 			t.Fatalf("client.GetAgentCard() error = %v, want nil", err)
 		}
 		if diff := cmp.Diff(want, got); diff != "" {
-			t.Fatalf("client.SendStreamingMessage() wrong result (+got,-want) diff = %s", diff)
+			t.Fatalf("client.SendStreamingMessage() wrong result (-want +got) diff = %s", diff)
 		}
 		eventCount++
 	}
@@ -620,10 +620,10 @@ func TestClient_InterceptSendMessage(t *testing.T) {
 		t.Fatalf("client.SendMessage() = (%v, %v), want %v", resp, err, task)
 	}
 	if diff := cmp.Diff(req, interceptor.lastReq.Payload); diff != "" {
-		t.Fatalf("wrong interceptor.lastReq.Payload (+got,-want) diff = %s", diff)
+		t.Fatalf("wrong interceptor.lastReq.Payload (-want +got) diff = %s", diff)
 	}
 	if diff := cmp.Diff(task, interceptor.lastResp.Payload); diff != "" {
-		t.Fatalf("wrong interceptor.lastResp.Payload (+got,-want) diff = %s", diff)
+		t.Fatalf("wrong interceptor.lastResp.Payload (-want +got) diff = %s", diff)
 	}
 }
 
@@ -698,7 +698,7 @@ func TestClient_InterceptSendStreamingMessage(t *testing.T) {
 		t.Fatalf("lastResp.Method = %v, want SendStreamingMessage", interceptor.lastResp.Method)
 	}
 	if diff := cmp.Diff(req, interceptor.lastReq.Payload); diff != "" {
-		t.Fatalf("wrong interceptor.lastReq.Payload (+got,-want) diff = %s", diff)
+		t.Fatalf("wrong interceptor.lastReq.Payload (-want +got) diff = %s", diff)
 	}
 }
 

--- a/a2aclient/client_test.go
+++ b/a2aclient/client_test.go
@@ -33,9 +33,9 @@ type testTransport struct {
 	SendMessageFn          func(context.Context, ServiceParams, *a2a.SendMessageRequest) (a2a.SendMessageResult, error)
 	SubscribeToTaskFn      func(context.Context, ServiceParams, *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error]
 	SendStreamingMessageFn func(context.Context, ServiceParams, *a2a.SendMessageRequest) iter.Seq2[a2a.Event, error]
-	GetTaskPushConfigFn    func(context.Context, ServiceParams, *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error)
-	ListTaskPushConfigFn   func(context.Context, ServiceParams, *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error)
-	CreateTaskPushConfigFn func(context.Context, ServiceParams, *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error)
+	GetTaskPushConfigFn    func(context.Context, ServiceParams, *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error)
+	ListTaskPushConfigFn   func(context.Context, ServiceParams, *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error)
+	CreateTaskPushConfigFn func(context.Context, ServiceParams, *a2a.PushConfig) (*a2a.PushConfig, error)
 	DeleteTaskPushConfigFn func(context.Context, ServiceParams, *a2a.DeleteTaskPushConfigRequest) error
 	GetExtendedAgentCardFn func(context.Context, ServiceParams, *a2a.GetExtendedAgentCardRequest) (*a2a.AgentCard, error)
 }
@@ -66,15 +66,15 @@ func (t *testTransport) SendStreamingMessage(ctx context.Context, params Service
 	return t.SendStreamingMessageFn(ctx, params, req)
 }
 
-func (t *testTransport) GetTaskPushConfig(ctx context.Context, sParams ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (t *testTransport) GetTaskPushConfig(ctx context.Context, sParams ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	return t.GetTaskPushConfigFn(ctx, sParams, req)
 }
 
-func (t *testTransport) ListTaskPushConfigs(ctx context.Context, sParams ServiceParams, params *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (t *testTransport) ListTaskPushConfigs(ctx context.Context, sParams ServiceParams, params *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	return t.ListTaskPushConfigFn(ctx, sParams, params)
 }
 
-func (t *testTransport) CreateTaskPushConfig(ctx context.Context, sParams ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (t *testTransport) CreateTaskPushConfig(ctx context.Context, sParams ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	return t.CreateTaskPushConfigFn(ctx, sParams, req)
 }
 
@@ -704,9 +704,9 @@ func TestClient_InterceptSendStreamingMessage(t *testing.T) {
 
 func TestClient_InterceptGetTaskPushConfig(t *testing.T) {
 	ctx := t.Context()
-	config := &a2a.TaskPushConfig{}
+	config := &a2a.PushConfig{}
 	transport := &testTransport{
-		GetTaskPushConfigFn: func(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+		GetTaskPushConfigFn: func(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 			return config, nil
 		},
 	}
@@ -733,10 +733,10 @@ func TestClient_InterceptGetTaskPushConfig(t *testing.T) {
 
 func TestClient_InterceptListTaskPushConfigs(t *testing.T) {
 	ctx := t.Context()
-	config := &a2a.TaskPushConfig{}
+	config := &a2a.PushConfig{}
 	transport := &testTransport{
-		ListTaskPushConfigFn: func(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
-			return []*a2a.TaskPushConfig{config}, nil
+		ListTaskPushConfigFn: func(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
+			return []*a2a.PushConfig{config}, nil
 		},
 	}
 	interceptor := &testInterceptor{}
@@ -755,22 +755,22 @@ func TestClient_InterceptListTaskPushConfigs(t *testing.T) {
 	if interceptor.lastReq.Payload != req {
 		t.Fatalf("interceptor.Before payload = %v, want %v", interceptor.lastReq.Payload, req)
 	}
-	if interceptor.lastResp.Payload.([]*a2a.TaskPushConfig)[0] != config {
+	if interceptor.lastResp.Payload.([]*a2a.PushConfig)[0] != config {
 		t.Fatalf("interceptor.After payload = %v, want %v", interceptor.lastResp.Payload, config)
 	}
 }
 
 func TestClient_InterceptCreateTaskPushConfigFn(t *testing.T) {
 	ctx := t.Context()
-	config := &a2a.TaskPushConfig{}
+	config := &a2a.PushConfig{}
 	transport := &testTransport{
-		CreateTaskPushConfigFn: func(ctx context.Context, params ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+		CreateTaskPushConfigFn: func(ctx context.Context, params ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 			return config, nil
 		},
 	}
 	interceptor := &testInterceptor{}
 	client := newTestClient(transport, interceptor)
-	req := &a2a.CreateTaskPushConfigRequest{}
+	req := &a2a.PushConfig{}
 	resp, err := client.CreateTaskPushConfig(ctx, req)
 	if interceptor.lastReq.Method != "CreateTaskPushConfig" {
 		t.Fatalf("lastReq.Method = %v, want CreateTaskPushConfig", interceptor.lastReq.Method)

--- a/a2aclient/jsonrpc.go
+++ b/a2aclient/jsonrpc.go
@@ -299,13 +299,13 @@ func (t *jsonrpcTransport) SubscribeToTask(ctx context.Context, params ServicePa
 }
 
 // GetTaskPushConfig implements [a2a.Transport].
-func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	result, err := t.sendRequest(ctx, jsonrpc.MethodPushConfigGet, params, req)
 	if err != nil {
 		return nil, err
 	}
 
-	var config a2a.TaskPushConfig
+	var config a2a.PushConfig
 	if err := json.Unmarshal(result, &config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
@@ -314,13 +314,13 @@ func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params Service
 }
 
 // ListTaskPushConfig implements [a2a.Transport].
-func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	result, err := t.sendRequest(ctx, jsonrpc.MethodPushConfigList, params, req)
 	if err != nil {
 		return nil, err
 	}
 
-	var configs []*a2a.TaskPushConfig
+	var configs []*a2a.PushConfig
 	if err := json.Unmarshal(result, &configs); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal configs: %w", err)
 	}
@@ -329,13 +329,13 @@ func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params Servi
 }
 
 // CreateTaskPushConfig implements [a2a.Transport].
-func (t *jsonrpcTransport) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (t *jsonrpcTransport) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	result, err := t.sendRequest(ctx, jsonrpc.MethodPushConfigSet, params, req)
 	if err != nil {
 		return nil, err
 	}
 
-	var config a2a.TaskPushConfig
+	var config a2a.PushConfig
 	if err := json.Unmarshal(result, &config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}

--- a/a2aclient/jsonrpc_test.go
+++ b/a2aclient/jsonrpc_test.go
@@ -509,13 +509,13 @@ func TestJSONRPCTransport_PushNotificationConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("Set", func(t *testing.T) {
+	t.Run("Create", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			req := mustDecodeJSONRPC(t, r, "CreateTaskPushNotificationConfig")
 
 			resp := newResponse(
 				req,
-				json.RawMessage(`{"taskId":"task-123","config":{"id":"config-123","url":"https://webhook.example.com"}}`),
+				json.RawMessage(`{"taskId":"task-123","id":"config-123","url":"https://webhook.example.com"}`),
 			)
 			_ = json.NewEncoder(w).Encode(resp)
 		}))
@@ -523,12 +523,10 @@ func TestJSONRPCTransport_PushNotificationConfig(t *testing.T) {
 
 		transport := NewJSONRPCTransport(server.URL, nil)
 
-		config, err := transport.CreateTaskPushConfig(t.Context(), ServiceParams{}, &a2a.CreateTaskPushConfigRequest{
+		config, err := transport.CreateTaskPushConfig(t.Context(), ServiceParams{}, &a2a.PushConfig{
 			TaskID: "task-123",
-			Config: a2a.PushConfig{
-				ID:  "config-123",
-				URL: "https://webhook.example.com",
-			},
+			ID:     "config-123",
+			URL:    "https://webhook.example.com",
 		})
 
 		if err != nil {
@@ -539,8 +537,8 @@ func TestJSONRPCTransport_PushNotificationConfig(t *testing.T) {
 			t.Errorf("got taskId %s, want task-123", config.TaskID)
 		}
 
-		if config.Config.URL != "https://webhook.example.com" {
-			t.Errorf("got URL %s, want https://webhook.example.com", config.Config.URL)
+		if config.URL != "https://webhook.example.com" {
+			t.Errorf("got URL %s, want https://webhook.example.com", config.URL)
 		}
 	})
 

--- a/a2aclient/jsonrpc_test.go
+++ b/a2aclient/jsonrpc_test.go
@@ -133,7 +133,7 @@ func TestJSONRPCTransport_ServiceParamsHeaders(t *testing.T) {
 		req := mustDecodeJSONRPC(t, r, "GetTask")
 
 		if diff := cmp.Diff(wantValues, r.Header.Values("foo")); diff != "" {
-			t.Fatalf("r.Header.Get() wrong result (+got,-want) diff = %s", diff)
+			t.Fatalf("r.Header.Get() wrong result (-want +got) diff = %s", diff)
 		}
 
 		resp := newResponse(req, json.RawMessage(`{"kind":"task"}`))
@@ -231,7 +231,7 @@ func TestJSONRPCTransport_ListTasks(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(wantResult, tasks); diff != "" {
-		t.Fatalf("ListTasks wrong result (-got +want): %s", diff)
+		t.Fatalf("ListTasks wrong result (-want +got): %s", diff)
 	}
 }
 
@@ -425,7 +425,7 @@ func TestJSONRPCTransport_GetAgentCard(t *testing.T) {
 		Description: "test",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("got wrong card (+got,-want) diff = %s", diff)
+		t.Errorf("got wrong card (-want +got) diff = %s", diff)
 	}
 }
 
@@ -639,7 +639,7 @@ func TestJSONRPCTransport_ErrorDetails(t *testing.T) {
 		t.Errorf("got message %q, want %q", a2aErr.Message, wantMsg)
 	}
 	if diff := cmp.Diff(wantDetails, a2aErr.Details); diff != "" {
-		t.Errorf("got wrong details (+got,-want) diff = %s", diff)
+		t.Errorf("got wrong details (-want +got) diff = %s", diff)
 	}
 }
 

--- a/a2aclient/rest.go
+++ b/a2aclient/rest.go
@@ -329,9 +329,9 @@ func (t *RESTTransport) SendStreamingMessage(ctx context.Context, params Service
 }
 
 // GetTaskPushConfig implements [a2a.Transport].
-func (t *RESTTransport) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (t *RESTTransport) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	path := rest.MakeGetPushConfigPath(string(req.TaskID), string(req.ID))
-	var config a2a.TaskPushConfig
+	var config a2a.PushConfig
 
 	if err := t.doRequest(ctx, &restRequest{
 		method:  "GET",
@@ -346,9 +346,9 @@ func (t *RESTTransport) GetTaskPushConfig(ctx context.Context, params ServicePar
 }
 
 // ListTaskPushConfigs implements [a2a.Transport].
-func (t *RESTTransport) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (t *RESTTransport) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	path := rest.MakeListPushConfigsPath(string(req.TaskID))
-	var configs []*a2a.TaskPushConfig
+	var configs []*a2a.PushConfig
 
 	if err := t.doRequest(ctx, &restRequest{
 		method:  "GET",
@@ -363,9 +363,9 @@ func (t *RESTTransport) ListTaskPushConfigs(ctx context.Context, params ServiceP
 }
 
 // CreateTaskPushConfig implements [a2a.Transport].
-func (t *RESTTransport) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (t *RESTTransport) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	path := rest.MakeCreatePushConfigPath(string(req.TaskID))
-	var config a2a.TaskPushConfig
+	var config a2a.PushConfig
 
 	if err := t.doRequest(ctx, &restRequest{
 		method:  "POST",

--- a/a2aclient/rest_test.go
+++ b/a2aclient/rest_test.go
@@ -337,7 +337,7 @@ func TestRESTTransport_GetTaskPushConfig(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"taskId":"task-123","config":{"id":"config-123","url":"https://webhook.example.com"}}`))
+		_, _ = w.Write([]byte(`{"taskId":"task-123","id":"config-123","url":"https://webhook.example.com"}`))
 	}))
 	defer server.Close()
 	transport := newRESTTransport(t, server)
@@ -354,11 +354,11 @@ func TestRESTTransport_GetTaskPushConfig(t *testing.T) {
 	if config.TaskID != "task-123" {
 		t.Errorf("got TaskID %s, want task-123", config.TaskID)
 	}
-	if config.Config.ID != "config-123" {
-		t.Errorf("got Config ID %s, want config-123", config.Config.ID)
+	if config.ID != "config-123" {
+		t.Errorf("got Config ID %s, want config-123", config.ID)
 	}
-	if config.Config.URL != "https://webhook.example.com" {
-		t.Errorf("got Config URL %s, want https://webhook.example.com", config.Config.URL)
+	if config.URL != "https://webhook.example.com" {
+		t.Errorf("got Config URL %s, want https://webhook.example.com", config.URL)
 	}
 }
 
@@ -373,8 +373,8 @@ func TestRESTTransport_ListTaskPushConfigs(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`[
-			{"taskId":"task-123","config":{"id":"config-1","url":"https://webhook1.example.com"}},
-			{"taskId":"task-123","config":{"id":"config-2","url":"https://webhook2.example.com"}}
+			{"taskId":"task-123","id":"config-1","url":"https://webhook1.example.com"},
+			{"taskId":"task-123","id":"config-2","url":"https://webhook2.example.com"}
 		]`))
 	}))
 	defer server.Close()
@@ -390,15 +390,15 @@ func TestRESTTransport_ListTaskPushConfigs(t *testing.T) {
 	if len(configs) != 2 {
 		t.Errorf("got %d configs, want 2", len(configs))
 	}
-	if configs[0].TaskID != "task-123" || configs[0].Config.ID != "config-1" {
-		t.Errorf("got first config %+v, want taskId task-1 and configId config-1", configs[0])
+	if configs[0].TaskID != "task-123" || configs[0].ID != "config-1" {
+		t.Errorf("got first config %+v, want taskId task-123 and configId config-1", configs[0])
 	}
-	if configs[1].TaskID != "task-123" || configs[1].Config.ID != "config-2" {
-		t.Errorf("got second config %+v, want taskId task-2 and configId config-2", configs[1])
+	if configs[1].TaskID != "task-123" || configs[1].ID != "config-2" {
+		t.Errorf("got second config %+v, want taskId task-123 and configId config-2", configs[1])
 	}
 }
 
-func TestRESTTransport_SetTaskPushConfig(t *testing.T) {
+func TestRESTTransport_CreateTaskPushConfig(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected method POST, got %s", r.Method)
@@ -408,30 +408,28 @@ func TestRESTTransport_SetTaskPushConfig(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"taskId":"task-123","config":{"id":"config-123","url":"https://webhook.example.com"}}`))
+		_, _ = w.Write([]byte(`{"taskId":"task-123","id":"config-123","url":"https://webhook.example.com"}`))
 	}))
 	defer server.Close()
 	transport := newRESTTransport(t, server)
 
-	config, err := transport.CreateTaskPushConfig(t.Context(), ServiceParams{}, &a2a.CreateTaskPushConfigRequest{
+	config, err := transport.CreateTaskPushConfig(t.Context(), ServiceParams{}, &a2a.PushConfig{
 		TaskID: "task-123",
-		Config: a2a.PushConfig{
-			ID:  "config-123",
-			URL: "https://webhook.example.com",
-		},
+		ID:     "config-123",
+		URL:    "https://webhook.example.com",
 	})
 
 	if err != nil {
-		t.Fatalf("SetTaskPushConfig failed: %v", err)
+		t.Fatalf("CreateTaskPushConfig failed: %v", err)
 	}
 	if config.TaskID != "task-123" {
 		t.Errorf("got taskId %s, want task-123", config.TaskID)
 	}
-	if config.Config.ID != "config-123" {
-		t.Errorf("got config ID %s, want config-123", config.Config.ID)
+	if config.ID != "config-123" {
+		t.Errorf("got config ID %s, want config-123", config.ID)
 	}
-	if config.Config.URL != "https://webhook.example.com" {
-		t.Errorf("got config URL %s, want https://webhook.example.com", config.Config.URL)
+	if config.URL != "https://webhook.example.com" {
+		t.Errorf("got config URL %s, want https://webhook.example.com", config.URL)
 	}
 }
 

--- a/a2aclient/rest_test.go
+++ b/a2aclient/rest_test.go
@@ -113,7 +113,7 @@ func TestRESTTransport_ListTasks(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(listTasksResult, wantResult); diff != "" {
-		t.Errorf("ListTasks() mismatch (+got -want):\n%s", diff)
+		t.Errorf("ListTasks() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/a2aclient/transport.go
+++ b/a2aclient/transport.go
@@ -47,13 +47,13 @@ type Transport interface {
 	SendStreamingMessage(context.Context, ServiceParams, *a2a.SendMessageRequest) iter.Seq2[a2a.Event, error]
 
 	// GetTaskPushConfig calls the `GetTaskPushNotificationConfig` protocol method.
-	GetTaskPushConfig(context.Context, ServiceParams, *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error)
+	GetTaskPushConfig(context.Context, ServiceParams, *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error)
 
 	// ListTaskPushConfigs calls the `ListTaskPushNotificationConfig` protocol method.
-	ListTaskPushConfigs(context.Context, ServiceParams, *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error)
+	ListTaskPushConfigs(context.Context, ServiceParams, *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error)
 
 	// CreateTaskPushConfig calls the `CreateTaskPushNotificationConfig` protocol method.
-	CreateTaskPushConfig(context.Context, ServiceParams, *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error)
+	CreateTaskPushConfig(context.Context, ServiceParams, *a2a.PushConfig) (*a2a.PushConfig, error)
 
 	// DeleteTaskPushConfig calls the `DeleteTaskPushNotificationConfig` protocol method.
 	DeleteTaskPushConfig(context.Context, ServiceParams, *a2a.DeleteTaskPushConfigRequest) error
@@ -113,15 +113,15 @@ func (unimplementedTransport) SendStreamingMessage(ctx context.Context, params S
 	}
 }
 
-func (unimplementedTransport) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (unimplementedTransport) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	return nil, errNotImplemented
 }
 
-func (unimplementedTransport) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (unimplementedTransport) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	return nil, errNotImplemented
 }
 
-func (unimplementedTransport) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (unimplementedTransport) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	return nil, errNotImplemented
 }
 
@@ -191,17 +191,17 @@ func (d *tenantTransportDecorator) SendStreamingMessage(ctx context.Context, par
 	return d.base.SendStreamingMessage(ctx, params, req)
 }
 
-func (d *tenantTransportDecorator) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (d *tenantTransportDecorator) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.GetTaskPushConfig(ctx, params, req)
 }
 
-func (d *tenantTransportDecorator) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (d *tenantTransportDecorator) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.ListTaskPushConfigs(ctx, params, req)
 }
 
-func (d *tenantTransportDecorator) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (d *tenantTransportDecorator) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	req.Tenant = d.updateTenant(ctx, req.Tenant)
 	return d.base.CreateTaskPushConfig(ctx, params, req)
 }

--- a/a2acompat/a2av0/agentcard_test.go
+++ b/a2acompat/a2av0/agentcard_test.go
@@ -112,7 +112,7 @@ func TestAgentCard_NewToNew(t *testing.T) {
 		t.Fatalf("parser.Parse() error = %v", err)
 	}
 	if diff := cmp.Diff(newAgentCard, gotCard); diff != "" {
-		t.Errorf("parser.Parse() wrong result  (+got,-want) diff = %s", diff)
+		t.Errorf("parser.Parse() wrong result  (-want +got) diff = %s", diff)
 	}
 }
 
@@ -129,7 +129,7 @@ func TestAgentCard_CompatToNew(t *testing.T) {
 		t.Fatalf("parser.Parse() error = %v", err)
 	}
 	if diff := cmp.Diff(newAgentCard, gotCard); diff != "" {
-		t.Errorf("parser.Parse() wrong result  (+got,-want) diff = %s", diff)
+		t.Errorf("parser.Parse() wrong result  (-want +got) diff = %s", diff)
 	}
 }
 
@@ -214,7 +214,7 @@ func TestAgentCard_OldToNew(t *testing.T) {
 		t.Fatalf("parser.Parse() error = %v", err)
 	}
 	if diff := cmp.Diff(newAgentCard, gotCard); diff != "" {
-		t.Errorf("parser.Parse() wrong result  (+got,-want) diff = %s", diff)
+		t.Errorf("parser.Parse() wrong result  (-want +got) diff = %s", diff)
 	}
 }
 

--- a/a2acompat/a2av0/conversions.go
+++ b/a2acompat/a2av0/conversions.go
@@ -527,76 +527,60 @@ func FromV1TaskArtifactUpdateEvent(e *a2a.TaskArtifactUpdateEvent) *a2alegacy.Ta
 	}
 }
 
-// ToV1PushConfig converts a legacy push config to a v1 push config.
-func ToV1PushConfig(c a2alegacy.PushConfig) *a2a.PushConfig {
-	res := &a2a.PushConfig{
-		ID:    c.ID,
-		Token: c.Token,
-		URL:   c.URL,
+// ToV1PushConfig converts a legacy task push config to a v1 push config.
+func ToV1PushConfig(c *a2alegacy.TaskPushConfig) *a2a.PushConfig {
+	if c == nil {
+		return nil
 	}
-	if c.Auth != nil {
+	res := &a2a.PushConfig{
+		TaskID: a2a.TaskID(c.TaskID),
+		ID:     c.Config.ID,
+		Token:  c.Config.Token,
+		URL:    c.Config.URL,
+	}
+	if c.Config.Auth != nil {
 		res.Auth = &a2a.PushAuthInfo{
-			Credentials: c.Auth.Credentials,
+			Credentials: c.Config.Auth.Credentials,
 		}
-		if len(c.Auth.Schemes) > 0 {
-			res.Auth.Scheme = c.Auth.Schemes[0]
+		if len(c.Config.Auth.Schemes) > 0 {
+			res.Auth.Scheme = c.Config.Auth.Schemes[0]
 		}
 	}
 	return res
 }
 
 // FromV1PushConfig converts a v1 push config to a legacy push config.
-func FromV1PushConfig(c *a2a.PushConfig) *a2alegacy.PushConfig {
+func FromV1PushConfig(c *a2a.PushConfig) *a2alegacy.TaskPushConfig {
 	if c == nil {
 		return nil
 	}
-	res := &a2alegacy.PushConfig{
+	config := &a2alegacy.PushConfig{
 		ID:    c.ID,
 		Token: c.Token,
 		URL:   c.URL,
 	}
 	if c.Auth != nil {
-		res.Auth = &a2alegacy.PushAuthInfo{
+		config.Auth = &a2alegacy.PushAuthInfo{
 			Credentials: c.Auth.Credentials,
 			Schemes:     []string{c.Auth.Scheme},
 		}
 	}
-	return res
-}
-
-// ToV1TaskPushConfig converts a legacy task push config to a v1 task push config.
-func ToV1TaskPushConfig(comp *a2alegacy.TaskPushConfig) (*a2a.TaskPushConfig, error) {
-	if comp == nil {
-		return nil, nil
-	}
-	return &a2a.TaskPushConfig{TaskID: a2a.TaskID(comp.TaskID), Config: *ToV1PushConfig(comp.Config)}, nil
-}
-
-// FromV1TaskPushConfig converts a v1 task push config to a legacy task push config.
-func FromV1TaskPushConfig(c *a2a.TaskPushConfig) (*a2alegacy.TaskPushConfig, error) {
-	if c == nil {
-		return nil, nil
-	}
-	res := &a2alegacy.TaskPushConfig{
-		Config: *FromV1PushConfig(&c.Config),
+	return &a2alegacy.TaskPushConfig{
+		Config: *config,
 		TaskID: a2alegacy.TaskID(c.TaskID),
 	}
-	return res, nil
 }
 
-// FromV1TaskPushConfigs converts multiple v1 task push configs to legacy task push configs.
-func FromV1TaskPushConfigs(cs []*a2a.TaskPushConfig) ([]*a2alegacy.TaskPushConfig, error) {
+// FromV1PushConfigs converts multiple v1 push configs to legacy task push configs.
+func FromV1PushConfigs(cs []*a2a.PushConfig) []*a2alegacy.TaskPushConfig {
 	var res []*a2alegacy.TaskPushConfig
 	for _, c := range cs {
-		comp, err := FromV1TaskPushConfig(c)
-		if err != nil {
-			return nil, err
-		}
+		comp := FromV1PushConfig(c)
 		if comp != nil {
 			res = append(res, comp)
 		}
 	}
-	return res, nil
+	return res
 }
 
 // ToV1GetTaskRequest converts a legacy get task request to a v1 request.
@@ -650,7 +634,11 @@ func ToV1SendMessageRequest(p *a2alegacy.MessageSendParams) (*a2a.SendMessageReq
 			req.Config.ReturnImmediately = !(*p.Config.Blocking)
 		}
 		if p.Config.PushConfig != nil {
-			req.Config.PushConfig = ToV1PushConfig(*p.Config.PushConfig)
+			legacyTaskPushConfig := &a2alegacy.TaskPushConfig{
+				Config: *p.Config.PushConfig,
+				TaskID: a2alegacy.TaskID(req.Message.TaskID),
+			}
+			req.Config.PushConfig = ToV1PushConfig(legacyTaskPushConfig)
 		}
 	}
 	return req, nil
@@ -672,7 +660,8 @@ func FromV1SendMessageRequest(req *a2a.SendMessageRequest) *a2alegacy.MessageSen
 		}
 		res.Config.Blocking = utils.Ptr(!req.Config.ReturnImmediately)
 		if req.Config.PushConfig != nil {
-			res.Config.PushConfig = FromV1PushConfig(req.Config.PushConfig)
+			legacyTaskPushConfig := FromV1PushConfig(req.Config.PushConfig)
+			res.Config.PushConfig = &legacyTaskPushConfig.Config
 		}
 	}
 	return res
@@ -729,26 +718,6 @@ func FromV1ListTaskPushConfigRequest(req *a2a.ListTaskPushConfigRequest) *a2aleg
 	return &a2alegacy.ListTaskPushConfigParams{
 		TaskID: a2alegacy.TaskID(req.TaskID),
 	}
-}
-
-// ToV1CreateTaskPushConfigRequest converts a legacy create task push config request to a v1 request.
-func ToV1CreateTaskPushConfigRequest(p *a2alegacy.TaskPushConfig) *a2a.CreateTaskPushConfigRequest {
-	return &a2a.CreateTaskPushConfigRequest{
-		TaskID: a2a.TaskID(p.TaskID),
-		Config: *ToV1PushConfig(p.Config),
-	}
-}
-
-// FromV1CreateTaskPushConfigRequest converts a v1 create task push config request to a legacy request.
-func FromV1CreateTaskPushConfigRequest(req *a2a.CreateTaskPushConfigRequest) *a2alegacy.TaskPushConfig {
-	if req == nil {
-		return nil
-	}
-	cfg := FromV1PushConfig(&req.Config)
-	if cfg == nil {
-		cfg = &a2alegacy.PushConfig{}
-	}
-	return &a2alegacy.TaskPushConfig{TaskID: a2alegacy.TaskID(req.TaskID), Config: *cfg}
 }
 
 // ToV1DeleteTaskPushConfigRequest converts a legacy delete task push config request to a v1 request.

--- a/a2acompat/a2av0/jsonrpc_client.go
+++ b/a2acompat/a2av0/jsonrpc_client.go
@@ -306,7 +306,7 @@ func (t *jsonrpcTransport) SubscribeToTask(ctx context.Context, params a2aclient
 }
 
 // GetTaskPushConfig retrieves the push notification configuration for a task.
-func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	compatReq := FromV1GetTaskPushConfigRequest(req)
 	result, err := t.sendRequest(ctx, methodPushConfigGet, params, compatReq)
 	if err != nil {
@@ -318,15 +318,12 @@ func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclie
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	config, err := ToV1TaskPushConfig(&compatConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert config: %w", err)
-	}
+	config := ToV1PushConfig(&compatConfig)
 	return config, nil
 }
 
 // ListTaskPushConfig lists push notification configurations.
-func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params a2aclient.ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params a2aclient.ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	compatReq := FromV1ListTaskPushConfigRequest(req)
 	result, err := t.sendRequest(ctx, methodPushConfigList, params, compatReq)
 	if err != nil {
@@ -338,12 +335,9 @@ func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params a2acl
 		return nil, fmt.Errorf("failed to unmarshal configs: %w", err)
 	}
 
-	configs := make([]*a2a.TaskPushConfig, 0, len(compatConfigs))
+	configs := make([]*a2a.PushConfig, 0, len(compatConfigs))
 	for _, compatConfig := range compatConfigs {
-		config, err := ToV1TaskPushConfig(compatConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert config: %w", err)
-		}
+		config := ToV1PushConfig(compatConfig)
 		configs = append(configs, config)
 	}
 
@@ -351,8 +345,8 @@ func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params a2acl
 }
 
 // CreateTaskPushConfig sets or updates the push notification configuration for a task.
-func (t *jsonrpcTransport) CreateTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
-	compatReq := FromV1CreateTaskPushConfigRequest(req)
+func (t *jsonrpcTransport) CreateTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
+	compatReq := FromV1PushConfig(req)
 	result, err := t.sendRequest(ctx, methodPushConfigSet, params, compatReq)
 	if err != nil {
 		return nil, err
@@ -363,10 +357,7 @@ func (t *jsonrpcTransport) CreateTaskPushConfig(ctx context.Context, params a2ac
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	config, err := ToV1TaskPushConfig(&compatConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert config: %w", err)
-	}
+	config := ToV1PushConfig(&compatConfig)
 	return config, nil
 }
 

--- a/a2acompat/a2av0/jsonrpc_server.go
+++ b/a2acompat/a2av0/jsonrpc_server.go
@@ -345,7 +345,7 @@ func (h *jsonrpcHandler) onGetTaskPushConfig(ctx context.Context, raw json.RawMe
 	if err != nil {
 		return nil, err
 	}
-	return FromV1TaskPushConfig(config)
+	return FromV1PushConfig(config), nil
 }
 
 func (h *jsonrpcHandler) onListTaskPushConfigs(ctx context.Context, raw json.RawMessage) ([]*a2alegacy.TaskPushConfig, error) {
@@ -357,7 +357,7 @@ func (h *jsonrpcHandler) onListTaskPushConfigs(ctx context.Context, raw json.Raw
 	if err != nil {
 		return nil, err
 	}
-	return FromV1TaskPushConfigs(configs)
+	return FromV1PushConfigs(configs), nil
 }
 
 func (h *jsonrpcHandler) onSetTaskPushConfig(ctx context.Context, raw json.RawMessage) (*a2alegacy.TaskPushConfig, error) {
@@ -365,11 +365,11 @@ func (h *jsonrpcHandler) onSetTaskPushConfig(ctx context.Context, raw json.RawMe
 	if err := json.Unmarshal(raw, &params); err != nil {
 		return nil, handleUnmarshalError(err)
 	}
-	config, err := h.handler.CreateTaskPushConfig(ctx, ToV1CreateTaskPushConfigRequest(&params))
+	config, err := h.handler.CreateTaskPushConfig(ctx, ToV1PushConfig(&params))
 	if err != nil {
 		return nil, err
 	}
-	return FromV1TaskPushConfig(config)
+	return FromV1PushConfig(config), nil
 }
 
 func (h *jsonrpcHandler) onDeleteTaskPushConfig(ctx context.Context, raw json.RawMessage) error {

--- a/a2acompat/a2av0/rest_client.go
+++ b/a2acompat/a2av0/rest_client.go
@@ -358,7 +358,7 @@ func (t *restCompatTransport) SubscribeToTask(ctx context.Context, params a2acli
 }
 
 // GetTaskPushConfig implements [a2aclient.Transport].
-func (t *restCompatTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (t *restCompatTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	var compatConfig a2alegacy.TaskPushConfig
 	if err := t.doRequest(ctx, &compatRestReq{
 		method: "GET",
@@ -367,15 +367,12 @@ func (t *restCompatTransport) GetTaskPushConfig(ctx context.Context, params a2ac
 	}, &compatConfig); err != nil {
 		return nil, err
 	}
-	config, err := ToV1TaskPushConfig(&compatConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert push config: %w", err)
-	}
+	config := ToV1PushConfig(&compatConfig)
 	return config, nil
 }
 
 // ListTaskPushConfigs implements [a2aclient.Transport].
-func (t *restCompatTransport) ListTaskPushConfigs(ctx context.Context, params a2aclient.ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (t *restCompatTransport) ListTaskPushConfigs(ctx context.Context, params a2aclient.ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	var compatConfigs []*a2alegacy.TaskPushConfig
 	if err := t.doRequest(ctx, &compatRestReq{
 		method: "GET",
@@ -384,20 +381,17 @@ func (t *restCompatTransport) ListTaskPushConfigs(ctx context.Context, params a2
 	}, &compatConfigs); err != nil {
 		return nil, err
 	}
-	configs := make([]*a2a.TaskPushConfig, 0, len(compatConfigs))
+	configs := make([]*a2a.PushConfig, 0, len(compatConfigs))
 	for _, c := range compatConfigs {
-		config, err := ToV1TaskPushConfig(c)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert push config: %w", err)
-		}
+		config := ToV1PushConfig(c)
 		configs = append(configs, config)
 	}
 	return configs, nil
 }
 
 // CreateTaskPushConfig implements [a2aclient.Transport].
-func (t *restCompatTransport) CreateTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
-	compatPushConfig := FromV1PushConfig(&req.Config)
+func (t *restCompatTransport) CreateTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
+	compatPushConfig := FromV1PushConfig(req)
 	var compatConfig a2alegacy.TaskPushConfig
 	if err := t.doRequest(ctx, &compatRestReq{
 		method:  "POST",
@@ -407,10 +401,7 @@ func (t *restCompatTransport) CreateTaskPushConfig(ctx context.Context, params a
 	}, &compatConfig); err != nil {
 		return nil, err
 	}
-	config, err := ToV1TaskPushConfig(&compatConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert push config: %w", err)
-	}
+	config := ToV1PushConfig(&compatConfig)
 	return config, nil
 }
 

--- a/a2acompat/a2av0/rest_server.go
+++ b/a2acompat/a2av0/rest_server.go
@@ -329,7 +329,7 @@ func (h *restCompatHandler) handleCreateTaskPushConfig(rw http.ResponseWriter, r
 		writeRESTCompatError(ctx, rw, a2a.ErrParseError, a2a.TaskID(taskID))
 		return
 	}
-	v1req := ToV1CreateTaskPushConfigRequest(&a2alegacy.TaskPushConfig{
+	v1req := ToV1PushConfig(&a2alegacy.TaskPushConfig{
 		TaskID: a2alegacy.TaskID(taskID),
 		Config: config,
 	})
@@ -338,11 +338,7 @@ func (h *restCompatHandler) handleCreateTaskPushConfig(rw http.ResponseWriter, r
 		writeRESTCompatError(ctx, rw, err, a2a.TaskID(taskID))
 		return
 	}
-	compatConfig, err := FromV1TaskPushConfig(result)
-	if err != nil {
-		writeRESTCompatError(ctx, rw, err, a2a.TaskID(taskID))
-		return
-	}
+	compatConfig := FromV1PushConfig(result)
 	writeSnakeCaseJSON(ctx, rw, compatConfig)
 }
 
@@ -362,11 +358,7 @@ func (h *restCompatHandler) handleGetTaskPushConfig(rw http.ResponseWriter, req 
 		writeRESTCompatError(ctx, rw, err, a2a.TaskID(taskID))
 		return
 	}
-	compatConfig, err := FromV1TaskPushConfig(result)
-	if err != nil {
-		writeRESTCompatError(ctx, rw, err, a2a.TaskID(taskID))
-		return
-	}
+	compatConfig := FromV1PushConfig(result)
 	writeSnakeCaseJSON(ctx, rw, compatConfig)
 }
 
@@ -384,11 +376,7 @@ func (h *restCompatHandler) handleListTaskPushConfigs(rw http.ResponseWriter, re
 		writeRESTCompatError(ctx, rw, err, a2a.TaskID(taskID))
 		return
 	}
-	compatConfigs, err := FromV1TaskPushConfigs(result)
-	if err != nil {
-		writeRESTCompatError(ctx, rw, err, a2a.TaskID(taskID))
-		return
-	}
+	compatConfigs := FromV1PushConfigs(result)
 	if compatConfigs == nil {
 		compatConfigs = []*a2alegacy.TaskPushConfig{}
 	}

--- a/a2aext/activator_test.go
+++ b/a2aext/activator_test.go
@@ -109,7 +109,7 @@ func TestActivator(t *testing.T) {
 
 			gotExtensions, _ := a2asrv.NewServiceParams(gotHeaders).Get(a2a.SvcParamExtensions)
 			if diff := cmp.Diff(tc.clientSends, gotExtensions, cmpIgnoreHeaderCase()); diff != "" {
-				t.Errorf("wrong extension headers (+got,-want), diff = %s", diff)
+				t.Errorf("wrong extension headers (-want +got), diff = %s", diff)
 			}
 		})
 	}

--- a/a2aext/propagator_test.go
+++ b/a2aext/propagator_test.go
@@ -137,7 +137,7 @@ func TestTripleHopPropagation(t *testing.T) {
 				t.Fatalf("client.SendMessage() = %v, want completed task", resp)
 			}
 			if diff := cmp.Diff(tc.wantPropagatedMeta, gotExecCtx.Metadata); diff != "" {
-				t.Fatalf("wrong end request meta (+got,-want), diff = %s", diff)
+				t.Fatalf("wrong end request meta (-want +got), diff = %s", diff)
 			}
 			ignoreStdHeaders := cmpopts.IgnoreMapEntries(func(k string, v any) bool {
 				return slices.Contains([]string{
@@ -145,7 +145,7 @@ func TestTripleHopPropagation(t *testing.T) {
 				}, k)
 			})
 			if diff := cmp.Diff(tc.wantPropagatedHeaders, gotHeaders, ignoreStdHeaders, cmpIgnoreHeaderCase()); diff != "" {
-				t.Fatalf("wrong end request headers (+got,-want), diff = %s", diff)
+				t.Fatalf("wrong end request headers (-want +got), diff = %s", diff)
 			}
 		})
 	}
@@ -243,7 +243,7 @@ func TestDefaultPropagation(t *testing.T) {
 				t.Fatalf("client.SendMessage() = %v, want completed task", resp)
 			}
 			if diff := cmp.Diff(tc.wantBReceivedMeta, gotExecCtx.Metadata); diff != "" {
-				t.Fatalf("wrong end request meta (+got,-want), diff = %s", diff)
+				t.Fatalf("wrong end request meta (-want +got), diff = %s", diff)
 			}
 			ignoreStdHeaders := cmpopts.IgnoreMapEntries(func(k string, v any) bool {
 				return slices.Contains([]string{
@@ -251,7 +251,7 @@ func TestDefaultPropagation(t *testing.T) {
 				}, k)
 			})
 			if diff := cmp.Diff(tc.wantBReceivedHeaders, gotHeaders, ignoreStdHeaders, cmpIgnoreHeaderCase()); diff != "" {
-				t.Fatalf("wrong end request headers (+got,-want), diff = %s", diff)
+				t.Fatalf("wrong end request headers (-want +got), diff = %s", diff)
 			}
 		})
 	}

--- a/a2agrpc/v0/client.go
+++ b/a2agrpc/v0/client.go
@@ -192,7 +192,7 @@ func drainEventStream(stream grpc.ServerStreamingClient[a2apb.StreamResponse], y
 	}
 }
 
-func (c *grpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (c *grpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	pbReq, err := pbconv.ToProtoGetTaskPushConfigRequest(req)
 	if err != nil {
 		return nil, err
@@ -206,7 +206,7 @@ func (c *grpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.
 	return pbconv.FromProtoTaskPushConfig(pbConfig)
 }
 
-func (c *grpcTransport) ListTaskPushConfigs(ctx context.Context, params a2aclient.ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (c *grpcTransport) ListTaskPushConfigs(ctx context.Context, params a2aclient.ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	pbReq, err := pbconv.ToProtoListTaskPushConfigRequest(req)
 	if err != nil {
 		return nil, err
@@ -224,7 +224,7 @@ func (c *grpcTransport) ListTaskPushConfigs(ctx context.Context, params a2aclien
 	return resp.Configs, nil
 }
 
-func (c *grpcTransport) CreateTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (c *grpcTransport) CreateTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	pbReq, err := pbconv.ToProtoCreateTaskPushConfigRequest(req)
 	if err != nil {
 		return nil, err

--- a/a2agrpc/v0/handler_test.go
+++ b/a2agrpc/v0/handler_test.go
@@ -118,7 +118,7 @@ var defaultMockHandler = &mockRequestHandler{
 // mockRequestHandler is a mock of a2asrv.RequestHandler.
 type mockRequestHandler struct {
 	tasks       map[a2a.TaskID]*a2a.Task
-	pushConfigs map[a2a.TaskID]map[string]*a2a.TaskPushConfig
+	pushConfigs map[a2a.TaskID]map[string]*a2a.PushConfig
 
 	// Fields to capture call parameters
 	capturedGetTaskRequest              *a2a.GetTaskRequest
@@ -127,7 +127,7 @@ type mockRequestHandler struct {
 	capturedSendMessageRequest          *a2a.SendMessageRequest
 	capturedSendMessageStreamRequest    *a2a.SendMessageRequest
 	capturedSubscribeToTaskRequest      *a2a.SubscribeToTaskRequest
-	capturedCreateTaskPushConfigRequest *a2a.CreateTaskPushConfigRequest
+	capturedCreateTaskPushConfigRequest *a2a.PushConfig
 	capturedGetTaskPushConfigRequest    *a2a.GetTaskPushConfigRequest
 	capturedListTaskPushConfigRequest   *a2a.ListTaskPushConfigRequest
 	capturedDeleteTaskPushConfigRequest *a2a.DeleteTaskPushConfigRequest
@@ -217,21 +217,21 @@ func (m *mockRequestHandler) SubscribeToTask(ctx context.Context, req *a2a.Subsc
 	}
 }
 
-func (m *mockRequestHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (m *mockRequestHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	m.capturedCreateTaskPushConfigRequest = req
 	if _, ok := m.tasks[req.TaskID]; ok {
 		if _, ok := m.pushConfigs[req.TaskID]; !ok {
-			m.pushConfigs[req.TaskID] = make(map[string]*a2a.TaskPushConfig)
+			m.pushConfigs[req.TaskID] = make(map[string]*a2a.PushConfig)
 		}
-		taskPushConfig := &a2a.TaskPushConfig{TaskID: req.TaskID, Config: req.Config}
-		m.pushConfigs[req.TaskID][req.Config.ID] = taskPushConfig
+		taskPushConfig := &a2a.PushConfig{TaskID: req.TaskID, ID: req.ID, URL: req.URL}
+		m.pushConfigs[req.TaskID][req.ID] = taskPushConfig
 		return taskPushConfig, nil
 	}
 
 	return nil, fmt.Errorf("task for push config not found, taskID: %s", req.TaskID)
 }
 
-func (m *mockRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (m *mockRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	m.capturedGetTaskPushConfigRequest = req
 	if _, ok := m.tasks[req.TaskID]; ok {
 		if pushConfigs, ok := m.pushConfigs[req.TaskID]; ok {
@@ -243,20 +243,20 @@ func (m *mockRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.Get
 	return nil, fmt.Errorf("task for push config not found, taskID: %s", req.TaskID)
 }
 
-func (m *mockRequestHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (m *mockRequestHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	m.capturedListTaskPushConfigRequest = req
 	if _, ok := m.tasks[req.TaskID]; ok {
 		if pushConfigs, ok := m.pushConfigs[req.TaskID]; ok {
-			var result []*a2a.TaskPushConfig
+			var result []*a2a.PushConfig
 			for _, v := range pushConfigs {
 				result = append(result, v)
 			}
 			return result, nil
 		}
-		return []*a2a.TaskPushConfig{}, nil // no configs for task id
+		return []*a2a.PushConfig{}, nil // no configs for task id
 	}
 
-	return []*a2a.TaskPushConfig{}, fmt.Errorf("task for push config not found, taskID: %s", req.TaskID)
+	return []*a2a.PushConfig{}, fmt.Errorf("task for push config not found, taskID: %s", req.TaskID)
 }
 
 func (m *mockRequestHandler) DeleteTaskPushConfig(ctx context.Context, req *a2a.DeleteTaskPushConfigRequest) error {
@@ -901,7 +901,7 @@ func TestGrpcHandler_CreateTaskPushNotificationConfig(t *testing.T) {
 	ctx := t.Context()
 	taskID := a2a.TaskID("test-task")
 	mockHandler := &mockRequestHandler{
-		pushConfigs: make(map[a2a.TaskID]map[string]*a2a.TaskPushConfig),
+		pushConfigs: make(map[a2a.TaskID]map[string]*a2a.PushConfig),
 		tasks: map[a2a.TaskID]*a2a.Task{
 			taskID: {ID: taskID, ContextID: "test-context"},
 		},
@@ -912,7 +912,7 @@ func TestGrpcHandler_CreateTaskPushNotificationConfig(t *testing.T) {
 		name        string
 		req         *a2apb.CreateTaskPushNotificationConfigRequest
 		want        *a2apb.TaskPushNotificationConfig
-		wantRequest *a2a.CreateTaskPushConfigRequest
+		wantRequest *a2a.PushConfig
 		wantErr     codes.Code
 	}{
 		{
@@ -927,9 +927,9 @@ func TestGrpcHandler_CreateTaskPushNotificationConfig(t *testing.T) {
 				Name:                   fmt.Sprintf("tasks/%s/pushNotificationConfigs/test-config", taskID),
 				PushNotificationConfig: &a2apb.PushNotificationConfig{Id: "test-config"},
 			},
-			wantRequest: &a2a.CreateTaskPushConfigRequest{
+			wantRequest: &a2a.PushConfig{
 				TaskID: taskID,
-				Config: a2a.PushConfig{ID: "test-config"},
+				ID:     "test-config",
 			},
 		},
 		{
@@ -984,9 +984,9 @@ func TestGrpcHandler_GetTaskPushNotificationConfig(t *testing.T) {
 	taskID := a2a.TaskID("test-task")
 	configID := "test-config"
 	mockHandler := &mockRequestHandler{
-		pushConfigs: map[a2a.TaskID]map[string]*a2a.TaskPushConfig{
+		pushConfigs: map[a2a.TaskID]map[string]*a2a.PushConfig{
 			taskID: {
-				configID: {TaskID: taskID, Config: a2a.PushConfig{ID: configID}},
+				configID: {TaskID: taskID, ID: configID},
 			},
 		},
 		tasks: map[a2a.TaskID]*a2a.Task{
@@ -1063,10 +1063,10 @@ func TestGrpcHandler_ListTaskPushNotificationConfig(t *testing.T) {
 	taskID := a2a.TaskID("test-task")
 	configID := "test-config"
 	mockHandler := &mockRequestHandler{
-		pushConfigs: map[a2a.TaskID]map[string]*a2a.TaskPushConfig{
+		pushConfigs: map[a2a.TaskID]map[string]*a2a.PushConfig{
 			taskID: {
-				fmt.Sprintf("%s-1", configID): {TaskID: taskID, Config: a2a.PushConfig{ID: fmt.Sprintf("%s-1", configID)}},
-				fmt.Sprintf("%s-2", configID): {TaskID: taskID, Config: a2a.PushConfig{ID: fmt.Sprintf("%s-2", configID)}},
+				fmt.Sprintf("%s-1", configID): {TaskID: taskID, ID: fmt.Sprintf("%s-1", configID)},
+				fmt.Sprintf("%s-2", configID): {TaskID: taskID, ID: fmt.Sprintf("%s-2", configID)},
 			},
 		},
 		tasks: map[a2a.TaskID]*a2a.Task{
@@ -1152,9 +1152,9 @@ func TestGrpcHandler_DeleteTaskPushNotificationConfig(t *testing.T) {
 	taskID := a2a.TaskID("test-task")
 	configID := "test-config"
 	mockHandler := &mockRequestHandler{
-		pushConfigs: map[a2a.TaskID]map[string]*a2a.TaskPushConfig{
+		pushConfigs: map[a2a.TaskID]map[string]*a2a.PushConfig{
 			taskID: {
-				configID: {TaskID: taskID, Config: a2a.PushConfig{ID: configID}},
+				configID: {TaskID: taskID, ID: configID},
 			},
 		},
 		tasks: map[a2a.TaskID]*a2a.Task{

--- a/a2agrpc/v1/client.go
+++ b/a2agrpc/v1/client.go
@@ -185,7 +185,7 @@ func drainEventStream(stream grpc.ServerStreamingClient[a2apb.StreamResponse], y
 	}
 }
 
-func (c *grpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (c *grpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	pbReq, err := pbconv.ToProtoGetTaskPushConfigRequest(req)
 	if err != nil {
 		return nil, err
@@ -199,7 +199,7 @@ func (c *grpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.
 	return pbconv.FromProtoTaskPushConfig(pbConfig)
 }
 
-func (c *grpcTransport) ListTaskPushConfigs(ctx context.Context, params a2aclient.ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (c *grpcTransport) ListTaskPushConfigs(ctx context.Context, params a2aclient.ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	pbReq, err := pbconv.ToProtoListTaskPushConfigRequest(req)
 	if err != nil {
 		return nil, err
@@ -217,8 +217,8 @@ func (c *grpcTransport) ListTaskPushConfigs(ctx context.Context, params a2aclien
 	return resp.Configs, nil
 }
 
-func (c *grpcTransport) CreateTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
-	pbReq, err := pbconv.ToProtoCreateTaskPushConfigRequest(req)
+func (c *grpcTransport) CreateTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
+	pbReq, err := pbconv.ToProtoTaskPushConfig(req)
 	if err != nil {
 		return nil, err
 	}

--- a/a2agrpc/v1/handler.go
+++ b/a2agrpc/v1/handler.go
@@ -188,7 +188,7 @@ func (h *Handler) SubscribeToTask(pbReq *a2apb.SubscribeToTaskRequest, stream gr
 
 // CreateTaskPushNotificationConfig implements a2apb.A2AServiceServer.
 func (h *Handler) CreateTaskPushNotificationConfig(ctx context.Context, pbReq *a2apb.TaskPushNotificationConfig) (*a2apb.TaskPushNotificationConfig, error) {
-	req, err := pbconv.FromProtoCreateTaskPushConfigRequest(pbReq)
+	req, err := pbconv.FromProtoTaskPushConfig(pbReq)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to convert request: %v", err)
 	}

--- a/a2agrpc/v1/handler_test.go
+++ b/a2agrpc/v1/handler_test.go
@@ -117,7 +117,7 @@ var defaultMockHandler = &mockRequestHandler{
 // mockRequestHandler is a mock of a2asrv.RequestHandler.
 type mockRequestHandler struct {
 	tasks       map[a2a.TaskID]*a2a.Task
-	pushConfigs map[a2a.TaskID]map[string]*a2a.TaskPushConfig
+	pushConfigs map[a2a.TaskID]map[string]*a2a.PushConfig
 
 	// Fields to capture call parameters
 	capturedGetTaskRequest              *a2a.GetTaskRequest
@@ -126,7 +126,7 @@ type mockRequestHandler struct {
 	capturedSendMessageRequest          *a2a.SendMessageRequest
 	capturedSendMessageStreamRequest    *a2a.SendMessageRequest
 	capturedSubscribeToTaskRequest      *a2a.SubscribeToTaskRequest
-	capturedCreateTaskPushConfigRequest *a2a.CreateTaskPushConfigRequest
+	capturedCreateTaskPushConfigRequest *a2a.PushConfig
 	capturedGetTaskPushConfigRequest    *a2a.GetTaskPushConfigRequest
 	capturedListTaskPushConfigRequest   *a2a.ListTaskPushConfigRequest
 	capturedDeleteTaskPushConfigRequest *a2a.DeleteTaskPushConfigRequest
@@ -216,21 +216,20 @@ func (m *mockRequestHandler) SubscribeToTask(ctx context.Context, req *a2a.Subsc
 	}
 }
 
-func (m *mockRequestHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (m *mockRequestHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	m.capturedCreateTaskPushConfigRequest = req
 	if _, ok := m.tasks[req.TaskID]; ok {
 		if _, ok := m.pushConfigs[req.TaskID]; !ok {
-			m.pushConfigs[req.TaskID] = make(map[string]*a2a.TaskPushConfig)
+			m.pushConfigs[req.TaskID] = make(map[string]*a2a.PushConfig)
 		}
-		taskPushConfig := &a2a.TaskPushConfig{TaskID: req.TaskID, Config: req.Config}
-		m.pushConfigs[req.TaskID][req.Config.ID] = taskPushConfig
-		return taskPushConfig, nil
+		m.pushConfigs[req.TaskID][req.ID] = req
+		return req, nil
 	}
 
 	return nil, fmt.Errorf("task for push config not found, taskID: %s", req.TaskID)
 }
 
-func (m *mockRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (m *mockRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	m.capturedGetTaskPushConfigRequest = req
 	if _, ok := m.tasks[req.TaskID]; ok {
 		if pushConfigs, ok := m.pushConfigs[req.TaskID]; ok {
@@ -242,20 +241,20 @@ func (m *mockRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.Get
 	return nil, fmt.Errorf("task for push config not found, taskID: %s", req.TaskID)
 }
 
-func (m *mockRequestHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (m *mockRequestHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	m.capturedListTaskPushConfigRequest = req
 	if _, ok := m.tasks[req.TaskID]; ok {
 		if pushConfigs, ok := m.pushConfigs[req.TaskID]; ok {
-			var result []*a2a.TaskPushConfig
+			var result []*a2a.PushConfig
 			for _, v := range pushConfigs {
 				result = append(result, v)
 			}
 			return result, nil
 		}
-		return []*a2a.TaskPushConfig{}, nil // no configs for task id
+		return []*a2a.PushConfig{}, nil // no configs for task id
 	}
 
-	return []*a2a.TaskPushConfig{}, fmt.Errorf("task for push config not found, taskID: %s", req.TaskID)
+	return []*a2a.PushConfig{}, fmt.Errorf("task for push config not found, taskID: %s", req.TaskID)
 }
 
 func (m *mockRequestHandler) DeleteTaskPushConfig(ctx context.Context, req *a2a.DeleteTaskPushConfigRequest) error {
@@ -897,7 +896,7 @@ func TestGrpcHandler_CreateTaskPushNotificationConfig(t *testing.T) {
 	ctx := t.Context()
 	taskID := a2a.TaskID("test-task")
 	mockHandler := &mockRequestHandler{
-		pushConfigs: make(map[a2a.TaskID]map[string]*a2a.TaskPushConfig),
+		pushConfigs: make(map[a2a.TaskID]map[string]*a2a.PushConfig),
 		tasks: map[a2a.TaskID]*a2a.Task{
 			taskID: {ID: taskID, ContextID: "test-context"},
 		},
@@ -908,7 +907,7 @@ func TestGrpcHandler_CreateTaskPushNotificationConfig(t *testing.T) {
 		name        string
 		req         *a2apb.TaskPushNotificationConfig
 		want        *a2apb.TaskPushNotificationConfig
-		wantRequest *a2a.CreateTaskPushConfigRequest
+		wantRequest *a2a.PushConfig
 		wantErr     codes.Code
 	}{
 		{
@@ -923,9 +922,10 @@ func TestGrpcHandler_CreateTaskPushNotificationConfig(t *testing.T) {
 				Id:     "test-config",
 				Url:    "https://example.com",
 			},
-			wantRequest: &a2a.CreateTaskPushConfigRequest{
+			wantRequest: &a2a.PushConfig{
 				TaskID: taskID,
-				Config: a2a.PushConfig{ID: "test-config", URL: "https://example.com"},
+				ID:     "test-config",
+				URL:    "https://example.com",
 			},
 		},
 		{
@@ -974,9 +974,9 @@ func TestGrpcHandler_GetTaskPushNotificationConfig(t *testing.T) {
 	taskID := a2a.TaskID("test-task")
 	configID := "test-config"
 	mockHandler := &mockRequestHandler{
-		pushConfigs: map[a2a.TaskID]map[string]*a2a.TaskPushConfig{
+		pushConfigs: map[a2a.TaskID]map[string]*a2a.PushConfig{
 			taskID: {
-				configID: {TaskID: taskID, Config: a2a.PushConfig{ID: configID}},
+				configID: {TaskID: taskID, ID: configID},
 			},
 		},
 		tasks: map[a2a.TaskID]*a2a.Task{
@@ -1049,10 +1049,10 @@ func TestGrpcHandler_ListTaskPushNotificationConfig(t *testing.T) {
 	taskID := a2a.TaskID("test-task")
 	configID := "test-config"
 	mockHandler := &mockRequestHandler{
-		pushConfigs: map[a2a.TaskID]map[string]*a2a.TaskPushConfig{
+		pushConfigs: map[a2a.TaskID]map[string]*a2a.PushConfig{
 			taskID: {
-				fmt.Sprintf("%s-1", configID): {TaskID: taskID, Config: a2a.PushConfig{ID: fmt.Sprintf("%s-1", configID)}},
-				fmt.Sprintf("%s-2", configID): {TaskID: taskID, Config: a2a.PushConfig{ID: fmt.Sprintf("%s-2", configID)}},
+				fmt.Sprintf("%s-1", configID): {TaskID: taskID, ID: fmt.Sprintf("%s-1", configID)},
+				fmt.Sprintf("%s-2", configID): {TaskID: taskID, ID: fmt.Sprintf("%s-2", configID)},
 			},
 		},
 		tasks: map[a2a.TaskID]*a2a.Task{
@@ -1133,9 +1133,9 @@ func TestGrpcHandler_DeleteTaskPushNotificationConfig(t *testing.T) {
 	taskID := a2a.TaskID("test-task")
 	configID := "test-config"
 	mockHandler := &mockRequestHandler{
-		pushConfigs: map[a2a.TaskID]map[string]*a2a.TaskPushConfig{
+		pushConfigs: map[a2a.TaskID]map[string]*a2a.PushConfig{
 			taskID: {
-				configID: {TaskID: taskID, Config: a2a.PushConfig{ID: configID}},
+				configID: {TaskID: taskID, ID: configID},
 			},
 		},
 		tasks: map[a2a.TaskID]*a2a.Task{

--- a/a2apb/v0/pbconv/from_proto.go
+++ b/a2apb/v0/pbconv/from_proto.go
@@ -260,7 +260,7 @@ func FromProtoListTasksResponse(resp *a2apb.ListTasksResponse) (*a2a.ListTasksRe
 }
 
 // FromProtoCreateTaskPushConfigRequest converts a [a2apb.CreateTaskPushNotificationConfigRequest] to a [a2a.CreateTaskPushConfigRequest].
-func FromProtoCreateTaskPushConfigRequest(req *a2apb.CreateTaskPushNotificationConfigRequest) (*a2a.CreateTaskPushConfigRequest, error) {
+func FromProtoCreateTaskPushConfigRequest(req *a2apb.CreateTaskPushNotificationConfigRequest) (*a2a.PushConfig, error) {
 	if req == nil {
 		return nil, nil
 	}
@@ -280,7 +280,7 @@ func FromProtoCreateTaskPushConfigRequest(req *a2apb.CreateTaskPushNotificationC
 		return nil, fmt.Errorf("failed to extract task id: %w", err)
 	}
 
-	return &a2a.CreateTaskPushConfigRequest{TaskID: taskID, Config: *pConf}, nil
+	return &a2a.PushConfig{TaskID: taskID, ID: pConf.ID, URL: pConf.URL, Token: pConf.Token, Auth: pConf.Auth}, nil
 }
 
 // FromProtoGetTaskPushConfigRequest converts a [a2apb.GetTaskPushNotificationConfigRequest] to a [a2a.GetTaskPushConfigRequest].
@@ -512,8 +512,8 @@ func FromProtoTask(pTask *a2apb.Task) (*a2a.Task, error) {
 	return result, nil
 }
 
-// FromProtoTaskPushConfig converts a [a2apb.TaskPushNotificationConfig] to a [a2a.TaskPushConfig].
-func FromProtoTaskPushConfig(pTaskConfig *a2apb.TaskPushNotificationConfig) (*a2a.TaskPushConfig, error) {
+// FromProtoTaskPushConfig converts a [a2apb.TaskPushNotificationConfig] to a [a2a.PushConfig].
+func FromProtoTaskPushConfig(pTaskConfig *a2apb.TaskPushNotificationConfig) (*a2a.PushConfig, error) {
 	if pTaskConfig == nil {
 		return nil, nil
 	}
@@ -542,7 +542,7 @@ func FromProtoTaskPushConfig(pTaskConfig *a2apb.TaskPushNotificationConfig) (*a2
 		return nil, fmt.Errorf("failed to convert push config: %w", err)
 	}
 
-	return &a2a.TaskPushConfig{TaskID: taskID, Config: *config}, nil
+	return &a2a.PushConfig{TaskID: taskID, ID: config.ID, URL: config.URL, Token: config.Token, Auth: config.Auth}, nil
 }
 
 // FromProtoListTaskPushConfigRequest converts a [a2apb.ListTaskPushNotificationConfigRequest] to a [a2a.ListTaskPushConfigRequest].
@@ -569,7 +569,7 @@ func FromProtoListTaskPushConfigResponse(resp *a2apb.ListTaskPushNotificationCon
 		return nil, fmt.Errorf("response is nil")
 	}
 
-	configs := make([]*a2a.TaskPushConfig, len(resp.GetConfigs()))
+	configs := make([]*a2a.PushConfig, len(resp.GetConfigs()))
 	for i, pConfig := range resp.GetConfigs() {
 		config, err := FromProtoTaskPushConfig(pConfig)
 		if err != nil {

--- a/a2apb/v0/pbconv/from_proto_test.go
+++ b/a2apb/v0/pbconv/from_proto_test.go
@@ -519,7 +519,7 @@ func TestFromProto_fromProtoCreateTaskPushConfigRequest(t *testing.T) {
 	tests := []struct {
 		name    string
 		req     *a2apb.CreateTaskPushNotificationConfigRequest
-		want    *a2a.CreateTaskPushConfigRequest
+		want    *a2a.PushConfig
 		wantErr bool
 	}{
 		{
@@ -530,7 +530,7 @@ func TestFromProto_fromProtoCreateTaskPushConfigRequest(t *testing.T) {
 					PushNotificationConfig: &a2apb.PushNotificationConfig{Id: "test-config"},
 				},
 			},
-			want: &a2a.CreateTaskPushConfigRequest{TaskID: "test", Config: a2a.PushConfig{ID: "test-config"}},
+			want: &a2a.PushConfig{TaskID: "test", ID: "test-config"},
 		},
 		{
 			name: "nil config",
@@ -562,7 +562,7 @@ func TestFromProto_fromProtoCreateTaskPushConfigRequest(t *testing.T) {
 					PushNotificationConfig: &a2apb.PushNotificationConfig{Id: ""},
 				},
 			},
-			want: &a2a.CreateTaskPushConfigRequest{TaskID: "t1", Config: a2a.PushConfig{}},
+			want: &a2a.PushConfig{TaskID: "t1", ID: ""},
 		},
 	}
 	for _, tt := range tests {

--- a/a2apb/v0/pbconv/from_proto_test.go
+++ b/a2apb/v0/pbconv/from_proto_test.go
@@ -232,7 +232,7 @@ func TestFromProto_fromProtoSendMessageConfig(t *testing.T) {
 				t.Fatalf("fromProtoSendMessageConfig() error = %v", err)
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("fromProtoSendMessageConfig() wrong result (+got,-want)\ngot = %v\n want %v\ndiff = %s", got, tt.want, diff)
+				t.Errorf("fromProtoSendMessageConfig() wrong result (-want +got)\ngot = %v\n want %v\ndiff = %s", got, tt.want, diff)
 			}
 		})
 	}
@@ -509,7 +509,7 @@ func TestFromProto_fromProtoListTasksResponse(t *testing.T) {
 				return
 			}
 			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("fromProtoListTasksResponse() mismatch (+got -want):\n%s", diff)
+				t.Errorf("fromProtoListTasksResponse() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/a2apb/v0/pbconv/to_proto.go
+++ b/a2apb/v0/pbconv/to_proto.go
@@ -134,20 +134,20 @@ func ToProtoTaskSubscriptionRequest(req *a2a.SubscribeToTaskRequest) (*a2apb.Tas
 	return &a2apb.TaskSubscriptionRequest{Name: MakeTaskName(req.ID)}, nil
 }
 
-// ToProtoCreateTaskPushConfigRequest converts a [a2a.CreateTaskPushConfigRequest] to a [a2apb.CreateTaskPushNotificationConfigRequest].
-func ToProtoCreateTaskPushConfigRequest(req *a2a.CreateTaskPushConfigRequest) (*a2apb.CreateTaskPushNotificationConfigRequest, error) {
+// ToProtoCreateTaskPushConfigRequest converts a [a2a.TaskPushConfig] to a [a2apb.CreateTaskPushNotificationConfigRequest].
+func ToProtoCreateTaskPushConfigRequest(req *a2a.PushConfig) (*a2apb.CreateTaskPushNotificationConfigRequest, error) {
 	if req == nil {
 		return nil, nil
 	}
 
-	pnc, err := toProtoPushConfig(&req.Config)
+	pnc, err := toProtoPushConfig(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert push config: %w", err)
 	}
 
 	return &a2apb.CreateTaskPushNotificationConfigRequest{
 		Parent:   MakeTaskName(req.TaskID),
-		ConfigId: req.Config.ID,
+		ConfigId: req.ID,
 		Config:   &a2apb.TaskPushNotificationConfig{PushNotificationConfig: pnc},
 	}, nil
 }
@@ -561,8 +561,8 @@ func ToProtoListTasksResponse(response *a2a.ListTasksResponse) (*a2apb.ListTasks
 	return result, nil
 }
 
-// ToProtoTaskPushConfig converts a [a2a.TaskPushConfig] to a [a2apb.TaskPushNotificationConfig].
-func ToProtoTaskPushConfig(config *a2a.TaskPushConfig) (*a2apb.TaskPushNotificationConfig, error) {
+// ToProtoTaskPushConfig converts a [a2a.PushConfig] to a [a2apb.TaskPushNotificationConfig].
+func ToProtoTaskPushConfig(config *a2a.PushConfig) (*a2apb.TaskPushNotificationConfig, error) {
 	if config == nil {
 		return nil, nil
 	}
@@ -571,7 +571,7 @@ func ToProtoTaskPushConfig(config *a2a.TaskPushConfig) (*a2apb.TaskPushNotificat
 		return nil, fmt.Errorf("taskID is required on TaskPushConfig")
 	}
 
-	pConfig, err := toProtoPushConfig(&config.Config)
+	pConfig, err := toProtoPushConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/a2apb/v0/pbconv/to_proto_test.go
+++ b/a2apb/v0/pbconv/to_proto_test.go
@@ -98,7 +98,7 @@ func TestToProto_toProtoMessage(t *testing.T) {
 					t.Errorf("fromProtoMessages() error = %v", err)
 				}
 				if diff := cmp.Diff([]*a2a.Message{tt.msg}, gotBack); diff != "" {
-					t.Errorf("fromProtoMessages() wrong result (+got,-want):\n diff = %s", diff)
+					t.Errorf("fromProtoMessages() wrong result (-want +got):\n diff = %s", diff)
 				}
 			}
 		})
@@ -973,7 +973,7 @@ func TestToProto_toProtoAgentCard(t *testing.T) {
 				t.Errorf("FromProtoAgentCard() error = %v", err)
 			}
 			if diff := cmp.Diff(tt.card, gotBack); diff != "" {
-				t.Errorf("FromProtoAgentCard() wrong result (+got,-want):\ndiff = %s", diff)
+				t.Errorf("FromProtoAgentCard() wrong result (-want +got):\ndiff = %s", diff)
 			}
 		})
 	}

--- a/a2apb/v0/pbconv/to_proto_test.go
+++ b/a2apb/v0/pbconv/to_proto_test.go
@@ -444,22 +444,20 @@ func TestToProto_toProtoTaskStatus(t *testing.T) {
 func TestToProto_toProtoTaskPushConfig(t *testing.T) {
 	tests := []struct {
 		name    string
-		config  *a2a.TaskPushConfig
+		config  *a2a.PushConfig
 		want    *a2apb.TaskPushNotificationConfig
 		wantErr bool
 	}{
 		{
 			name: "full config",
-			config: &a2a.TaskPushConfig{
+			config: &a2a.PushConfig{
 				TaskID: "t1",
-				Config: a2a.PushConfig{
-					ID:    "c1",
-					URL:   "http://a.com",
-					Token: "tok",
-					Auth: &a2a.PushAuthInfo{
-						Scheme:      "Bearer",
-						Credentials: "cred",
-					},
+				ID:     "c1",
+				URL:    "http://a.com",
+				Token:  "tok",
+				Auth: &a2a.PushAuthInfo{
+					Scheme:      "Bearer",
+					Credentials: "cred",
 				},
 			},
 			want: &a2apb.TaskPushNotificationConfig{
@@ -477,9 +475,10 @@ func TestToProto_toProtoTaskPushConfig(t *testing.T) {
 		},
 		{
 			name: "config without auth",
-			config: &a2a.TaskPushConfig{
+			config: &a2a.PushConfig{
 				TaskID: "t1",
-				Config: a2a.PushConfig{ID: "c1", URL: "http://a.com"},
+				ID:     "c1",
+				URL:    "http://a.com",
 			},
 			want: &a2apb.TaskPushNotificationConfig{
 				Name: "tasks/t1/pushNotificationConfigs/c1",
@@ -496,9 +495,9 @@ func TestToProto_toProtoTaskPushConfig(t *testing.T) {
 		},
 		{
 			name: "empty inner push config",
-			config: &a2a.TaskPushConfig{
+			config: &a2a.PushConfig{
 				TaskID: "test-task",
-				Config: a2a.PushConfig{},
+				ID:     "",
 			},
 			want: &a2apb.TaskPushNotificationConfig{
 				Name:                   "tasks/test-task/pushNotificationConfigs/",
@@ -522,9 +521,9 @@ func TestToProto_toProtoTaskPushConfig(t *testing.T) {
 }
 
 func TestToProto_toProtoListTaskPushConfigResponse(t *testing.T) {
-	configs := []*a2a.TaskPushConfig{
-		{TaskID: "test-task", Config: a2a.PushConfig{ID: "test-config1"}},
-		{TaskID: "test-task", Config: a2a.PushConfig{ID: "test-config2"}},
+	configs := []*a2a.PushConfig{
+		{TaskID: "test-task", ID: "test-config1"},
+		{TaskID: "test-task", ID: "test-config2"},
 	}
 	pConf1, _ := ToProtoTaskPushConfig(configs[0])
 	pConf2, _ := ToProtoTaskPushConfig(configs[1])
@@ -538,7 +537,7 @@ func TestToProto_toProtoListTaskPushConfigResponse(t *testing.T) {
 		{
 			name: "success",
 			resp: &a2a.ListTaskPushConfigResponse{
-				Configs: []*a2a.TaskPushConfig{
+				Configs: []*a2a.PushConfig{
 					configs[0],
 					configs[1],
 				},
@@ -550,7 +549,7 @@ func TestToProto_toProtoListTaskPushConfigResponse(t *testing.T) {
 		{
 			name: "empty slice",
 			resp: &a2a.ListTaskPushConfigResponse{
-				Configs: []*a2a.TaskPushConfig{},
+				Configs: []*a2a.PushConfig{},
 			},
 			want: &a2apb.ListTaskPushNotificationConfigResponse{
 				Configs: []*a2apb.TaskPushNotificationConfig{},
@@ -559,7 +558,7 @@ func TestToProto_toProtoListTaskPushConfigResponse(t *testing.T) {
 		{
 			name: "conversion error",
 			resp: &a2a.ListTaskPushConfigResponse{
-				Configs: []*a2a.TaskPushConfig{{TaskID: "", Config: a2a.PushConfig{ID: "test"}}},
+				Configs: []*a2a.PushConfig{{TaskID: "", ID: "test"}},
 			},
 			wantErr: true,
 		},

--- a/a2apb/v1/pbconv/from_proto.go
+++ b/a2apb/v1/pbconv/from_proto.go
@@ -132,30 +132,6 @@ func fromProtoRole(role a2apb.Role) a2a.MessageRole {
 	}
 }
 
-func fromProtoPushConfig(pConf *a2apb.TaskPushNotificationConfig) (*a2a.PushConfig, error) {
-	if pConf == nil {
-		return nil, nil
-	}
-
-	auth, err := fromProtoAuthenticationInfo(pConf.GetAuthentication())
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert authentication info: %w", err)
-	}
-	url := pConf.GetUrl()
-	if url == "" {
-		return nil, fmt.Errorf("url cannot be empty")
-	}
-
-	result := &a2a.PushConfig{
-		ID:    pConf.GetId(),
-		URL:   url,
-		Token: pConf.GetToken(),
-		Auth:  auth,
-	}
-
-	return result, nil
-}
-
 func fromProtoAuthenticationInfo(pAuth *a2apb.AuthenticationInfo) (*a2a.PushAuthInfo, error) {
 	if pAuth == nil {
 		return nil, nil
@@ -175,7 +151,7 @@ func fromProtoSendMessageConfig(conf *a2apb.SendMessageConfiguration) (*a2a.Send
 		return nil, nil
 	}
 
-	pConf, err := fromProtoPushConfig(conf.GetTaskPushNotificationConfig())
+	pConf, err := FromProtoTaskPushConfig(conf.GetTaskPushNotificationConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert push config: %w", err)
 	}
@@ -309,28 +285,6 @@ func FromProtoListTasksResponse(resp *a2apb.ListTasksResponse) (*a2a.ListTasksRe
 		TotalSize:     int(resp.GetTotalSize()),
 		PageSize:      int(resp.GetPageSize()),
 		NextPageToken: resp.GetNextPageToken(),
-	}, nil
-}
-
-// FromProtoCreateTaskPushConfigRequest converts a [a2apb.CreateTaskPushNotificationConfigRequest] to a [a2a.CreateTaskPushConfigRequest].
-func FromProtoCreateTaskPushConfigRequest(req *a2apb.TaskPushNotificationConfig) (*a2a.CreateTaskPushConfigRequest, error) {
-	if req == nil {
-		return nil, nil
-	}
-
-	pConf, err := fromProtoPushConfig(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert push config: %w", err)
-	}
-	taskID := a2a.TaskID(req.GetTaskId())
-	if taskID == "" {
-		return nil, fmt.Errorf("task id cannot be empty")
-	}
-
-	return &a2a.CreateTaskPushConfigRequest{
-		Tenant: req.GetTenant(),
-		Config: *pConf,
-		TaskID: taskID,
 	}, nil
 }
 
@@ -577,31 +531,32 @@ func FromProtoTask(pTask *a2apb.Task) (*a2a.Task, error) {
 }
 
 // FromProtoTaskPushConfig converts a [a2apb.TaskPushNotificationConfig] to a [a2a.TaskPushConfig].
-func FromProtoTaskPushConfig(pTaskConfig *a2apb.TaskPushNotificationConfig) (*a2a.TaskPushConfig, error) {
+func FromProtoTaskPushConfig(pTaskConfig *a2apb.TaskPushNotificationConfig) (*a2a.PushConfig, error) {
 	if pTaskConfig == nil {
 		return nil, nil
 	}
-
-	taskID := a2a.TaskID(pTaskConfig.GetTaskId())
-	if taskID == "" {
-		return nil, fmt.Errorf("task id cannot be empty")
-	}
-
-	config, err := fromProtoPushConfig(pTaskConfig)
+	auth, err := fromProtoAuthenticationInfo(pTaskConfig.GetAuthentication())
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert push config: %w", err)
+		return nil, fmt.Errorf("failed to convert authentication info: %w", err)
+	}
+	url := pTaskConfig.GetUrl()
+	if url == "" {
+		return nil, fmt.Errorf("url cannot be empty")
 	}
 
-	return &a2a.TaskPushConfig{
+	return &a2a.PushConfig{
 		Tenant: pTaskConfig.GetTenant(),
-		Config: *config,
-		TaskID: taskID,
+		TaskID: a2a.TaskID(pTaskConfig.GetTaskId()),
+		ID:     pTaskConfig.GetId(),
+		URL:    url,
+		Auth:   auth,
+		Token:  pTaskConfig.GetToken(),
 	}, nil
 }
 
 // FromProtoListTaskPushConfigResponse converts a [a2apb.ListTaskPushNotificationConfigResponse] to a [a2a.ListTaskPushConfigResponse].
 func FromProtoListTaskPushConfigResponse(resp *a2apb.ListTaskPushNotificationConfigsResponse) (*a2a.ListTaskPushConfigResponse, error) {
-	configs := make([]*a2a.TaskPushConfig, len(resp.GetConfigs()))
+	configs := make([]*a2a.PushConfig, len(resp.GetConfigs()))
 	for i, pConfig := range resp.GetConfigs() {
 		config, err := FromProtoTaskPushConfig(pConfig)
 		if err != nil {

--- a/a2apb/v1/pbconv/from_proto_test.go
+++ b/a2apb/v1/pbconv/from_proto_test.go
@@ -523,61 +523,6 @@ func TestFromProto_fromProtoListTasksResponse(t *testing.T) {
 	}
 }
 
-func TestFromProto_fromProtoCreateTaskPushConfigRequest(t *testing.T) {
-	tests := []struct {
-		name    string
-		req     *a2apb.TaskPushNotificationConfig
-		want    *a2a.CreateTaskPushConfigRequest
-		wantErr bool
-	}{
-		{
-			name: "success",
-			req: &a2apb.TaskPushNotificationConfig{
-				TaskId: "test-task",
-				Url:    "http://example.com/hook",
-				Id:     "test-config",
-			},
-			want: &a2a.CreateTaskPushConfigRequest{TaskID: "test-task", Config: a2a.PushConfig{ID: "test-config", URL: "http://example.com/hook"}},
-		},
-		{
-			name: "nil config",
-			req: &a2apb.TaskPushNotificationConfig{
-				TaskId: "test",
-			},
-			wantErr: true,
-		},
-		{
-			name: "nil push config",
-			req: &a2apb.TaskPushNotificationConfig{
-				TaskId: "test",
-				Url:    "",
-			},
-			wantErr: true,
-		},
-		{
-			name: "empty optional ID conversion push config conversion",
-			req: &a2apb.TaskPushNotificationConfig{
-				TaskId: "t1",
-				Id:     "",
-				Url:    "http://example.com/hook",
-			},
-			want: &a2a.CreateTaskPushConfigRequest{TaskID: "t1", Config: a2a.PushConfig{URL: "http://example.com/hook"}},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := FromProtoCreateTaskPushConfigRequest(tt.req)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("fromProtoCreateTaskPushConfigRequest() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("fromProtoCreateTaskPushConfigRequest() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestFromProto_fromProtoGetTaskPushConfigRequest(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/a2apb/v1/pbconv/from_proto_test.go
+++ b/a2apb/v1/pbconv/from_proto_test.go
@@ -225,7 +225,7 @@ func TestFromProto_fromProtoSendMessageConfig(t *testing.T) {
 				t.Fatalf("fromProtoSendMessageConfig() error = %v", err)
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("fromProtoSendMessageConfig() wrong result (+got,-want)\ngot = %v\n want %v\ndiff = %s", got, tt.want, diff)
+				t.Errorf("fromProtoSendMessageConfig() wrong result (-want +got)\ngot = %v\n want %v\ndiff = %s", got, tt.want, diff)
 			}
 		})
 	}
@@ -517,7 +517,7 @@ func TestFromProto_fromProtoListTasksResponse(t *testing.T) {
 				return
 			}
 			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("fromProtoListTasksResponse() mismatch (+got -want):\n%s", diff)
+				t.Errorf("fromProtoListTasksResponse() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/a2apb/v1/pbconv/to_proto.go
+++ b/a2apb/v1/pbconv/to_proto.go
@@ -65,27 +65,6 @@ func ToProtoSendMessageRequest(req *a2a.SendMessageRequest) (*a2apb.SendMessageR
 	}, nil
 }
 
-func toProtoPushConfig(config *a2a.PushConfig) (*a2apb.TaskPushNotificationConfig, error) {
-	// TODO: add validation
-	if config == nil {
-		return nil, nil
-	}
-
-	auth, err := toProtoAuthenticationInfo(config.Auth)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert authentication info: %w", err)
-	}
-
-	pConf := &a2apb.TaskPushNotificationConfig{
-		Id:             config.ID,
-		Url:            config.URL,
-		Token:          config.Token,
-		Authentication: auth,
-	}
-
-	return pConf, nil
-}
-
 func toProtoAuthenticationInfo(auth *a2a.PushAuthInfo) (*a2apb.AuthenticationInfo, error) {
 	// TODO: add validation
 	if auth == nil {
@@ -102,7 +81,7 @@ func toProtoSendMessageConfig(config *a2a.SendMessageConfig) (*a2apb.SendMessage
 		return nil, nil
 	}
 
-	pushConf, err := toProtoPushConfig(config.PushConfig)
+	pushConf, err := ToProtoTaskPushConfig(config.PushConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert push config: %w", err)
 	}
@@ -110,8 +89,8 @@ func toProtoSendMessageConfig(config *a2a.SendMessageConfig) (*a2apb.SendMessage
 	pConf := &a2apb.SendMessageConfiguration{
 		AcceptedOutputModes:        config.AcceptedOutputModes,
 		TaskPushNotificationConfig: pushConf,
+		ReturnImmediately:          config.ReturnImmediately,
 	}
-	pConf.ReturnImmediately = config.ReturnImmediately
 	if config.HistoryLength != nil {
 		pConf.HistoryLength = proto.Int32(int32(*config.HistoryLength))
 	}
@@ -164,24 +143,6 @@ func ToProtoSubscribeToTaskRequest(req *a2a.SubscribeToTaskRequest) (*a2apb.Subs
 		Tenant: req.Tenant,
 		Id:     string(req.ID),
 	}, nil
-}
-
-// ToProtoCreateTaskPushConfigRequest converts a [a2a.CreateTaskPushConfigRequest] to a [a2apb.TaskPushNotificationConfig].
-func ToProtoCreateTaskPushConfigRequest(config *a2a.CreateTaskPushConfigRequest) (*a2apb.TaskPushNotificationConfig, error) {
-	// TODO: add validation
-	if config == nil {
-		return nil, nil
-	}
-
-	pConfig, err := toProtoPushConfig(&config.Config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert push config: %w", err)
-	}
-
-	pConfig.Tenant = config.Tenant
-	pConfig.TaskId = string(config.TaskID)
-
-	return pConfig, nil
 }
 
 // ToProtoGetTaskPushConfigRequest converts a [a2a.GetTaskPushConfigRequest] to a [a2apb.GetTaskPushNotificationConfigRequest].
@@ -552,26 +513,29 @@ func ToProtoListTasksResponse(response *a2a.ListTasksResponse) (*a2apb.ListTasks
 	return result, nil
 }
 
-// ToProtoTaskPushConfig converts a [a2a.TaskPushConfig] to a [a2apb.TaskPushNotificationConfig].
-func ToProtoTaskPushConfig(config *a2a.TaskPushConfig) (*a2apb.TaskPushNotificationConfig, error) {
+// ToProtoTaskPushConfig converts a [a2a.PushConfig] to a [a2apb.TaskPushNotificationConfig].
+func ToProtoTaskPushConfig(config *a2a.PushConfig) (*a2apb.TaskPushNotificationConfig, error) {
 	// TODO: add validation
 	if config == nil {
 		return nil, nil
 	}
 
-	if config.TaskID == "" {
-		return nil, fmt.Errorf("taskID is required on TaskPushConfig")
-	}
-
-	pConfig, err := toProtoPushConfig(&config.Config)
+	auth, err := toProtoAuthenticationInfo(config.Auth)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to convert authentication info: %w", err)
 	}
 
-	pConfig.Tenant = config.Tenant
-	pConfig.TaskId = string(config.TaskID)
+	pConf := &a2apb.TaskPushNotificationConfig{
+		Tenant:         config.Tenant,
+		TaskId:         string(config.TaskID),
+		Id:             config.ID,
+		Url:            config.URL,
+		Token:          config.Token,
+		Authentication: auth,
+	}
 
-	return pConfig, nil
+	return pConf, nil
+
 }
 
 // ToProtoListTaskPushConfigResponse converts a [a2a.ListTaskPushConfigResponse] to a [a2apb.ListTaskPushNotificationConfigResponse].

--- a/a2apb/v1/pbconv/to_proto_test.go
+++ b/a2apb/v1/pbconv/to_proto_test.go
@@ -431,25 +431,23 @@ func TestToProto_toProtoTaskStatus(t *testing.T) {
 	}
 }
 
-func TestToProto_toProtoTaskPushConfig(t *testing.T) {
+func TestToProto_ToProtoTaskPushConfig(t *testing.T) {
 	tests := []struct {
 		name    string
-		config  *a2a.TaskPushConfig
+		config  *a2a.PushConfig
 		want    *a2apb.TaskPushNotificationConfig
 		wantErr bool
 	}{
 		{
 			name: "full config",
-			config: &a2a.TaskPushConfig{
+			config: &a2a.PushConfig{
 				TaskID: "t1",
-				Config: a2a.PushConfig{
-					ID:    "c1",
-					URL:   "http://a.com",
-					Token: "tok",
-					Auth: &a2a.PushAuthInfo{
-						Scheme:      "Bearer",
-						Credentials: "cred",
-					},
+				ID:     "c1",
+				URL:    "http://a.com",
+				Token:  "tok",
+				Auth: &a2a.PushAuthInfo{
+					Scheme:      "Bearer",
+					Credentials: "cred",
 				},
 			},
 			want: &a2apb.TaskPushNotificationConfig{
@@ -465,9 +463,10 @@ func TestToProto_toProtoTaskPushConfig(t *testing.T) {
 		},
 		{
 			name: "config without auth",
-			config: &a2a.TaskPushConfig{
+			config: &a2a.PushConfig{
 				TaskID: "t1",
-				Config: a2a.PushConfig{ID: "c1", URL: "http://a.com"},
+				ID:     "c1",
+				URL:    "http://a.com",
 			},
 			want: &a2apb.TaskPushNotificationConfig{
 				TaskId: "t1",
@@ -482,9 +481,8 @@ func TestToProto_toProtoTaskPushConfig(t *testing.T) {
 		},
 		{
 			name: "empty inner push config",
-			config: &a2a.TaskPushConfig{
+			config: &a2a.PushConfig{
 				TaskID: "test-task",
-				Config: a2a.PushConfig{},
 			},
 			want: &a2apb.TaskPushNotificationConfig{
 				TaskId: "test-task",
@@ -508,9 +506,9 @@ func TestToProto_toProtoTaskPushConfig(t *testing.T) {
 
 func TestToProto_toProtoListTaskPushConfigResponse(t *testing.T) {
 	configs := &a2a.ListTaskPushConfigResponse{
-		Configs: []*a2a.TaskPushConfig{
-			{TaskID: "test-task", Config: a2a.PushConfig{ID: "test-config1"}},
-			{TaskID: "test-task", Config: a2a.PushConfig{ID: "test-config2"}},
+		Configs: []*a2a.PushConfig{
+			{TaskID: "test-task", ID: "test-config1"},
+			{TaskID: "test-task", ID: "test-config2"},
 		},
 		NextPageToken: "next",
 	}
@@ -537,11 +535,6 @@ func TestToProto_toProtoListTaskPushConfigResponse(t *testing.T) {
 			want: &a2apb.ListTaskPushNotificationConfigsResponse{
 				Configs: []*a2apb.TaskPushNotificationConfig{},
 			},
-		},
-		{
-			name:    "conversion error",
-			configs: &a2a.ListTaskPushConfigResponse{Configs: []*a2a.TaskPushConfig{{TaskID: "", Config: a2a.PushConfig{ID: "test"}}}},
-			wantErr: true,
 		},
 	}
 

--- a/a2apb/v1/pbconv/to_proto_test.go
+++ b/a2apb/v1/pbconv/to_proto_test.go
@@ -97,7 +97,7 @@ func TestToProto_toProtoMessage(t *testing.T) {
 					t.Errorf("fromProtoMessages() error = %v", err)
 				}
 				if diff := cmp.Diff([]*a2a.Message{tt.msg}, gotBack); diff != "" {
-					t.Errorf("fromProtoMessages() wrong result (+got,-want):\n diff = %s", diff)
+					t.Errorf("fromProtoMessages() wrong result (-want +got):\n diff = %s", diff)
 				}
 			}
 		})
@@ -945,7 +945,7 @@ func TestToProto_toProtoAgentCard(t *testing.T) {
 				t.Errorf("FromProtoAgentCard() error = %v", err)
 			}
 			if diff := cmp.Diff(tt.card, gotBack); diff != "" {
-				t.Errorf("FromProtoAgentCard() wrong result (+got,-want):\ndiff = %s", diff)
+				t.Errorf("FromProtoAgentCard() wrong result (-want +got):\ndiff = %s", diff)
 			}
 		})
 	}

--- a/a2asrv/agentcard_test.go
+++ b/a2asrv/agentcard_test.go
@@ -146,7 +146,7 @@ func TestAgentCardHandler(t *testing.T) {
 						t.Errorf("json.Decode() error = %v", err)
 					}
 					if diff := cmp.Diff(card, &gotCard); diff != "" {
-						t.Errorf("wrong card (+got,-want) diff = %s", diff)
+						t.Errorf("wrong card (-want +got) diff = %s", diff)
 					}
 				}
 			})

--- a/a2asrv/eventqueue/manager_in_memory_impl_test.go
+++ b/a2asrv/eventqueue/manager_in_memory_impl_test.go
@@ -49,7 +49,7 @@ func TestInMemoryManager(t *testing.T) {
 		t.Fatalf("reader.Read() error = %v", err)
 	}
 	if diff := cmp.Diff(wantEvent, got.Event); diff != "" {
-		t.Fatalf("reader.Read() wrong result (+got,-want) diff = %s", diff)
+		t.Fatalf("reader.Read() wrong result (-want +got) diff = %s", diff)
 	}
 	<-doneChan
 	if err := manager.Destroy(ctx, tid); err != nil {
@@ -112,7 +112,7 @@ func TestInMemoryManager_ConcurrentCreation(t *testing.T) {
 				t.Fatalf("readQueue.Read() error = %v", err)
 			}
 			if diff := cmp.Diff(want, got.Event); diff != "" {
-				t.Fatalf("readQueue.Read() wrong result (+got,-want) diff = %s", diff)
+				t.Fatalf("readQueue.Read() wrong result (-want +got) diff = %s", diff)
 			}
 		}
 	}

--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -51,13 +51,13 @@ type RequestHandler interface {
 	SendStreamingMessage(context.Context, *a2a.SendMessageRequest) iter.Seq2[a2a.Event, error]
 
 	// GetTaskPushConfig handles the `GetTaskPushNotificationConfig` protocol method.
-	GetTaskPushConfig(context.Context, *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error)
+	GetTaskPushConfig(context.Context, *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error)
 
 	// ListTaskPushConfigs handles the `ListTaskPushNotificationConfigs` protocol method.
-	ListTaskPushConfigs(context.Context, *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error)
+	ListTaskPushConfigs(context.Context, *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error)
 
 	// CreateTaskPushConfig handles the `CreateTaskPushNotificationConfig` protocol method.
-	CreateTaskPushConfig(context.Context, *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error)
+	CreateTaskPushConfig(context.Context, *a2a.PushConfig) (*a2a.PushConfig, error)
 
 	// DeleteTaskPushConfig handles the `DeleteTaskPushNotificationConfig` protocol method.
 	DeleteTaskPushConfig(context.Context, *a2a.DeleteTaskPushConfigRequest) error
@@ -362,7 +362,7 @@ func (h *defaultRequestHandler) handleSendMessage(ctx context.Context, req *a2a.
 }
 
 // GetTaskPushConfig implements RequestHandler.
-func (h *defaultRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (h *defaultRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	if err := checkPushNotificationSupport(h, ctx); err != nil {
 		return nil, err
 	}
@@ -370,17 +370,14 @@ func (h *defaultRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.
 	if err != nil {
 		return nil, fmt.Errorf("failed to get push configs: %w", err)
 	}
-	if config != nil {
-		return &a2a.TaskPushConfig{
-			TaskID: req.TaskID,
-			Config: *config,
-		}, nil
+	if config == nil {
+		return nil, push.ErrPushConfigNotFound
 	}
-	return nil, push.ErrPushConfigNotFound
+	return config, nil
 }
 
 // ListTaskPushConfigs implements RequestHandler.
-func (h *defaultRequestHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (h *defaultRequestHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	if err := checkPushNotificationSupport(h, ctx); err != nil {
 		return nil, err
 	}
@@ -388,28 +385,21 @@ func (h *defaultRequestHandler) ListTaskPushConfigs(ctx context.Context, req *a2
 	if err != nil {
 		return nil, fmt.Errorf("failed to list push configs: %w", err)
 	}
-	result := make([]*a2a.TaskPushConfig, len(configs))
-	for i, config := range configs {
-		result[i] = &a2a.TaskPushConfig{
-			TaskID: req.TaskID,
-			Config: *config,
-		}
-	}
-	return result, nil
+	return configs, nil
 }
 
 // CreateTaskPushConfig implements RequestHandler.
-func (h *defaultRequestHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (h *defaultRequestHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	if err := checkPushNotificationSupport(h, ctx); err != nil {
 		return nil, err
 	}
 
-	saved, err := h.pushConfigStore.Save(ctx, req.TaskID, &req.Config)
+	saved, err := h.pushConfigStore.Save(ctx, req.TaskID, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to save push config: %w", err)
 	}
 
-	return &a2a.TaskPushConfig{TaskID: req.TaskID, Config: *saved}, nil
+	return saved, nil
 }
 
 // DeleteTaskPushConfig implements RequestHandler.
@@ -453,16 +443,16 @@ func shouldInterruptNonStreaming(req *a2a.SendMessageRequest, event a2a.Event) (
 }
 
 func checkPushNotificationSupport(h *defaultRequestHandler, ctx context.Context) error {
-	// With capability checks, PushNootifications not supported
+	// With capability checks, PushNotifications not supported
 	if h.capabilities != nil && !h.capabilities.PushNotifications {
 		return a2a.ErrPushNotificationNotSupported
 	}
-	// With capability checks, PushNootifications supported, but not configured
+	// With capability checks, PushNotifications supported, but not configured
 	if h.capabilities != nil && (h.pushConfigStore == nil || h.pushSender == nil) {
 		log.Error(ctx, "push notifications are enabled but push config store or sender is not configured", a2a.ErrInternalError)
 		return a2a.ErrInternalError
 	}
-	// Without capability checks and PushNootifications are not configured
+	// Without capability checks and PushNotifications are not configured
 	if h.pushConfigStore == nil || h.pushSender == nil {
 		return a2a.ErrPushNotificationNotSupported
 	}

--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -385,6 +385,9 @@ func (h *defaultRequestHandler) ListTaskPushConfigs(ctx context.Context, req *a2
 	if err != nil {
 		return nil, fmt.Errorf("failed to list push configs: %w", err)
 	}
+	if configs == nil {
+		return []*a2a.PushConfig{}, nil
+	}
 	return configs, nil
 }
 

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -1800,15 +1800,16 @@ func TestRequestHandler_CreateTaskPushConfig(t *testing.T) {
 
 	testCases := []struct {
 		name    string
-		req     *a2a.CreateTaskPushConfigRequest
+		req     *a2a.PushConfig
 		wantErr error
 		options []RequestHandlerOption
 	}{
 		{
 			name: "valid config with id",
-			req: &a2a.CreateTaskPushConfigRequest{
+			req: &a2a.PushConfig{
 				TaskID: taskID,
-				Config: a2a.PushConfig{ID: "config-1", URL: "https://example.com/push"},
+				ID:     "config-1",
+				URL:    "https://example.com/push",
 			},
 			options: []RequestHandlerOption{
 				WithPushNotifications(ps, pn),
@@ -1816,9 +1817,9 @@ func TestRequestHandler_CreateTaskPushConfig(t *testing.T) {
 		},
 		{
 			name: "valid config without id",
-			req: &a2a.CreateTaskPushConfigRequest{
+			req: &a2a.PushConfig{
 				TaskID: taskID,
-				Config: a2a.PushConfig{URL: "https://example.com/push-no-id"},
+				URL:    "https://example.com/push-no-id",
 			},
 			options: []RequestHandlerOption{
 				WithPushNotifications(ps, pn),
@@ -1826,9 +1827,9 @@ func TestRequestHandler_CreateTaskPushConfig(t *testing.T) {
 		},
 		{
 			name: "invalid config - empty URL",
-			req: &a2a.CreateTaskPushConfigRequest{
+			req: &a2a.PushConfig{
 				TaskID: taskID,
-				Config: a2a.PushConfig{ID: "config-invalid"},
+				ID:     "config-invalid",
 			},
 			wantErr: fmt.Errorf("failed to save push config: %w: push config endpoint cannot be empty", a2a.ErrInvalidParams),
 			options: []RequestHandlerOption{
@@ -1837,9 +1838,10 @@ func TestRequestHandler_CreateTaskPushConfig(t *testing.T) {
 		},
 		{
 			name: "pushNotifications not supported",
-			req: &a2a.CreateTaskPushConfigRequest{
+			req: &a2a.PushConfig{
 				TaskID: taskID,
-				Config: a2a.PushConfig{ID: "config-1", URL: "https://example.com/push"},
+				ID:     "config-1",
+				URL:    "https://example.com/push",
 			},
 			wantErr: a2a.ErrPushNotificationNotSupported,
 			options: []RequestHandlerOption{
@@ -1848,9 +1850,10 @@ func TestRequestHandler_CreateTaskPushConfig(t *testing.T) {
 		},
 		{
 			name: "pushNotifications supported but not configured",
-			req: &a2a.CreateTaskPushConfigRequest{
+			req: &a2a.PushConfig{
 				TaskID: taskID,
-				Config: a2a.PushConfig{ID: "config-1", URL: "https://example.com/push"},
+				ID:     "config-1",
+				URL:    "https://example.com/push",
 			},
 			wantErr: a2a.ErrInternalError,
 			options: []RequestHandlerOption{
@@ -1859,9 +1862,10 @@ func TestRequestHandler_CreateTaskPushConfig(t *testing.T) {
 		},
 		{
 			name: "without capability checks and pushNotifications not configured",
-			req: &a2a.CreateTaskPushConfigRequest{
+			req: &a2a.PushConfig{
 				TaskID: taskID,
-				Config: a2a.PushConfig{ID: "config-1", URL: "https://example.com/push"},
+				ID:     "config-1",
+				URL:    "https://example.com/push",
 			},
 			wantErr: a2a.ErrPushNotificationNotSupported,
 		},
@@ -1884,18 +1888,18 @@ func TestRequestHandler_CreateTaskPushConfig(t *testing.T) {
 				return
 			}
 
-			if got.Config.ID == "" {
+			if got.ID == "" {
 				t.Errorf("CreateTaskPushConfig() expected a generated ID, but it was empty")
 				return
 			}
 
-			if tc.req.Config.ID == "" {
-				got.Config.ID = ""
+			if tc.req.ID == "" {
+				got.ID = ""
 			}
 
-			want := &a2a.TaskPushConfig{Config: tc.req.Config, TaskID: tc.req.TaskID}
-			if want.Config.ID == "" {
-				want.Config.ID = got.Config.ID
+			want := &a2a.PushConfig{TaskID: tc.req.TaskID, ID: tc.req.ID, URL: tc.req.URL}
+			if want.ID == "" {
+				want.ID = got.ID
 			}
 			if diff := cmp.Diff(want, got); diff != "" {
 				t.Errorf("CreateTaskPushConfig() mismatch (-want +got):\n%s", diff)
@@ -1914,14 +1918,14 @@ func TestRequestHandler_GetTaskPushConfig(t *testing.T) {
 	testCases := []struct {
 		name    string
 		req     *a2a.GetTaskPushConfigRequest
-		want    *a2a.TaskPushConfig
+		want    *a2a.PushConfig
 		options []RequestHandlerOption
 		wantErr error
 	}{
 		{
 			name: "success",
 			req:  &a2a.GetTaskPushConfigRequest{TaskID: taskID, ID: config1.ID},
-			want: &a2a.TaskPushConfig{TaskID: taskID, Config: *config1},
+			want: &a2a.PushConfig{TaskID: taskID, ID: config1.ID, URL: config1.URL},
 			options: []RequestHandlerOption{
 				WithPushNotifications(ps, pn),
 			},
@@ -2002,16 +2006,16 @@ func TestRequestHandler_ListTaskPushConfigs(t *testing.T) {
 	testCases := []struct {
 		name    string
 		req     *a2a.ListTaskPushConfigRequest
-		want    []*a2a.TaskPushConfig
+		want    []*a2a.PushConfig
 		options []RequestHandlerOption
 		wantErr error
 	}{
 		{
 			name: "list existing",
 			req:  &a2a.ListTaskPushConfigRequest{TaskID: taskID},
-			want: []*a2a.TaskPushConfig{
-				{TaskID: taskID, Config: config1},
-				{TaskID: taskID, Config: config2},
+			want: []*a2a.PushConfig{
+				{TaskID: taskID, ID: config1.ID, URL: config1.URL},
+				{TaskID: taskID, ID: config2.ID, URL: config2.URL},
 			},
 			options: []RequestHandlerOption{
 				WithPushNotifications(ps, pn),
@@ -2020,7 +2024,7 @@ func TestRequestHandler_ListTaskPushConfigs(t *testing.T) {
 		{
 			name: "list with empty task",
 			req:  &a2a.ListTaskPushConfigRequest{TaskID: emptyTaskID},
-			want: []*a2a.TaskPushConfig{},
+			want: []*a2a.PushConfig{},
 			options: []RequestHandlerOption{
 				WithPushNotifications(ps, pn),
 			},
@@ -2028,7 +2032,7 @@ func TestRequestHandler_ListTaskPushConfigs(t *testing.T) {
 		{
 			name: "list non-existent task",
 			req:  &a2a.ListTaskPushConfigRequest{TaskID: "non-existent-task"},
-			want: []*a2a.TaskPushConfig{},
+			want: []*a2a.PushConfig{},
 			options: []RequestHandlerOption{
 				WithPushNotifications(ps, pn),
 			},
@@ -2036,9 +2040,9 @@ func TestRequestHandler_ListTaskPushConfigs(t *testing.T) {
 		{
 			name: "pushNotifications not supported",
 			req:  &a2a.ListTaskPushConfigRequest{TaskID: taskID},
-			want: []*a2a.TaskPushConfig{
-				{TaskID: taskID, Config: config1},
-				{TaskID: taskID, Config: config2},
+			want: []*a2a.PushConfig{
+				{TaskID: taskID, ID: config1.ID, URL: config1.URL},
+				{TaskID: taskID, ID: config2.ID, URL: config2.URL},
 			},
 			options: []RequestHandlerOption{
 				WithCapabilityChecks(&a2a.AgentCapabilities{PushNotifications: false}),
@@ -2048,9 +2052,9 @@ func TestRequestHandler_ListTaskPushConfigs(t *testing.T) {
 		{
 			name: "pushNotifications supported but not configured",
 			req:  &a2a.ListTaskPushConfigRequest{TaskID: taskID},
-			want: []*a2a.TaskPushConfig{
-				{TaskID: taskID, Config: config1},
-				{TaskID: taskID, Config: config2},
+			want: []*a2a.PushConfig{
+				{TaskID: taskID, ID: config1.ID, URL: config1.URL},
+				{TaskID: taskID, ID: config2.ID, URL: config2.URL},
 			},
 			options: []RequestHandlerOption{
 				WithCapabilityChecks(&a2a.AgentCapabilities{PushNotifications: true}),
@@ -2060,9 +2064,9 @@ func TestRequestHandler_ListTaskPushConfigs(t *testing.T) {
 		{
 			name: "without capability checks and pushNotifications not configured",
 			req:  &a2a.ListTaskPushConfigRequest{TaskID: taskID},
-			want: []*a2a.TaskPushConfig{
-				{TaskID: taskID, Config: config1},
-				{TaskID: taskID, Config: config2},
+			want: []*a2a.PushConfig{
+				{TaskID: taskID, ID: config1.ID, URL: config1.URL},
+				{TaskID: taskID, ID: config2.ID, URL: config2.URL},
 			},
 			wantErr: a2a.ErrPushNotificationNotSupported,
 		},
@@ -2077,7 +2081,7 @@ func TestRequestHandler_ListTaskPushConfigs(t *testing.T) {
 				return
 			}
 			if tc.wantErr == nil {
-				sort.Slice(got, func(i, j int) bool { return got[i].Config.ID < got[j].Config.ID })
+				sort.Slice(got, func(i, j int) bool { return got[i].ID < got[j].ID })
 				if diff := cmp.Diff(tc.want, got); diff != "" {
 					t.Errorf("ListTaskPushConfigs() mismatch (-want +got):\n%s", diff)
 				}
@@ -2095,7 +2099,7 @@ func TestRequestHandler_DeleteTaskPushConfig(t *testing.T) {
 	testCases := []struct {
 		name            string
 		req             *a2a.DeleteTaskPushConfigRequest
-		wantRemain      []*a2a.TaskPushConfig
+		wantRemain      []*a2a.PushConfig
 		options         []RequestHandlerOption
 		withPushConfigs bool
 		wantErr         error
@@ -2103,33 +2107,33 @@ func TestRequestHandler_DeleteTaskPushConfig(t *testing.T) {
 		{
 			name:            "delete existing",
 			req:             &a2a.DeleteTaskPushConfigRequest{TaskID: taskID, ID: config1.ID},
-			wantRemain:      []*a2a.TaskPushConfig{{TaskID: taskID, Config: config2}},
+			wantRemain:      []*a2a.PushConfig{{TaskID: taskID, ID: config2.ID, URL: config2.URL}},
 			withPushConfigs: true,
 		},
 		{
 			name: "delete non-existent config",
 			req:  &a2a.DeleteTaskPushConfigRequest{TaskID: taskID, ID: "non-existent"},
-			wantRemain: []*a2a.TaskPushConfig{
-				{TaskID: taskID, Config: config1},
-				{TaskID: taskID, Config: config2},
+			wantRemain: []*a2a.PushConfig{
+				{TaskID: taskID, ID: config1.ID, URL: config1.URL},
+				{TaskID: taskID, ID: config2.ID, URL: config2.URL},
 			},
 			withPushConfigs: true,
 		},
 		{
 			name: "delete from non-existent task",
 			req:  &a2a.DeleteTaskPushConfigRequest{TaskID: "non-existent-task", ID: config1.ID},
-			wantRemain: []*a2a.TaskPushConfig{
-				{TaskID: taskID, Config: config1},
-				{TaskID: taskID, Config: config2},
+			wantRemain: []*a2a.PushConfig{
+				{TaskID: taskID, ID: config1.ID, URL: config1.URL},
+				{TaskID: taskID, ID: config2.ID, URL: config2.URL},
 			},
 			withPushConfigs: true,
 		},
 		{
 			name: "pushNotifications not supported",
 			req:  &a2a.DeleteTaskPushConfigRequest{TaskID: taskID, ID: config1.ID},
-			wantRemain: []*a2a.TaskPushConfig{
-				{TaskID: taskID, Config: config1},
-				{TaskID: taskID, Config: config2},
+			wantRemain: []*a2a.PushConfig{
+				{TaskID: taskID, ID: config1.ID, URL: config1.URL},
+				{TaskID: taskID, ID: config2.ID, URL: config2.URL},
 			},
 			options: []RequestHandlerOption{
 				WithCapabilityChecks(&a2a.AgentCapabilities{PushNotifications: false}),
@@ -2139,9 +2143,9 @@ func TestRequestHandler_DeleteTaskPushConfig(t *testing.T) {
 		{
 			name: "pushNotifications supported but not configured",
 			req:  &a2a.DeleteTaskPushConfigRequest{TaskID: taskID, ID: config1.ID},
-			wantRemain: []*a2a.TaskPushConfig{
-				{TaskID: taskID, Config: config1},
-				{TaskID: taskID, Config: config2},
+			wantRemain: []*a2a.PushConfig{
+				{TaskID: taskID, ID: config1.ID, URL: config1.URL},
+				{TaskID: taskID, ID: config2.ID, URL: config2.URL},
 			},
 			options: []RequestHandlerOption{
 				WithCapabilityChecks(&a2a.AgentCapabilities{PushNotifications: true}),
@@ -2151,9 +2155,9 @@ func TestRequestHandler_DeleteTaskPushConfig(t *testing.T) {
 		{
 			name: "without capability checks and pushNotifications not configured",
 			req:  &a2a.DeleteTaskPushConfigRequest{TaskID: taskID, ID: config1.ID},
-			wantRemain: []*a2a.TaskPushConfig{
-				{TaskID: taskID, Config: config1},
-				{TaskID: taskID, Config: config2},
+			wantRemain: []*a2a.PushConfig{
+				{TaskID: taskID, ID: config1.ID, URL: config1.URL},
+				{TaskID: taskID, ID: config2.ID, URL: config2.URL},
 			},
 			wantErr: a2a.ErrPushNotificationNotSupported,
 		},
@@ -2180,7 +2184,7 @@ func TestRequestHandler_DeleteTaskPushConfig(t *testing.T) {
 					return
 				}
 
-				sort.Slice(got, func(i, j int) bool { return got[i].Config.ID < got[j].Config.ID })
+				sort.Slice(got, func(i, j int) bool { return got[i].ID < got[j].ID })
 				if diff := cmp.Diff(tc.wantRemain, got); diff != "" {
 					t.Errorf("Remaining configs mismatch (-want +got):\n%s", diff)
 				}

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -290,7 +290,7 @@ func TestRequestHandler_SendMessage(t *testing.T) {
 					return
 				}
 				if diff := cmp.Diff(tt.wantResult, result); diff != "" {
-					t.Errorf("SendMessage() (+got,-want):\ngot = %v\nwant %v\ndiff = %s", result, tt.wantResult, diff)
+					t.Errorf("SendMessage() (-want +got):\ngot = %v\nwant %v\ndiff = %s", result, tt.wantResult, diff)
 				}
 			} else {
 				if gotErr == nil {
@@ -340,7 +340,7 @@ func TestRequestHandler_SendMessage(t *testing.T) {
 					eventI++
 				}
 				if diff := cmp.Diff(want, got); diff != "" {
-					t.Errorf("SendStreamingMessage() (+got,-want):\ngot = %v\nwant %v\ndiff = %s", got, want, diff)
+					t.Errorf("SendStreamingMessage() (-want +got):\ngot = %v\nwant %v\ndiff = %s", got, want, diff)
 					return
 				}
 			}
@@ -1287,7 +1287,7 @@ func TestRequestHandler_SendMessage_NewTaskHistory(t *testing.T) {
 	}
 	if task, ok := result.(*a2a.Task); ok {
 		if diff := cmp.Diff([]*a2a.Message{msg}, task.History); diff != "" {
-			t.Fatalf("SendMessage() wrong result (+got,-want):\ngot = %v\nwant = %v\ndiff = %s", task.History, []*a2a.Message{msg}, diff)
+			t.Fatalf("SendMessage() wrong result (-want +got):\ngot = %v\nwant = %v\ndiff = %s", task.History, []*a2a.Message{msg}, diff)
 		}
 	} else {
 		t.Fatalf("SendMessage() = %v, want a2a.Task", result)
@@ -1454,7 +1454,7 @@ func TestRequestHandler_ListTasks(t *testing.T) {
 					return
 				}
 				if diff := cmp.Diff(result, tt.wantResponse); diff != "" {
-					t.Errorf("ListTasks() mismatch (+got -want): %s", diff)
+					t.Errorf("ListTasks() mismatch (-want +got): %s", diff)
 				}
 			} else {
 				if err == nil {
@@ -1777,10 +1777,10 @@ func TestRequestHandler_ExecuteRequestContextLoading(t *testing.T) {
 			}
 			opts := []cmp.Option{cmpopts.IgnoreFields(a2a.Task{}, "History")}
 			if diff := cmp.Diff(tc.wantStoredTask, gotExecCtx.StoredTask, opts...); diff != "" {
-				t.Fatalf("wrong request context stored task (+got,-want): diff = %s", diff)
+				t.Fatalf("wrong request context stored task (-want +got): diff = %s", diff)
 			}
 			if diff := cmp.Diff(tc.wantExecCtxMeta, gotExecCtx.Metadata); diff != "" {
-				t.Fatalf("wrong request context meta (+got,-want): diff = %s", diff)
+				t.Fatalf("wrong request context meta (-want +got): diff = %s", diff)
 			}
 			if tc.wantContextID != "" {
 				if tc.wantContextID != gotExecCtx.ContextID {

--- a/a2asrv/intercepted_handler.go
+++ b/a2asrv/intercepted_handler.go
@@ -159,21 +159,21 @@ func (h *InterceptedHandler) SubscribeToTask(ctx context.Context, req *a2a.Subsc
 }
 
 // GetTaskPushConfig implements RequestHandler.
-func (h *InterceptedHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (h *InterceptedHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	ctx, callCtx := attachMethodCallContext(ctx, "GetTaskPushConfig", req.Tenant)
 	ctx = h.withLoggerContext(ctx, slog.String("task_id", string(req.TaskID)))
 	return doCall(ctx, callCtx, h, req, h.Handler.GetTaskPushConfig)
 }
 
 // ListTaskPushConfigs implements RequestHandler.
-func (h *InterceptedHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (h *InterceptedHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	ctx, callCtx := attachMethodCallContext(ctx, "ListTaskPushConfigs", req.Tenant)
 	ctx = h.withLoggerContext(ctx, slog.String("task_id", string(req.TaskID)))
 	return doCall(ctx, callCtx, h, req, h.Handler.ListTaskPushConfigs)
 }
 
 // CreateTaskPushConfig implements RequestHandler.
-func (h *InterceptedHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (h *InterceptedHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	ctx, callCtx := attachMethodCallContext(ctx, "CreateTaskPushConfig", req.Tenant)
 	ctx = h.withLoggerContext(ctx, slog.String("task_id", string(req.TaskID)))
 	return doCall(ctx, callCtx, h, req, h.Handler.CreateTaskPushConfig)

--- a/a2asrv/intercepted_handler_test.go
+++ b/a2asrv/intercepted_handler_test.go
@@ -99,28 +99,28 @@ func (h *mockHandler) SubscribeToTask(ctx context.Context, req *a2a.SubscribeToT
 	}
 }
 
-func (h *mockHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (h *mockHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	h.lastCallContext, _ = CallContextFrom(ctx)
 	if h.resultErr != nil {
 		return nil, h.resultErr
 	}
-	return &a2a.TaskPushConfig{}, h.resultErr
+	return &a2a.PushConfig{}, h.resultErr
 }
 
-func (h *mockHandler) ListTaskPushConfigs(ctx context.Context, params *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (h *mockHandler) ListTaskPushConfigs(ctx context.Context, params *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	h.lastCallContext, _ = CallContextFrom(ctx)
 	if h.resultErr != nil {
 		return nil, h.resultErr
 	}
-	return []*a2a.TaskPushConfig{{}}, nil
+	return []*a2a.PushConfig{{}}, nil
 }
 
-func (h *mockHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (h *mockHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	h.lastCallContext, _ = CallContextFrom(ctx)
 	if h.resultErr != nil {
 		return nil, h.resultErr
 	}
-	return &a2a.TaskPushConfig{}, h.resultErr
+	return &a2a.PushConfig{}, h.resultErr
 }
 
 func (h *mockHandler) DeleteTaskPushConfig(ctx context.Context, req *a2a.DeleteTaskPushConfigRequest) error {
@@ -217,7 +217,7 @@ var methodCalls = []struct {
 	{
 		method: "CreateTaskPushConfig",
 		call: func(ctx context.Context, h RequestHandler) (any, error) {
-			return h.CreateTaskPushConfig(ctx, &a2a.CreateTaskPushConfigRequest{})
+			return h.CreateTaskPushConfig(ctx, &a2a.PushConfig{})
 		},
 	},
 	{

--- a/a2asrv/jsonrpc.go
+++ b/a2asrv/jsonrpc.go
@@ -315,7 +315,7 @@ func (h *jsonrpcHandler) onSendMessageStream(ctx context.Context, raw json.RawMe
 	}
 }
 
-func (h *jsonrpcHandler) onGetTaskPushConfig(ctx context.Context, raw json.RawMessage) (*a2a.TaskPushConfig, error) {
+func (h *jsonrpcHandler) onGetTaskPushConfig(ctx context.Context, raw json.RawMessage) (*a2a.PushConfig, error) {
 	var params a2a.GetTaskPushConfigRequest
 	if err := json.Unmarshal(raw, &params); err != nil {
 		return nil, handleUnmarshalError(err)
@@ -323,7 +323,7 @@ func (h *jsonrpcHandler) onGetTaskPushConfig(ctx context.Context, raw json.RawMe
 	return h.handler.GetTaskPushConfig(ctx, &params)
 }
 
-func (h *jsonrpcHandler) onListTaskPushConfigs(ctx context.Context, raw json.RawMessage) ([]*a2a.TaskPushConfig, error) {
+func (h *jsonrpcHandler) onListTaskPushConfigs(ctx context.Context, raw json.RawMessage) ([]*a2a.PushConfig, error) {
 	var params a2a.ListTaskPushConfigRequest
 	if err := json.Unmarshal(raw, &params); err != nil {
 		return nil, handleUnmarshalError(err)
@@ -331,8 +331,8 @@ func (h *jsonrpcHandler) onListTaskPushConfigs(ctx context.Context, raw json.Raw
 	return h.handler.ListTaskPushConfigs(ctx, &params)
 }
 
-func (h *jsonrpcHandler) onSetTaskPushConfig(ctx context.Context, raw json.RawMessage) (*a2a.TaskPushConfig, error) {
-	var params a2a.CreateTaskPushConfigRequest
+func (h *jsonrpcHandler) onSetTaskPushConfig(ctx context.Context, raw json.RawMessage) (*a2a.PushConfig, error) {
+	var params a2a.PushConfig
 	if err := json.Unmarshal(raw, &params); err != nil {
 		return nil, handleUnmarshalError(err)
 	}

--- a/a2asrv/jsonrpc_test.go
+++ b/a2asrv/jsonrpc_test.go
@@ -86,7 +86,7 @@ func TestJSONRPC_RequestRouting(t *testing.T) {
 		{
 			method: "CreateTaskPushConfig",
 			call: func(ctx context.Context, client *a2aclient.Client) (any, error) {
-				return client.CreateTaskPushConfig(ctx, &a2a.CreateTaskPushConfigRequest{})
+				return client.CreateTaskPushConfig(ctx, &a2a.PushConfig{})
 			},
 		},
 		{

--- a/a2asrv/push/store.go
+++ b/a2asrv/push/store.go
@@ -74,6 +74,7 @@ func (s *InMemoryPushConfigStore) Save(ctx context.Context, taskID a2a.TaskID, c
 	if toSave.ID == "" {
 		toSave.ID = newID()
 	}
+	toSave.TaskID = taskID
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/a2asrv/push/store_test.go
+++ b/a2asrv/push/store_test.go
@@ -210,7 +210,7 @@ func TestInMemoryPushConfigStore_Get(t *testing.T) {
 					t.Fatalf("Get() failed: %v", err)
 				}
 				if diff := cmp.Diff(tc.want, got); diff != "" {
-					t.Fatalf("Get() (+got,-want):\ngot = %v\nwant %v\ndiff = %s", got, tc.want, diff)
+					t.Fatalf("Get() (-want +got):\ngot = %v\nwant %v\ndiff = %s", got, tc.want, diff)
 				}
 			} else {
 				if err == nil || err.Error() != tc.wantErr.Error() {
@@ -255,7 +255,7 @@ func TestInMemoryPushConfigStore_List(t *testing.T) {
 			want := sortConfigList(tc.want)
 			got := sortConfigList(configs)
 			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("Get() (+got,-want):\ngot = %v\nwant %v\ndiff = %s", got, want, diff)
+				t.Errorf("Get() (-want +got):\ngot = %v\nwant %v\ndiff = %s", got, want, diff)
 			}
 		})
 	}
@@ -312,7 +312,7 @@ func TestInMemoryPushConfigStore_Delete(t *testing.T) {
 			want := sortConfigList(tc.want)
 			got = sortConfigList(got)
 			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("Get() (+got,-want):\ngot = %v\nwant %v\ndiff = %s", got, want, diff)
+				t.Errorf("Get() (-want +got):\ngot = %v\nwant %v\ndiff = %s", got, want, diff)
 			}
 		})
 	}
@@ -415,7 +415,7 @@ func TestInMemoryPushConfigStore_ConcurrenctCreation(t *testing.T) {
 			t.Fatalf("Get() failed: %v", err)
 		}
 		if diff := cmp.Diff(c, got); diff != "" {
-			t.Errorf("Get() (+got,-want):\ngot = %v\nwant %v\ndiff = %s", got, c, diff)
+			t.Errorf("Get() (-want +got):\ngot = %v\nwant %v\ndiff = %s", got, c, diff)
 		}
 	}
 }

--- a/a2asrv/push/store_test.go
+++ b/a2asrv/push/store_test.go
@@ -27,11 +27,13 @@ import (
 func TestInMemoryPushConfigStore_Save(t *testing.T) {
 	ctx := t.Context()
 	taskID := a2a.TaskID("task")
+	configID := newID()
 
 	testCases := []struct {
 		name    string
 		config  *a2a.PushConfig
 		wantErr error
+		want    *a2a.PushConfig
 	}{
 		{
 			name: "valid config with no id",
@@ -39,14 +41,23 @@ func TestInMemoryPushConfigStore_Save(t *testing.T) {
 				URL: "https://example.com/push",
 			},
 			wantErr: nil,
+			want: &a2a.PushConfig{
+				TaskID: taskID,
+				URL:    "https://example.com/push",
+			},
 		},
 		{
 			name: "valid config with id",
 			config: &a2a.PushConfig{
-				ID:  newID(),
+				ID:  configID,
 				URL: "https://example.com/push",
 			},
 			wantErr: nil,
+			want: &a2a.PushConfig{
+				TaskID: taskID,
+				ID:     configID,
+				URL:    "https://example.com/push",
+			},
 		},
 		{
 			name:    "nil config",
@@ -79,7 +90,7 @@ func TestInMemoryPushConfigStore_Save(t *testing.T) {
 					}
 					saved.ID = ""
 				}
-				if diff := cmp.Diff(tc.config, saved); diff != "" {
+				if diff := cmp.Diff(tc.want, saved); diff != "" {
 					t.Fatalf("Stored config mismatch (-want +got):\n%s", diff)
 				}
 			} else {
@@ -112,7 +123,7 @@ func TestInMemoryPushConfigStore_ModifiedConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Get() failed: %v", err)
 		}
-		wantConfig := &a2a.PushConfig{ID: savedID, URL: savedURL}
+		wantConfig := &a2a.PushConfig{TaskID: taskID, ID: savedID, URL: savedURL}
 		if diff := cmp.Diff(wantConfig, got); diff != "" {
 			t.Errorf("Retrieved config mismatch after modifying original (-want +got):\n%s", diff)
 		}
@@ -135,7 +146,7 @@ func TestInMemoryPushConfigStore_ModifiedConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Get() failed: %v", err)
 		}
-		wantConfig := &a2a.PushConfig{ID: savedID, URL: savedURL}
+		wantConfig := &a2a.PushConfig{TaskID: taskID, ID: savedID, URL: savedURL}
 		if diff := cmp.Diff(wantConfig, got); diff != "" {
 			t.Errorf("Retrieved config mismatch after modifying original (-want +got):\n%s", diff)
 		}
@@ -143,7 +154,7 @@ func TestInMemoryPushConfigStore_ModifiedConfig(t *testing.T) {
 
 	t.Run("modify retrieved config after get", func(t *testing.T) {
 		store := NewInMemoryStore()
-		initialConfig := &a2a.PushConfig{ID: newID(), URL: "https://initial-get.com"}
+		initialConfig := &a2a.PushConfig{TaskID: taskID, ID: newID(), URL: "https://initial-get.com"}
 		saved, err := store.Save(ctx, taskID, initialConfig)
 		if err != nil {
 			t.Fatalf("Save() failed: %v", err)
@@ -268,13 +279,13 @@ func TestInMemoryPushConfigStore_Delete(t *testing.T) {
 			name:     "existing config",
 			taskID:   taskID,
 			configID: configs[0].ID,
-			want:     []*a2a.PushConfig{configs[1]},
+			want:     []*a2a.PushConfig{{TaskID: taskID, ID: configs[1].ID, URL: configs[1].URL}},
 		},
 		{
 			name:     "non-existent config",
 			taskID:   taskID,
 			configID: newID(),
-			want:     configs,
+			want:     []*a2a.PushConfig{{TaskID: taskID, ID: configs[0].ID, URL: configs[0].URL}, {TaskID: taskID, ID: configs[1].ID, URL: configs[1].URL}},
 		},
 		{
 			name:   "non-existent task",
@@ -311,13 +322,13 @@ func TestInMemoryPushConfigStore_DeleteAll(t *testing.T) {
 	ctx := t.Context()
 	taskID := a2a.TaskID("task")
 	configs := sortConfigList([]*a2a.PushConfig{
-		{ID: newID(), URL: "https://example.com/push1"},
-		{ID: newID(), URL: "https://example.com/push2"},
+		{TaskID: taskID, ID: newID(), URL: "https://example.com/push1"},
+		{TaskID: taskID, ID: newID(), URL: "https://example.com/push2"},
 	})
 	anotherTaskID := a2a.TaskID("another-task")
 	anotherConfigs := sortConfigList([]*a2a.PushConfig{
-		{ID: newID(), URL: "https://example.com/push3"},
-		{ID: newID(), URL: "https://example.com/push4"},
+		{TaskID: anotherTaskID, ID: newID(), URL: "https://example.com/push3"},
+		{TaskID: anotherTaskID, ID: newID(), URL: "https://example.com/push4"},
 	})
 
 	testCases := []struct {

--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -375,7 +375,7 @@ func (h *restHandler) handleCreateTaskPushConfig(rw http.ResponseWriter, req *ht
 		return
 	}
 
-	request := &a2a.CreateTaskPushConfigRequest{}
+	request := &a2a.PushConfig{}
 	if err := json.NewDecoder(req.Body).Decode(request); err != nil {
 		writeRESTError(ctx, rw, a2a.ErrParseError, a2a.TaskID(taskID))
 		return

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -79,7 +79,7 @@ func TestREST_RequestRouting(t *testing.T) {
 		{
 			method: "CreateTaskPushConfig",
 			call: func(ctx context.Context, client *a2aclient.Client) (any, error) {
-				return client.CreateTaskPushConfig(ctx, &a2a.CreateTaskPushConfigRequest{TaskID: a2a.TaskID("test-id")})
+				return client.CreateTaskPushConfig(ctx, &a2a.PushConfig{TaskID: a2a.TaskID("test-id")})
 			},
 		},
 		{
@@ -167,7 +167,7 @@ func TestREST_RequestRouting(t *testing.T) {
 func TestREST_Validations(t *testing.T) {
 	taskID := a2a.NewTaskID()
 	config := a2a.PushConfig{
-		ID:  string(taskID),
+		ID:  "test-config-id",
 		URL: "https://example.com/push",
 	}
 	task := &a2a.Task{ID: taskID}
@@ -219,7 +219,7 @@ func TestREST_Validations(t *testing.T) {
 			name:    "CreateAndListTaskPushConfig",
 			methods: []string{http.MethodGet, http.MethodPost},
 			path:    "/tasks/" + string(taskID) + "/pushNotificationConfigs",
-			body:    &a2a.CreateTaskPushConfigRequest{TaskID: taskID, Config: config},
+			body:    &a2a.PushConfig{ID: "test-config-id", TaskID: taskID, URL: "https://example.com/push"},
 		},
 		{
 			name:    "GetAndDeleteTaskPushConfig",

--- a/a2asrv/taskstore/store_test.go
+++ b/a2asrv/taskstore/store_test.go
@@ -356,14 +356,14 @@ func TestInMemoryTaskStore_List_WithFilters(t *testing.T) {
 					t.Fatalf("Expected error but got nil")
 				}
 				if diff := cmp.Diff(err.Error(), tc.wantErr.Error()); diff != "" {
-					t.Fatalf("Error mismatch (+got -want):\n%s", diff)
+					t.Fatalf("Error mismatch (-want +got):\n%s", diff)
 				}
 			} else {
 				if err != nil {
 					t.Fatalf("Unexpected error: got = %v, want nil", err)
 				}
 				if diff := cmp.Diff(listResponse.Tasks, tc.wantResponse.Tasks); diff != "" {
-					t.Fatalf("Tasks mismatch (+got -want):\n%s", diff)
+					t.Fatalf("Tasks mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})
@@ -443,7 +443,7 @@ func TestInMemoryTaskStore_List_Pagination(t *testing.T) {
 				}
 			}
 			if diff := cmp.Diff(result, tc.result); diff != "" {
-				t.Fatalf("Tasks mismatch (+got -want):\n%s", diff)
+				t.Fatalf("Tasks mismatch (-want +got):\n%s", diff)
 			}
 			if actualCalls != tc.wantCalls {
 				t.Fatalf("Unexpected number of calls: got = %v, want %v", actualCalls, tc.wantCalls)

--- a/e2e/jsonrpc_test.go
+++ b/e2e/jsonrpc_test.go
@@ -72,7 +72,7 @@ func TestJSONRPC_Streaming(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(executor.Emitted(), received); diff != "" {
-		t.Fatalf("client.SendStreamingMessage() wrong events (+got,-want) diff = %s", diff)
+		t.Fatalf("client.SendStreamingMessage() wrong events (-want +got) diff = %s", diff)
 	}
 }
 

--- a/e2e/push_configs_test.go
+++ b/e2e/push_configs_test.go
@@ -39,7 +39,8 @@ func TestPushConfigs_ClientServerRoundtrip(t *testing.T) {
 		ID: a2a.NewTaskID(),
 	}
 	config := a2a.PushConfig{
-		ID: "config-123",
+		ID:     "config-123",
+		TaskID: task.ID,
 		Auth: &a2a.PushAuthInfo{
 			Scheme:      "Bearer",
 			Credentials: "token-123",
@@ -47,24 +48,16 @@ func TestPushConfigs_ClientServerRoundtrip(t *testing.T) {
 		Token: "interop-token",
 		URL:   "https://example.invalid/webhook",
 	}
-	want := &a2a.TaskPushConfig{
-		TaskID: task.ID,
-		Config: config,
-	}
 
 	for _, transport := range []a2a.TransportProtocol{a2a.TransportProtocolHTTPJSON, a2a.TransportProtocolJSONRPC, a2a.TransportProtocolGRPC} {
 		t.Run(string(transport), func(t *testing.T) {
 			client := startPushServer(t, task, transport)
 			t.Run("CreateTaskPushConfig", func(t *testing.T) {
-				createTaskPushConfigReq := &a2a.CreateTaskPushConfigRequest{
-					TaskID: task.ID,
-					Config: config,
-				}
-				result, err := client.CreateTaskPushConfig(ctx, createTaskPushConfigReq)
+				result, err := client.CreateTaskPushConfig(ctx, &config)
 				if err != nil {
 					t.Fatalf("client.CreateTaskPushConfig() error = %v", err)
 				}
-				if diff := cmp.Diff(want, result); diff != "" {
+				if diff := cmp.Diff(&config, result); diff != "" {
 					t.Fatalf("client.CreateTaskPushConfig() returned diff (+got,-want): %s", diff)
 				}
 			})
@@ -77,7 +70,7 @@ func TestPushConfigs_ClientServerRoundtrip(t *testing.T) {
 				if err != nil {
 					t.Fatalf("client.GetTaskPushConfig() error = %v", err)
 				}
-				if diff := cmp.Diff(want, result); diff != "" {
+				if diff := cmp.Diff(&config, result); diff != "" {
 					t.Fatalf("client.GetTaskPushConfig() returned diff (+got,-want): %s", diff)
 				}
 			})
@@ -85,7 +78,7 @@ func TestPushConfigs_ClientServerRoundtrip(t *testing.T) {
 				listTaskPushConfigsReq := &a2a.ListTaskPushConfigRequest{
 					TaskID: task.ID,
 				}
-				wantListResult := []*a2a.TaskPushConfig{want}
+				wantListResult := []*a2a.PushConfig{&config}
 				result, err := client.ListTaskPushConfigs(ctx, listTaskPushConfigsReq)
 				if err != nil {
 					t.Fatalf("client.ListTaskPushConfigs() error = %v", err)
@@ -106,7 +99,7 @@ func TestPushConfigs_ClientServerRoundtrip(t *testing.T) {
 				listTaskPushConfigsReq := &a2a.ListTaskPushConfigRequest{
 					TaskID: task.ID,
 				}
-				wantListResult := []*a2a.TaskPushConfig{}
+				wantListResult := []*a2a.PushConfig{}
 				result, err := client.ListTaskPushConfigs(ctx, listTaskPushConfigsReq)
 				if err != nil {
 					t.Fatalf("client.ListTaskPushConfigs() error = %v", err)

--- a/e2e/push_configs_test.go
+++ b/e2e/push_configs_test.go
@@ -58,7 +58,7 @@ func TestPushConfigs_ClientServerRoundtrip(t *testing.T) {
 					t.Fatalf("client.CreateTaskPushConfig() error = %v", err)
 				}
 				if diff := cmp.Diff(&config, result); diff != "" {
-					t.Fatalf("client.CreateTaskPushConfig() returned diff (+got,-want): %s", diff)
+					t.Fatalf("client.CreateTaskPushConfig() returned diff (-want +got): %s", diff)
 				}
 			})
 			t.Run("GetTaskPushConfig", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestPushConfigs_ClientServerRoundtrip(t *testing.T) {
 					t.Fatalf("client.GetTaskPushConfig() error = %v", err)
 				}
 				if diff := cmp.Diff(&config, result); diff != "" {
-					t.Fatalf("client.GetTaskPushConfig() returned diff (+got,-want): %s", diff)
+					t.Fatalf("client.GetTaskPushConfig() returned diff (-want +got): %s", diff)
 				}
 			})
 			t.Run("ListTaskPushConfigs", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestPushConfigs_ClientServerRoundtrip(t *testing.T) {
 					t.Fatalf("client.ListTaskPushConfigs() error = %v", err)
 				}
 				if diff := cmp.Diff(wantListResult, result); diff != "" {
-					t.Fatalf("client.ListTaskPushConfigs() returned diff (+got,-want): %s", diff)
+					t.Fatalf("client.ListTaskPushConfigs() returned diff (-want +got): %s", diff)
 				}
 			})
 			t.Run("DeleteTaskPushConfig", func(t *testing.T) {
@@ -105,7 +105,7 @@ func TestPushConfigs_ClientServerRoundtrip(t *testing.T) {
 					t.Fatalf("client.ListTaskPushConfigs() error = %v", err)
 				}
 				if diff := cmp.Diff(wantListResult, result); diff != "" {
-					t.Fatalf("client.ListTaskPushConfigs() returned diff (+got,-want): %s", diff)
+					t.Fatalf("client.ListTaskPushConfigs() returned diff (-want +got): %s", diff)
 				}
 			})
 		})

--- a/internal/cli/serve_proxy.go
+++ b/internal/cli/serve_proxy.go
@@ -127,15 +127,15 @@ func (p *proxyHandler) SendStreamingMessage(ctx context.Context, req *a2a.SendMe
 	return p.client.SendStreamingMessage(p.withParams(ctx), req)
 }
 
-func (p *proxyHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (p *proxyHandler) GetTaskPushConfig(ctx context.Context, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	return p.client.GetTaskPushConfig(p.withParams(ctx), req)
 }
 
-func (p *proxyHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.TaskPushConfig, error) {
+func (p *proxyHandler) ListTaskPushConfigs(ctx context.Context, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	return p.client.ListTaskPushConfigs(p.withParams(ctx), req)
 }
 
-func (p *proxyHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.CreateTaskPushConfigRequest) (*a2a.TaskPushConfig, error) {
+func (p *proxyHandler) CreateTaskPushConfig(ctx context.Context, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	return p.client.CreateTaskPushConfig(p.withParams(ctx), req)
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -56,7 +56,7 @@ func TestExecExecutor_PipesStdinToCommand(t *testing.T) {
 	}
 	got := allArtifactText(task)
 	if diff := cmp.Diff("echo back", got); diff != "" {
-		t.Fatalf("artifact text wrong result (+got,-want) diff = %s", diff)
+		t.Fatalf("artifact text wrong result (-want +got) diff = %s", diff)
 	}
 }
 
@@ -71,7 +71,7 @@ func TestExecExecutor_CommandOutput(t *testing.T) {
 	}
 	got := allArtifactText(task)
 	if diff := cmp.Diff("hello\n", got); diff != "" {
-		t.Fatalf("artifact text wrong result (+got,-want) diff = %s", diff)
+		t.Fatalf("artifact text wrong result (-want +got) diff = %s", diff)
 	}
 }
 
@@ -164,7 +164,7 @@ func TestSplitByDelimiter(t *testing.T) {
 				data = data[advance:]
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Fatalf("splitByDelimiter(%q) wrong result (+got,-want) diff = %s", tt.delim, diff)
+				t.Fatalf("splitByDelimiter(%q) wrong result (-want +got) diff = %s", tt.delim, diff)
 			}
 		})
 	}

--- a/internal/eventpipe/local_test.go
+++ b/internal/eventpipe/local_test.go
@@ -47,7 +47,7 @@ func TestLocalPipe_WriteRead(t *testing.T) {
 	mustWrite(t, pipe, want)
 	got := mustRead(t, pipe)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("Read() wrong result (+got,-want) diff = %s", diff)
+		t.Fatalf("Read() wrong result (-want +got) diff = %s", diff)
 	}
 }
 
@@ -59,7 +59,7 @@ func TestLocalPipe_WriteCloseRead(t *testing.T) {
 	pipe.Close()
 	got := mustRead(t, pipe)
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Fatalf("Read() wrong result (+got,-want) diff = %s", diff)
+		t.Fatalf("Read() wrong result (-want +got) diff = %s", diff)
 	}
 }
 

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -270,7 +270,7 @@ func TestFromGRPCError(t *testing.T) {
 					t.Fatalf("got error type %T, want *a2a.Error", got)
 				}
 				if diff := cmp.Diff(wantDetails, a2aErr.Details); diff != "" {
-					t.Fatalf("got wrong details (+got,-want) diff = %s", diff)
+					t.Fatalf("got wrong details (-want +got) diff = %s", diff)
 				}
 			}
 		})

--- a/internal/pathtemplate/pathtemplate_test.go
+++ b/internal/pathtemplate/pathtemplate_test.go
@@ -186,7 +186,7 @@ func TestMatch(t *testing.T) {
 				return
 			}
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Fatalf("Template(%q).Match(%q) wrong result (+got,-want) diff = %s", tt.template, tt.path, diff)
+				t.Fatalf("Template(%q).Match(%q) wrong result (-want +got) diff = %s", tt.template, tt.path, diff)
 			}
 		})
 	}

--- a/internal/taskexec/distributed_manager_test.go
+++ b/internal/taskexec/distributed_manager_test.go
@@ -228,7 +228,7 @@ func TestClusterFrontend_Execute(t *testing.T) {
 					tc.wantQueueWrite.TaskID = wq.Payloads[0].TaskID
 				}
 				if diff := cmp.Diff(tc.wantQueueWrite, wq.Payloads[0]); diff != "" {
-					t.Errorf("Execute() payload mismatch (+got,-want):\n%s", diff)
+					t.Errorf("Execute() payload mismatch (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/internal/taskexec/manager_test.go
+++ b/internal/taskexec/manager_test.go
@@ -347,7 +347,7 @@ func TestManager_Execute(t *testing.T) {
 				t.Fatalf("subscription error = %v, want nil", subErr)
 			}
 			if diff := cmp.Diff([]a2a.Event{want}, subEvents); diff != "" {
-				t.Fatalf("subscription events incorrect (+got,-want) diff = %s", diff)
+				t.Fatalf("subscription events incorrect (-want +got) diff = %s", diff)
 			}
 		})
 	}
@@ -374,7 +374,7 @@ func TestManager_EventProcessingFailureFailsExecution(t *testing.T) {
 		t.Fatalf("subscription error = %v, want %v", subErr, executor.processErr)
 	}
 	if diff := cmp.Diff([]a2a.Event{}, subEvents); diff != "" {
-		t.Fatalf("subscription events incorrect (+got,-want) diff = %s", diff)
+		t.Fatalf("subscription events incorrect (-want +got) diff = %s", diff)
 	}
 }
 
@@ -396,7 +396,7 @@ func TestManager_ExecuteFailureFailsExecution(t *testing.T) {
 		t.Fatalf("subscription error = %v, want %v", subErr, executor.executeErr)
 	}
 	if diff := cmp.Diff([]a2a.Event{}, subEvents); diff != "" {
-		t.Fatalf("subscription events incorrect (+got,-want) diff = %s", diff)
+		t.Fatalf("subscription events incorrect (-want +got) diff = %s", diff)
 	}
 }
 
@@ -475,7 +475,7 @@ func TestManager_ExecuteErrorOverwriteByProcessorResult(t *testing.T) {
 	}
 	subEvents := <-subEventsChan
 	if diff := cmp.Diff([]a2a.Event{wantResult}, subEvents); diff != "" {
-		t.Fatalf("subscription events incorrect (+got,-want) diff = %s", diff)
+		t.Fatalf("subscription events incorrect (-want +got) diff = %s", diff)
 	}
 }
 

--- a/internal/taskexec/subscription_test.go
+++ b/internal/taskexec/subscription_test.go
@@ -186,7 +186,7 @@ func TestRemoteSubscription_Events(t *testing.T) {
 				t.Fatalf("Events() error = nil, want %v", tc.wantErrContain)
 			}
 			if diff := cmp.Diff(tc.wantEvents, gotEvents); diff != "" {
-				t.Fatalf("Events() result mismatch (+got,-want):\n%s", diff)
+				t.Fatalf("Events() result mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/taskupdate/manager_test.go
+++ b/internal/taskupdate/manager_test.go
@@ -104,10 +104,10 @@ func TestManager_TaskSaved(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(saver.saved, updated); diff != "" {
-		t.Fatalf("wrong saved task state (+got,-want):\n%s", diff)
+		t.Fatalf("wrong saved task state (-want +got):\n%s", diff)
 	}
 	if diff := cmp.Diff(result.Task, updated); diff != "" {
-		t.Fatalf("wrong result task (+got,-want):\n%s", diff)
+		t.Fatalf("wrong result task (-want +got):\n%s", diff)
 	}
 	if result.Task.Status.State != newState {
 		t.Fatalf("task state not updated: got = %v, want = %v", result.Task.Status.State, newState)
@@ -483,10 +483,10 @@ func TestManager_ArtifactUpdates(t *testing.T) {
 				got = lastResult.Task.Artifacts
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("wrong result (+got,-want)\ngot = %v\nwant = %v\ndiff=%s", got, tc.want, diff)
+				t.Errorf("wrong result (-want +got)\ngot = %v\nwant = %v\ndiff=%s", got, tc.want, diff)
 			}
 			if diff := cmp.Diff(tc.want, saved); diff != "" {
-				t.Errorf("wrong artifacts saved (+got,-want)\ngot = %v\nwant = %v\ndiff=%s", saved, tc.want, diff)
+				t.Errorf("wrong artifacts saved (-want +got)\ngot = %v\nwant = %v\ndiff=%s", saved, tc.want, diff)
 			}
 		})
 	}

--- a/log/handler_test.go
+++ b/log/handler_test.go
@@ -175,7 +175,7 @@ func TestHandler_Handle(t *testing.T) {
 					t.Fatalf("missing key %q in log output: %s", k, buf.String())
 				}
 				if diff := cmp.Diff(want, gotVal); diff != "" {
-					t.Fatalf("key %q wrong result (+got,-want) diff = %s", k, diff)
+					t.Fatalf("key %q wrong result (-want +got) diff = %s", k, diff)
 				}
 			}
 		})
@@ -212,7 +212,7 @@ func TestHandler_WithAttrs(t *testing.T) {
 		t.Fatalf("missing key \"task\" in log output: %s", buf.String())
 	}
 	if diff := cmp.Diff(want, gotTask); diff != "" {
-		t.Fatalf("Handler.WithAttrs() wrong result (+got,-want) diff = %s", diff)
+		t.Fatalf("Handler.WithAttrs() wrong result (-want +got) diff = %s", diff)
 	}
 }
 
@@ -252,7 +252,7 @@ func TestHandler_WithGroup(t *testing.T) {
 		t.Fatalf("missing key \"task\" in group: %s", buf.String())
 	}
 	if diff := cmp.Diff(want, gotTask); diff != "" {
-		t.Fatalf("Handler.WithGroup() wrong result (+got,-want) diff = %s", diff)
+		t.Fatalf("Handler.WithGroup() wrong result (-want +got) diff = %s", diff)
 	}
 }
 
@@ -309,7 +309,7 @@ func TestHandler_nestedGroupFormatting(t *testing.T) {
 		t.Fatalf("missing key \"task\" in outer group: %s", buf.String())
 	}
 	if diff := cmp.Diff(want, gotTask); diff != "" {
-		t.Fatalf("nested group formatting wrong result (+got,-want) diff = %s", diff)
+		t.Fatalf("nested group formatting wrong result (-want +got) diff = %s", diff)
 	}
 }
 


### PR DESCRIPTION
Consolidated push configurations to use the `PushConfig` type globally. It now utilizes the `taskPushNotificationConfig` JSON tag to implement the `TaskPushNotificationConfig` specification.

Kept `TaskPushConfig` as a type alias for `PushConfig` to ensure existing integrations remain functional.

Removed the `CreateTaskPushConfigRequest` type. Following the updated spec, `CreateTaskPushConfig` now accepts `PushConfig` directly.

Updated error reporting throughout the project to adopt a consistent `(-want +got)` template for diff output.