### PR TITLE
fix: extra query and fast client rejection in local executor

### DIFF
--- a/a2asrv/agentexec.go
+++ b/a2asrv/agentexec.go
@@ -126,11 +126,12 @@ type AgentExecutionCleaner interface {
 }
 
 type factory struct {
-	taskStore       taskstore.Store
-	pushSender      push.Sender
-	pushConfigStore push.ConfigStore
-	agent           AgentExecutor
-	interceptors    []ExecutorContextInterceptor
+	taskStore          taskstore.Store
+	pushSender         push.Sender
+	pushConfigStore    push.ConfigStore
+	agent              AgentExecutor
+	interceptors       []ExecutorContextInterceptor
+	taskRetrySupported bool
 }
 
 var _ taskexec.Factory = (*factory)(nil)
@@ -177,10 +178,15 @@ type executionContext struct {
 func (f *factory) loadExecutionContext(ctx context.Context, tid a2a.TaskID, params *a2a.SendMessageRequest) (*executionContext, error) {
 	message := params.Message
 
-	taskStoreTask, err := f.taskStore.Get(ctx, tid)
-	if errors.Is(err, a2a.ErrTaskNotFound) && message.TaskID == "" {
+	if message.TaskID == "" && !f.taskRetrySupported {
 		return f.createNewExecutionContext(tid, params)
 	}
+
+	taskStoreTask, err := f.taskStore.Get(ctx, tid)
+	if message.TaskID == "" && errors.Is(err, a2a.ErrTaskNotFound) {
+		return f.createNewExecutionContext(tid, params)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("task loading failed: %w", err)
 	}

--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -177,6 +177,9 @@ func NewHandler(executor AgentExecutor, options ...RequestHandlerOption) Request
 		pushSender:      h.pushSender,
 		pushConfigStore: h.pushConfigStore,
 		interceptors:    h.reqContextInterceptors,
+		// TODO(yarolegovich): there should be a flag to specify whether workqueue implementation supports
+		// retries or not to be able to opt-out of extra GetTask RPC
+		taskRetrySupported: h.workQueue != nil,
 	}
 	if h.workQueue != nil {
 		if h.taskStore == nil || h.queueManager == nil {

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1231,38 +1232,64 @@ func TestRequestHandler_SendMessage_AgentExecutionFails(t *testing.T) {
 	}
 }
 
-func TestRequestHandler_SendMessage_NoTaskCreated(t *testing.T) {
-	ctx := t.Context()
-	getCalled := 0
-	savedCalled := 0
-	mockStore := testutil.NewTestTaskStore()
-	mockStore.GetFunc = func(ctx context.Context, taskID a2a.TaskID) (*taskstore.StoredTask, error) {
-		getCalled += 1
-		return nil, a2a.ErrTaskNotFound
-	}
-	mockStore.CreateFunc = func(ctx context.Context, task *a2a.Task) (taskstore.TaskVersion, error) {
-		savedCalled += 1
-		return taskstore.TaskVersionMissing, nil
-	}
+func TestRequestHandler_OnSendMessage_NoTaskCreated(t *testing.T) {
+	for _, clusterMode := range []bool{false, true} {
+		name := "local"
+		if clusterMode {
+			name = "cluster"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+			var getCalled atomic.Int32
+			savedCalled := 0
+			mockStore := testutil.NewTestTaskStore()
+			mockStore.GetFunc = func(ctx context.Context, taskID a2a.TaskID) (*taskstore.StoredTask, error) {
+				getCalled.Add(1)
+				return nil, a2a.ErrTaskNotFound
+			}
+			mockStore.CreateFunc = func(ctx context.Context, task *a2a.Task) (taskstore.TaskVersion, error) {
+				savedCalled += 1
+				return taskstore.TaskVersionMissing, nil
+			}
 
-	executor := newEventReplayAgent([]a2a.Event{newAgentMessage("hello")}, nil)
-	handler := NewHandler(executor, WithTaskStore(mockStore))
+			executor := newEventReplayAgent([]a2a.Event{newAgentMessage("hello")}, nil)
+			var opts []RequestHandlerOption
+			if clusterMode {
+				opts = append(opts, WithClusterMode(ClusterConfig{
+					QueueManager: testutil.NewTestQueueManager(),
+					WorkQueue:    testutil.NewInMemoryWorkQueue(),
+					TaskStore:    mockStore,
+				}))
+			} else {
+				opts = append(opts, WithTaskStore(mockStore))
+			}
+			handler := NewHandler(executor, opts...)
 
-	result, gotErr := handler.SendMessage(ctx, &a2a.SendMessageRequest{
-		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("Work")),
-	})
-	if gotErr != nil {
-		t.Fatalf("SendMessage() error = %v, wantErr nil", gotErr)
-	}
-	if _, ok := result.(*a2a.Message); !ok {
-		t.Fatalf("SendMessage() = %v, want a2a.Message", result)
-	}
+			result, gotErr := handler.SendMessage(ctx, &a2a.SendMessageRequest{
+				Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("Work")),
+			})
+			if gotErr != nil {
+				t.Fatalf("OnSendMessage() error = %v, wantErr nil", gotErr)
+			}
+			if _, ok := result.(*a2a.Message); !ok {
+				t.Fatalf("OnSendMessage() = %v, want a2a.Message", result)
+			}
 
-	if getCalled != 1 {
-		t.Fatalf("SendMessage() TaskStore.Get called %d times, want 1", getCalled)
-	}
-	if savedCalled > 0 {
-		t.Fatalf("SendMessage() TaskStore.Save called %d times, want 0", savedCalled)
+			var wantGetCalls int32 = 0
+			if clusterMode {
+				// in cluster mode the first get call is performed on task submission to prevent work submission for
+				// tasks in finished state.
+				// the second get call is performed before starting an execution even when a message does not reference
+				// a task, because workqueue implementation can support retries
+				wantGetCalls = 2
+			}
+			if getCalled.Load() != wantGetCalls {
+				t.Fatalf("OnSendMessage() TaskStore.Get called %d times, want %d", getCalled.Load(), wantGetCalls)
+			}
+			if savedCalled > 0 {
+				t.Fatalf("OnSendMessage() TaskStore.Save called %d times, want 0", savedCalled)
+			}
+		})
 	}
 }
 

--- a/internal/taskexec/local_manager.go
+++ b/internal/taskexec/local_manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv/eventqueue"
@@ -73,6 +74,10 @@ type localExecution struct {
 	pipe         *eventpipe.Local
 	queueManager eventqueue.Manager
 	store        taskstore.Store
+
+	// exiting flag is set to true after we know the execution is about to finish.
+	// a fast client might attempt to send a follow-up before the execution gets unregistered.
+	exiting atomic.Bool
 }
 
 var _ Manager = (*localManager)(nil)
@@ -143,6 +148,10 @@ func (m *localManager) Execute(ctx context.Context, req *a2a.SendMessageRequest)
 		tid = a2a.NewTaskID()
 	} else {
 		tid = req.Message.TaskID
+		// handle fast client sending a follow-up message before execution was unregistered
+		if err := m.waitForExiting(ctx, tid); err != nil {
+			return nil, err
+		}
 	}
 
 	execution, err := m.createExecution(ctx, tid, req)
@@ -167,6 +176,20 @@ func (m *localManager) Execute(ctx context.Context, req *a2a.SendMessageRequest)
 	go m.handleExecution(detachedCtx, execution, eventBroadcastQueue)
 
 	return newLocalSubscription(execution, defaultSubReadQueue), nil
+}
+
+func (m *localManager) waitForExiting(ctx context.Context, tid a2a.TaskID) error {
+	m.mu.Lock()
+	exec, ok := m.executions[tid]
+	m.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	if !exec.exiting.Load() {
+		return ErrExecutionInProgress
+	}
+	_, _ = exec.result.wait(ctx)
+	return ctx.Err()
 }
 
 func (m *localManager) createExecution(ctx context.Context, tid a2a.TaskID, req *a2a.SendMessageRequest) (*localExecution, error) {
@@ -253,8 +276,12 @@ func (m *localManager) handleExecution(ctx context.Context, execution *localExec
 	handler := &executionHandler{
 		agentEvents:       execution.pipe.Reader,
 		handledEventQueue: eventBroadcast,
-		handleEventFn:     processor.Process,
-		handleErrorFn:     processor.ProcessError,
+		handleEventFn: func(ctx context.Context, e a2a.Event) (*ProcessorResult, error) {
+			result, err := processor.Process(ctx, e)
+			execution.exiting.Store(err != nil || result.ExecutionResult != nil)
+			return result, err
+		},
+		handleErrorFn: processor.ProcessError,
 	}
 	result, err := runProducerConsumer(
 		ctx,

--- a/internal/testutil/workqueue.go
+++ b/internal/testutil/workqueue.go
@@ -55,3 +55,20 @@ func NewTestWorkQueue() *TestWorkQueue {
 		Payloads: make([]*workqueue.Payload, 0),
 	}
 }
+
+// NewInMemoryWorkQueue is a simple workqueue implementation.
+func NewInMemoryWorkQueue() *TestWorkQueue {
+	var handler workqueue.HandlerFn
+	tq := &TestWorkQueue{
+		WriteFunc: func(ctx context.Context, p *workqueue.Payload) (a2a.TaskID, error) {
+			go func(ctx context.Context) {
+				_, _ = handler(ctx, p)
+			}(context.WithoutCancel(ctx))
+			return p.TaskID, nil
+		},
+		RegisterHandlerFunc: func(cc workqueue.HandlerConfig, hf workqueue.HandlerFn) {
+			handler = hf
+		},
+	}
+	return tq
+}


### PR DESCRIPTION
This PR cherry-picks changes from 0.3.14 (730788ccab82cdc8fbe77093f4a717d712fe5265) and 0.3.15 (081cf219ac5fc60a2a8a82462967c6a140720edc)