### PR TITLE
refactor: reduce JSON-RPC duplication

### DIFF
--- a/a2aclient/jsonrpc.go
+++ b/a2aclient/jsonrpc.go
@@ -137,6 +137,15 @@ func (t *jsonrpcTransport) sendRequest(ctx context.Context, method string, param
 	return resp.Result, nil
 }
 
+func sendRequestAs[T any](t *jsonrpcTransport, ctx context.Context, method string, params ServiceParams, req any, resultName string) (T, error) {
+	result, err := t.sendRequest(ctx, method, params, req)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return jsonrpc.UnmarshalResult[T](result, resultName)
+}
+
 // sendStreamingRequest sends a streaming JSON-RPC request and returns an SSE stream.
 func (t *jsonrpcTransport) sendStreamingRequest(ctx context.Context, method string, params ServiceParams, req any) (io.ReadCloser, error) {
 	httpReq, err := t.newHTTPRequest(ctx, method, params, req)
@@ -158,30 +167,6 @@ func (t *jsonrpcTransport) sendStreamingRequest(ctx context.Context, method stri
 	}
 
 	return httpResp.Body, nil
-}
-
-// parseSSEStream parses Server-Sent Events and yields JSON-RPC responses.
-func parseSSEStream(body io.Reader) iter.Seq2[json.RawMessage, error] {
-	return func(yield func(json.RawMessage, error) bool) {
-		for data, err := range sse.ParseDataStream(body) {
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-			var resp jsonrpc.ClientResponse
-			if err := json.Unmarshal(data, &resp); err != nil {
-				yield(nil, fmt.Errorf("failed to parse SSE data: %w", err))
-				return
-			}
-			if resp.Error != nil {
-				yield(nil, jsonrpc.FromJSONRPCError(resp.Error))
-				return
-			}
-			if !yield(resp.Result, nil) {
-				return
-			}
-		}
-	}
 }
 
 // SendMessage implements [a2a.Transport].
@@ -223,7 +208,7 @@ func (t *jsonrpcTransport) streamRequestToEvents(ctx context.Context, method str
 			}
 		}()
 
-		for result, err := range parseSSEStream(body) {
+		for result, err := range jsonrpc.ParseSSEStream(body) {
 			if err != nil {
 				yield(nil, err)
 				return
@@ -250,14 +235,9 @@ func (t *jsonrpcTransport) SendStreamingMessage(ctx context.Context, params Serv
 
 // GetTask implements [a2a.Transport].
 func (t *jsonrpcTransport) GetTask(ctx context.Context, params ServiceParams, req *a2a.GetTaskRequest) (*a2a.Task, error) {
-	result, err := t.sendRequest(ctx, jsonrpc.MethodTasksGet, params, req)
+	task, err := sendRequestAs[a2a.Task](t, ctx, jsonrpc.MethodTasksGet, params, req, "task")
 	if err != nil {
 		return nil, err
-	}
-
-	var task a2a.Task
-	if err := json.Unmarshal(result, &task); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal task: %w", err)
 	}
 
 	return &task, nil
@@ -265,14 +245,9 @@ func (t *jsonrpcTransport) GetTask(ctx context.Context, params ServiceParams, re
 
 // ListTasks implements [a2a.Transport].
 func (t *jsonrpcTransport) ListTasks(ctx context.Context, params ServiceParams, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
-	result, err := t.sendRequest(ctx, jsonrpc.MethodTasksList, params, req)
+	response, err := sendRequestAs[a2a.ListTasksResponse](t, ctx, jsonrpc.MethodTasksList, params, req, "response")
 	if err != nil {
 		return nil, err
-	}
-
-	var response a2a.ListTasksResponse
-	if err := json.Unmarshal(result, &response); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
 	return &response, nil
@@ -280,14 +255,9 @@ func (t *jsonrpcTransport) ListTasks(ctx context.Context, params ServiceParams, 
 
 // CancelTask implements [a2a.Transport].
 func (t *jsonrpcTransport) CancelTask(ctx context.Context, params ServiceParams, req *a2a.CancelTaskRequest) (*a2a.Task, error) {
-	result, err := t.sendRequest(ctx, jsonrpc.MethodTasksCancel, params, req)
+	task, err := sendRequestAs[a2a.Task](t, ctx, jsonrpc.MethodTasksCancel, params, req, "task")
 	if err != nil {
 		return nil, err
-	}
-
-	var task a2a.Task
-	if err := json.Unmarshal(result, &task); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal task: %w", err)
 	}
 
 	return &task, nil
@@ -300,14 +270,9 @@ func (t *jsonrpcTransport) SubscribeToTask(ctx context.Context, params ServicePa
 
 // GetTaskPushConfig implements [a2a.Transport].
 func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
-	result, err := t.sendRequest(ctx, jsonrpc.MethodPushConfigGet, params, req)
+	config, err := sendRequestAs[a2a.PushConfig](t, ctx, jsonrpc.MethodPushConfigGet, params, req, "config")
 	if err != nil {
 		return nil, err
-	}
-
-	var config a2a.PushConfig
-	if err := json.Unmarshal(result, &config); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
 	return &config, nil
@@ -315,29 +280,14 @@ func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params Service
 
 // ListTaskPushConfig implements [a2a.Transport].
 func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
-	result, err := t.sendRequest(ctx, jsonrpc.MethodPushConfigList, params, req)
-	if err != nil {
-		return nil, err
-	}
-
-	var configs []*a2a.PushConfig
-	if err := json.Unmarshal(result, &configs); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal configs: %w", err)
-	}
-
-	return configs, nil
+	return sendRequestAs[[]*a2a.PushConfig](t, ctx, jsonrpc.MethodPushConfigList, params, req, "configs")
 }
 
 // CreateTaskPushConfig implements [a2a.Transport].
 func (t *jsonrpcTransport) CreateTaskPushConfig(ctx context.Context, params ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
-	result, err := t.sendRequest(ctx, jsonrpc.MethodPushConfigSet, params, req)
+	config, err := sendRequestAs[a2a.PushConfig](t, ctx, jsonrpc.MethodPushConfigSet, params, req, "config")
 	if err != nil {
 		return nil, err
-	}
-
-	var config a2a.PushConfig
-	if err := json.Unmarshal(result, &config); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
 	return &config, nil
@@ -351,14 +301,9 @@ func (t *jsonrpcTransport) DeleteTaskPushConfig(ctx context.Context, params Serv
 
 // GetExtendedAgentCard implements [a2a.Transport].
 func (t *jsonrpcTransport) GetExtendedAgentCard(ctx context.Context, params ServiceParams, req *a2a.GetExtendedAgentCardRequest) (*a2a.AgentCard, error) {
-	result, err := t.sendRequest(ctx, jsonrpc.MethodGetExtendedAgentCard, params, req)
+	card, err := sendRequestAs[a2a.AgentCard](t, ctx, jsonrpc.MethodGetExtendedAgentCard, params, req, "agent card")
 	if err != nil {
 		return nil, err
-	}
-
-	var card a2a.AgentCard
-	if err := json.Unmarshal(result, &card); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal agent card: %w", err)
 	}
 	return &card, nil
 }

--- a/a2aclient/jsonrpc_test.go
+++ b/a2aclient/jsonrpc_test.go
@@ -331,7 +331,7 @@ data: {"jsonrpc":"2.0","id":"2","result":{"message":{"role":"agent"}}}
 	body := io.NopCloser(bytes.NewBufferString(sseData))
 
 	results := []json.RawMessage{}
-	for result, err := range parseSSEStream(body) {
+	for result, err := range jsonrpc.ParseSSEStream(body) {
 		if err != nil {
 			t.Fatalf("Parse error: %v", err)
 		}

--- a/a2acompat/a2av0/jsonrpc_client.go
+++ b/a2acompat/a2av0/jsonrpc_client.go
@@ -136,6 +136,15 @@ func (t *jsonrpcTransport) sendRequest(ctx context.Context, method string, param
 	return resp.Result, nil
 }
 
+func sendRequestAs[T any](t *jsonrpcTransport, ctx context.Context, method string, params a2aclient.ServiceParams, req any, resultName string) (T, error) {
+	result, err := t.sendRequest(ctx, method, params, req)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	return jsonrpc.UnmarshalResult[T](result, resultName)
+}
+
 func (t *jsonrpcTransport) sendStreamingRequest(ctx context.Context, method string, params a2aclient.ServiceParams, req any) (io.ReadCloser, error) {
 	httpReq, err := t.newHTTPRequest(ctx, method, params, req)
 	if err != nil {
@@ -156,29 +165,6 @@ func (t *jsonrpcTransport) sendStreamingRequest(ctx context.Context, method stri
 	}
 
 	return httpResp.Body, nil
-}
-
-func parseSSEStream(body io.Reader) iter.Seq2[json.RawMessage, error] {
-	return func(yield func(json.RawMessage, error) bool) {
-		for data, err := range sse.ParseDataStream(body) {
-			if err != nil {
-				yield(nil, err)
-				return
-			}
-			var resp jsonrpc.ClientResponse
-			if err := json.Unmarshal(data, &resp); err != nil {
-				yield(nil, fmt.Errorf("failed to parse SSE data: %w", err))
-				return
-			}
-			if resp.Error != nil {
-				yield(nil, jsonrpc.FromJSONRPCError(resp.Error))
-				return
-			}
-			if !yield(resp.Result, nil) {
-				return
-			}
-		}
-	}
 }
 
 // SendMessage sends a non-streaming message to the agent.
@@ -222,7 +208,7 @@ func (t *jsonrpcTransport) streamRequestToEvents(ctx context.Context, method str
 			}
 		}()
 
-		for result, err := range parseSSEStream(body) {
+		for result, err := range jsonrpc.ParseSSEStream(body) {
 			if err != nil {
 				yield(nil, err)
 				return
@@ -256,14 +242,9 @@ func (t *jsonrpcTransport) SendStreamingMessage(ctx context.Context, params a2ac
 // GetTask retrieves the current state of a task.
 func (t *jsonrpcTransport) GetTask(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskRequest) (*a2a.Task, error) {
 	compatReq := FromV1GetTaskRequest(req)
-	result, err := t.sendRequest(ctx, methodTasksGet, params, compatReq)
+	compatTask, err := sendRequestAs[a2alegacy.Task](t, ctx, methodTasksGet, params, compatReq, "task")
 	if err != nil {
 		return nil, err
-	}
-
-	var compatTask a2alegacy.Task
-	if err := json.Unmarshal(result, &compatTask); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal task: %w", err)
 	}
 
 	task, err := ToV1Task(&compatTask)
@@ -281,14 +262,9 @@ func (t *jsonrpcTransport) ListTasks(ctx context.Context, params a2aclient.Servi
 // CancelTask requests cancellation of a task.
 func (t *jsonrpcTransport) CancelTask(ctx context.Context, params a2aclient.ServiceParams, req *a2a.CancelTaskRequest) (*a2a.Task, error) {
 	compatReq := FromV1CancelTaskRequest(req)
-	result, err := t.sendRequest(ctx, methodTasksCancel, params, compatReq)
+	compatTask, err := sendRequestAs[a2alegacy.Task](t, ctx, methodTasksCancel, params, compatReq, "task")
 	if err != nil {
 		return nil, err
-	}
-
-	var compatTask a2alegacy.Task
-	if err := json.Unmarshal(result, &compatTask); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal task: %w", err)
 	}
 
 	task, err := ToV1Task(&compatTask)
@@ -308,14 +284,9 @@ func (t *jsonrpcTransport) SubscribeToTask(ctx context.Context, params a2aclient
 // GetTaskPushConfig retrieves the push notification configuration for a task.
 func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.GetTaskPushConfigRequest) (*a2a.PushConfig, error) {
 	compatReq := FromV1GetTaskPushConfigRequest(req)
-	result, err := t.sendRequest(ctx, methodPushConfigGet, params, compatReq)
+	compatConfig, err := sendRequestAs[a2alegacy.TaskPushConfig](t, ctx, methodPushConfigGet, params, compatReq, "config")
 	if err != nil {
 		return nil, err
-	}
-
-	var compatConfig a2alegacy.TaskPushConfig
-	if err := json.Unmarshal(result, &compatConfig); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
 	config := ToV1PushConfig(&compatConfig)
@@ -325,14 +296,9 @@ func (t *jsonrpcTransport) GetTaskPushConfig(ctx context.Context, params a2aclie
 // ListTaskPushConfig lists push notification configurations.
 func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params a2aclient.ServiceParams, req *a2a.ListTaskPushConfigRequest) ([]*a2a.PushConfig, error) {
 	compatReq := FromV1ListTaskPushConfigRequest(req)
-	result, err := t.sendRequest(ctx, methodPushConfigList, params, compatReq)
+	compatConfigs, err := sendRequestAs[[]*a2alegacy.TaskPushConfig](t, ctx, methodPushConfigList, params, compatReq, "configs")
 	if err != nil {
 		return nil, err
-	}
-
-	var compatConfigs []*a2alegacy.TaskPushConfig
-	if err := json.Unmarshal(result, &compatConfigs); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal configs: %w", err)
 	}
 
 	configs := make([]*a2a.PushConfig, 0, len(compatConfigs))
@@ -347,14 +313,9 @@ func (t *jsonrpcTransport) ListTaskPushConfigs(ctx context.Context, params a2acl
 // CreateTaskPushConfig sets or updates the push notification configuration for a task.
 func (t *jsonrpcTransport) CreateTaskPushConfig(ctx context.Context, params a2aclient.ServiceParams, req *a2a.PushConfig) (*a2a.PushConfig, error) {
 	compatReq := FromV1PushConfig(req)
-	result, err := t.sendRequest(ctx, methodPushConfigSet, params, compatReq)
+	compatConfig, err := sendRequestAs[a2alegacy.TaskPushConfig](t, ctx, methodPushConfigSet, params, compatReq, "config")
 	if err != nil {
 		return nil, err
-	}
-
-	var compatConfig a2alegacy.TaskPushConfig
-	if err := json.Unmarshal(result, &compatConfig); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
 	config := ToV1PushConfig(&compatConfig)

--- a/a2acompat/a2av0/jsonrpc_server.go
+++ b/a2acompat/a2av0/jsonrpc_server.go
@@ -17,7 +17,6 @@ package a2av0
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"iter"
 	"net/http"
@@ -64,7 +63,7 @@ func (h *jsonrpcHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	var payload jsonrpc.ServerRequest
 	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-		h.writeJSONRPCError(ctx, rw, handleUnmarshalError(err), nil)
+		h.writeJSONRPCError(ctx, rw, jsonrpc.UnmarshalError(err), nil)
 		return
 	}
 
@@ -130,7 +129,7 @@ func (h *jsonrpcHandler) handleRequest(ctx context.Context, rw http.ResponseWrit
 	}
 
 	rw.Header().Set("Content-Type", jsonrpc.ContentJSON)
-	resp := jsonrpc.ServerResponse{JSONRPC: jsonrpc.Version, ID: req.ID, Result: result}
+	resp := jsonrpc.NewResultResponse(req.ID, result)
 	if err := json.NewEncoder(rw).Encode(resp); err != nil {
 		log.Error(ctx, "failed to encode response", err)
 	}
@@ -186,7 +185,7 @@ func (h *jsonrpcHandler) handleStreamingRequest(ctx context.Context, rw http.Res
 			if h.cfg.PanicHandler == nil {
 				panic(err)
 			}
-			data, ok := marshalJSONRPCError(req, h.cfg.PanicHandler(err))
+			data, ok := jsonrpc.MarshalErrorResponse(req.ID, h.cfg.PanicHandler(err))
 			if !ok {
 				log.Error(ctx, "failed to marshal error response", err)
 				return
@@ -214,7 +213,7 @@ func (h *jsonrpcHandler) handleStreamingRequest(ctx context.Context, rw http.Res
 
 func eventSeqToSSEDataStream(ctx context.Context, req *jsonrpc.ServerRequest, sseChan chan []byte, events iter.Seq2[a2a.Event, error]) {
 	handleError := func(err error) {
-		bytes, ok := marshalJSONRPCError(req, err)
+		bytes, ok := jsonrpc.MarshalErrorResponse(req.ID, err)
 		if !ok {
 			log.Error(ctx, "failed to marshal error response", err)
 			return
@@ -238,7 +237,7 @@ func eventSeqToSSEDataStream(ctx context.Context, req *jsonrpc.ServerRequest, ss
 			return
 		}
 
-		resp := jsonrpc.ServerResponse{JSONRPC: jsonrpc.Version, ID: req.ID, Result: compatEvent}
+		resp := jsonrpc.NewResultResponse(req.ID, compatEvent)
 		bytes, err := json.Marshal(resp)
 		if err != nil {
 			handleError(err)
@@ -254,11 +253,11 @@ func eventSeqToSSEDataStream(ctx context.Context, req *jsonrpc.ServerRequest, ss
 }
 
 func (h *jsonrpcHandler) onGetTask(ctx context.Context, raw json.RawMessage) (*a2alegacy.Task, error) {
-	var query a2alegacy.TaskQueryParams
-	if err := json.Unmarshal(raw, &query); err != nil {
-		return nil, handleUnmarshalError(err)
+	query, err := jsonrpc.UnmarshalParams[a2alegacy.TaskQueryParams](raw)
+	if err != nil {
+		return nil, err
 	}
-	compatTask, err := h.handler.GetTask(ctx, ToV1GetTaskRequest(&query))
+	compatTask, err := h.handler.GetTask(ctx, ToV1GetTaskRequest(query))
 	if err != nil {
 		return nil, err
 	}
@@ -266,11 +265,11 @@ func (h *jsonrpcHandler) onGetTask(ctx context.Context, raw json.RawMessage) (*a
 }
 
 func (h *jsonrpcHandler) onCancelTask(ctx context.Context, raw json.RawMessage) (*a2alegacy.Task, error) {
-	var id a2alegacy.TaskIDParams
-	if err := json.Unmarshal(raw, &id); err != nil {
-		return nil, handleUnmarshalError(err)
+	id, err := jsonrpc.UnmarshalParams[a2alegacy.TaskIDParams](raw)
+	if err != nil {
+		return nil, err
 	}
-	compatTask, err := h.handler.CancelTask(ctx, ToV1CancelTaskRequest(&id))
+	compatTask, err := h.handler.CancelTask(ctx, ToV1CancelTaskRequest(id))
 	if err != nil {
 		return nil, err
 	}
@@ -278,13 +277,13 @@ func (h *jsonrpcHandler) onCancelTask(ctx context.Context, raw json.RawMessage) 
 }
 
 func (h *jsonrpcHandler) onSendMessage(ctx context.Context, raw json.RawMessage) (a2alegacy.SendMessageResult, error) {
-	var message a2alegacy.MessageSendParams
-	if err := json.Unmarshal(raw, &message); err != nil {
-		return nil, handleUnmarshalError(err)
-	}
-	req, err := ToV1SendMessageRequest(&message)
+	message, err := jsonrpc.UnmarshalParams[a2alegacy.MessageSendParams](raw)
 	if err != nil {
-		return nil, handleUnmarshalError(err)
+		return nil, err
+	}
+	req, err := ToV1SendMessageRequest(message)
+	if err != nil {
+		return nil, jsonrpc.UnmarshalError(err)
 	}
 	compatResult, err := h.handler.SendMessage(ctx, req)
 	if err != nil {
@@ -303,12 +302,12 @@ func (h *jsonrpcHandler) onSendMessage(ctx context.Context, raw json.RawMessage)
 
 func (h *jsonrpcHandler) onResubscribeToTask(ctx context.Context, raw json.RawMessage) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
-		var id a2alegacy.TaskIDParams
-		if err := json.Unmarshal(raw, &id); err != nil {
-			yield(nil, handleUnmarshalError(err))
+		id, err := jsonrpc.UnmarshalParams[a2alegacy.TaskIDParams](raw)
+		if err != nil {
+			yield(nil, err)
 			return
 		}
-		for event, err := range h.handler.SubscribeToTask(ctx, ToV1SubscribeToTaskRequest(&id)) {
+		for event, err := range h.handler.SubscribeToTask(ctx, ToV1SubscribeToTaskRequest(id)) {
 			if !yield(event, err) {
 				return
 			}
@@ -318,14 +317,14 @@ func (h *jsonrpcHandler) onResubscribeToTask(ctx context.Context, raw json.RawMe
 
 func (h *jsonrpcHandler) onSendMessageStream(ctx context.Context, raw json.RawMessage) iter.Seq2[a2a.Event, error] {
 	return func(yield func(a2a.Event, error) bool) {
-		var message a2alegacy.MessageSendParams
-		if err := json.Unmarshal(raw, &message); err != nil {
-			yield(nil, handleUnmarshalError(err))
+		message, err := jsonrpc.UnmarshalParams[a2alegacy.MessageSendParams](raw)
+		if err != nil {
+			yield(nil, err)
 			return
 		}
-		req, err := ToV1SendMessageRequest(&message)
+		req, err := ToV1SendMessageRequest(message)
 		if err != nil {
-			yield(nil, handleUnmarshalError(err))
+			yield(nil, jsonrpc.UnmarshalError(err))
 			return
 		}
 		for event, err := range h.handler.SendStreamingMessage(ctx, req) {
@@ -338,11 +337,11 @@ func (h *jsonrpcHandler) onSendMessageStream(ctx context.Context, raw json.RawMe
 }
 
 func (h *jsonrpcHandler) onGetTaskPushConfig(ctx context.Context, raw json.RawMessage) (*a2alegacy.TaskPushConfig, error) {
-	var params a2alegacy.GetTaskPushConfigParams
-	if err := json.Unmarshal(raw, &params); err != nil {
-		return nil, handleUnmarshalError(err)
+	params, err := jsonrpc.UnmarshalParams[a2alegacy.GetTaskPushConfigParams](raw)
+	if err != nil {
+		return nil, err
 	}
-	config, err := h.handler.GetTaskPushConfig(ctx, ToV1GetTaskPushConfigRequest(&params))
+	config, err := h.handler.GetTaskPushConfig(ctx, ToV1GetTaskPushConfigRequest(params))
 	if err != nil {
 		return nil, err
 	}
@@ -350,11 +349,11 @@ func (h *jsonrpcHandler) onGetTaskPushConfig(ctx context.Context, raw json.RawMe
 }
 
 func (h *jsonrpcHandler) onListTaskPushConfigs(ctx context.Context, raw json.RawMessage) ([]*a2alegacy.TaskPushConfig, error) {
-	var params a2alegacy.ListTaskPushConfigParams
-	if err := json.Unmarshal(raw, &params); err != nil {
-		return nil, handleUnmarshalError(err)
+	params, err := jsonrpc.UnmarshalParams[a2alegacy.ListTaskPushConfigParams](raw)
+	if err != nil {
+		return nil, err
 	}
-	configs, err := h.handler.ListTaskPushConfigs(ctx, ToV1ListTaskPushConfigRequest(&params))
+	configs, err := h.handler.ListTaskPushConfigs(ctx, ToV1ListTaskPushConfigRequest(params))
 	if err != nil {
 		return nil, err
 	}
@@ -362,11 +361,11 @@ func (h *jsonrpcHandler) onListTaskPushConfigs(ctx context.Context, raw json.Raw
 }
 
 func (h *jsonrpcHandler) onSetTaskPushConfig(ctx context.Context, raw json.RawMessage) (*a2alegacy.TaskPushConfig, error) {
-	var params a2alegacy.TaskPushConfig
-	if err := json.Unmarshal(raw, &params); err != nil {
-		return nil, handleUnmarshalError(err)
+	params, err := jsonrpc.UnmarshalParams[a2alegacy.TaskPushConfig](raw)
+	if err != nil {
+		return nil, err
 	}
-	config, err := h.handler.CreateTaskPushConfig(ctx, ToV1PushConfig(&params))
+	config, err := h.handler.CreateTaskPushConfig(ctx, ToV1PushConfig(params))
 	if err != nil {
 		return nil, err
 	}
@@ -374,11 +373,11 @@ func (h *jsonrpcHandler) onSetTaskPushConfig(ctx context.Context, raw json.RawMe
 }
 
 func (h *jsonrpcHandler) onDeleteTaskPushConfig(ctx context.Context, raw json.RawMessage) error {
-	var params a2alegacy.DeleteTaskPushConfigParams
-	if err := json.Unmarshal(raw, &params); err != nil {
-		return handleUnmarshalError(err)
+	params, err := jsonrpc.UnmarshalParams[a2alegacy.DeleteTaskPushConfigParams](raw)
+	if err != nil {
+		return err
 	}
-	return h.handler.DeleteTaskPushConfig(ctx, ToV1DeleteTaskPushConfigRequest(&params))
+	return h.handler.DeleteTaskPushConfig(ctx, ToV1DeleteTaskPushConfigRequest(params))
 }
 
 func (h *jsonrpcHandler) onGetAgentCard(ctx context.Context) (*a2alegacy.AgentCard, error) {
@@ -389,27 +388,8 @@ func (h *jsonrpcHandler) onGetAgentCard(ctx context.Context) (*a2alegacy.AgentCa
 	return FromV1AgentCard(card), nil
 }
 
-func marshalJSONRPCError(req *jsonrpc.ServerRequest, err error) ([]byte, bool) {
-	jsonrpcErr := jsonrpc.ToJSONRPCError(err)
-	resp := jsonrpc.ServerResponse{JSONRPC: jsonrpc.Version, ID: req.ID, Error: jsonrpcErr}
-	bytes, err := json.Marshal(resp)
-	if err != nil {
-		return nil, false
-	}
-	return bytes, true
-}
-
-func handleUnmarshalError(err error) error {
-	var typeErr *json.UnmarshalTypeError
-	if errors.As(err, &typeErr) {
-		return fmt.Errorf("%w: %w", a2a.ErrInvalidParams, err)
-	}
-	return fmt.Errorf("%w: %w", a2a.ErrParseError, err)
-}
-
 func (h *jsonrpcHandler) writeJSONRPCError(ctx context.Context, rw http.ResponseWriter, err error, reqID any) {
-	jsonrpcErr := jsonrpc.ToJSONRPCError(err)
-	resp := jsonrpc.ServerResponse{JSONRPC: jsonrpc.Version, Error: jsonrpcErr, ID: reqID}
+	resp := jsonrpc.NewErrorResponse(reqID, err)
 	if err := json.NewEncoder(rw).Encode(resp); err != nil {
 		log.Error(ctx, "failed to send error response", err)
 	}

--- a/a2asrv/jsonrpc.go
+++ b/a2asrv/jsonrpc.go
@@ -17,7 +17,6 @@ package a2asrv
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"iter"
 	"net/http"
@@ -62,7 +61,7 @@ func (h *jsonrpcHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	var payload jsonrpc.ServerRequest
 	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-		h.writeJSONRPCError(ctx, rw, handleUnmarshalError(err), nil)
+		h.writeJSONRPCError(ctx, rw, jsonrpc.UnmarshalError(err), nil)
 		return
 	}
 
@@ -133,8 +132,8 @@ func (h *jsonrpcHandler) handleRequest(ctx context.Context, rw http.ResponseWrit
 		return
 	}
 
-	rw.Header().Set("Content-Type", "application/json")
-	resp := jsonrpc.ServerResponse{JSONRPC: jsonrpc.Version, ID: req.ID, Result: result}
+	rw.Header().Set("Content-Type", jsonrpc.ContentJSON)
+	resp := jsonrpc.NewResultResponse(req.ID, result)
 	if err := json.NewEncoder(rw).Encode(resp); err != nil {
 		log.Error(ctx, "failed to encode response", err)
 	}
@@ -191,7 +190,7 @@ func (h *jsonrpcHandler) handleStreamingRequest(ctx context.Context, rw http.Res
 			if h.cfg.PanicHandler == nil {
 				panic(err)
 			}
-			data, ok := marshalJSONRPCError(req, h.cfg.PanicHandler(err))
+			data, ok := jsonrpc.MarshalErrorResponse(req.ID, h.cfg.PanicHandler(err))
 			if !ok {
 				log.Error(ctx, "failed to marshal error response", err)
 				return
@@ -220,7 +219,7 @@ func (h *jsonrpcHandler) handleStreamingRequest(ctx context.Context, rw http.Res
 
 func eventSeqToSSEDataStream(ctx context.Context, req *jsonrpc.ServerRequest, sseChan chan []byte, events iter.Seq2[a2a.Event, error]) {
 	handleError := func(err error) {
-		bytes, ok := marshalJSONRPCError(req, err)
+		bytes, ok := jsonrpc.MarshalErrorResponse(req.ID, err)
 		if !ok {
 			log.Error(ctx, "failed to marshal error response", err)
 			return
@@ -238,7 +237,7 @@ func eventSeqToSSEDataStream(ctx context.Context, req *jsonrpc.ServerRequest, ss
 			return
 		}
 
-		resp := jsonrpc.ServerResponse{JSONRPC: jsonrpc.Version, ID: req.ID, Result: a2a.StreamResponse{Event: event}}
+		resp := jsonrpc.NewResultResponse(req.ID, a2a.StreamResponse{Event: event})
 		bytes, err := json.Marshal(resp)
 		if err != nil {
 			handleError(err)
@@ -253,130 +252,85 @@ func eventSeqToSSEDataStream(ctx context.Context, req *jsonrpc.ServerRequest, ss
 	}
 }
 
-func (h *jsonrpcHandler) onGetTask(ctx context.Context, raw json.RawMessage) (*a2a.Task, error) {
-	var query a2a.GetTaskRequest
-	if err := json.Unmarshal(raw, &query); err != nil {
-		return nil, handleUnmarshalError(err)
+func callJSONRPC[Req any, Resp any](ctx context.Context, raw json.RawMessage, call func(context.Context, *Req) (Resp, error)) (Resp, error) {
+	var zero Resp
+	params, err := jsonrpc.UnmarshalParams[Req](raw)
+	if err != nil {
+		return zero, err
 	}
-	return h.handler.GetTask(ctx, &query)
+	return call(ctx, params)
+}
+
+func callJSONRPCNoResult[Req any](ctx context.Context, raw json.RawMessage, call func(context.Context, *Req) error) error {
+	params, err := jsonrpc.UnmarshalParams[Req](raw)
+	if err != nil {
+		return err
+	}
+	return call(ctx, params)
+}
+
+func streamJSONRPC[Req any](ctx context.Context, raw json.RawMessage, call func(context.Context, *Req) iter.Seq2[a2a.Event, error]) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {
+		params, err := jsonrpc.UnmarshalParams[Req](raw)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		for event, err := range call(ctx, params) {
+			if !yield(event, err) {
+				return
+			}
+		}
+	}
+}
+
+func (h *jsonrpcHandler) onGetTask(ctx context.Context, raw json.RawMessage) (*a2a.Task, error) {
+	return callJSONRPC(ctx, raw, h.handler.GetTask)
 }
 
 func (h *jsonrpcHandler) onListTasks(ctx context.Context, raw json.RawMessage) (*a2a.ListTasksResponse, error) {
-	var request a2a.ListTasksRequest
-	if err := json.Unmarshal(raw, &request); err != nil {
-		return nil, handleUnmarshalError(err)
-	}
-	return h.handler.ListTasks(ctx, &request)
+	return callJSONRPC(ctx, raw, h.handler.ListTasks)
 }
 
 func (h *jsonrpcHandler) onCancelTask(ctx context.Context, raw json.RawMessage) (*a2a.Task, error) {
-	var id a2a.CancelTaskRequest
-	if err := json.Unmarshal(raw, &id); err != nil {
-		return nil, handleUnmarshalError(err)
-	}
-	return h.handler.CancelTask(ctx, &id)
+	return callJSONRPC(ctx, raw, h.handler.CancelTask)
 }
 
 func (h *jsonrpcHandler) onSendMessage(ctx context.Context, raw json.RawMessage) (a2a.SendMessageResult, error) {
-	var message a2a.SendMessageRequest
-	if err := json.Unmarshal(raw, &message); err != nil {
-		return nil, handleUnmarshalError(err)
-	}
-	return h.handler.SendMessage(ctx, &message)
+	return callJSONRPC(ctx, raw, h.handler.SendMessage)
 }
 
 func (h *jsonrpcHandler) onResubscribeToTask(ctx context.Context, raw json.RawMessage) iter.Seq2[a2a.Event, error] {
-	return func(yield func(a2a.Event, error) bool) {
-		var id a2a.SubscribeToTaskRequest
-		if err := json.Unmarshal(raw, &id); err != nil {
-			yield(nil, handleUnmarshalError(err))
-			return
-		}
-		for event, err := range h.handler.SubscribeToTask(ctx, &id) {
-			if !yield(event, err) {
-				return
-			}
-		}
-	}
+	return streamJSONRPC(ctx, raw, h.handler.SubscribeToTask)
 }
 
 func (h *jsonrpcHandler) onSendMessageStream(ctx context.Context, raw json.RawMessage) iter.Seq2[a2a.Event, error] {
-	return func(yield func(a2a.Event, error) bool) {
-		var message a2a.SendMessageRequest
-		if err := json.Unmarshal(raw, &message); err != nil {
-			yield(nil, handleUnmarshalError(err))
-			return
-		}
-		for event, err := range h.handler.SendStreamingMessage(ctx, &message) {
-			if !yield(event, err) {
-				return
-			}
-		}
-	}
+	return streamJSONRPC(ctx, raw, h.handler.SendStreamingMessage)
 }
 
 func (h *jsonrpcHandler) onGetTaskPushConfig(ctx context.Context, raw json.RawMessage) (*a2a.PushConfig, error) {
-	var params a2a.GetTaskPushConfigRequest
-	if err := json.Unmarshal(raw, &params); err != nil {
-		return nil, handleUnmarshalError(err)
-	}
-	return h.handler.GetTaskPushConfig(ctx, &params)
+	return callJSONRPC(ctx, raw, h.handler.GetTaskPushConfig)
 }
 
 func (h *jsonrpcHandler) onListTaskPushConfigs(ctx context.Context, raw json.RawMessage) ([]*a2a.PushConfig, error) {
-	var params a2a.ListTaskPushConfigRequest
-	if err := json.Unmarshal(raw, &params); err != nil {
-		return nil, handleUnmarshalError(err)
-	}
-	return h.handler.ListTaskPushConfigs(ctx, &params)
+	return callJSONRPC(ctx, raw, h.handler.ListTaskPushConfigs)
 }
 
 func (h *jsonrpcHandler) onSetTaskPushConfig(ctx context.Context, raw json.RawMessage) (*a2a.PushConfig, error) {
-	var params a2a.PushConfig
-	if err := json.Unmarshal(raw, &params); err != nil {
-		return nil, handleUnmarshalError(err)
-	}
-	return h.handler.CreateTaskPushConfig(ctx, &params)
+	return callJSONRPC(ctx, raw, h.handler.CreateTaskPushConfig)
 }
 
 func (h *jsonrpcHandler) onDeleteTaskPushConfig(ctx context.Context, raw json.RawMessage) error {
-	var params a2a.DeleteTaskPushConfigRequest
-	if err := json.Unmarshal(raw, &params); err != nil {
-		return handleUnmarshalError(err)
-	}
-	return h.handler.DeleteTaskPushConfig(ctx, &params)
+	return callJSONRPCNoResult(ctx, raw, h.handler.DeleteTaskPushConfig)
 }
 
 func (h *jsonrpcHandler) onGetExtendedAgentCard(ctx context.Context, raw json.RawMessage) (*a2a.AgentCard, error) {
-	var params a2a.GetExtendedAgentCardRequest
-	if err := json.Unmarshal(raw, &params); err != nil {
-		return nil, handleUnmarshalError(err)
-	}
-	return h.handler.GetExtendedAgentCard(ctx, &params)
-}
-
-func marshalJSONRPCError(req *jsonrpc.ServerRequest, err error) ([]byte, bool) {
-	jsonrpcErr := jsonrpc.ToJSONRPCError(err)
-	resp := jsonrpc.ServerResponse{JSONRPC: jsonrpc.Version, ID: req.ID, Error: jsonrpcErr}
-	bytes, err := json.Marshal(resp)
-	if err != nil {
-		return nil, false
-	}
-	return bytes, true
-}
-
-func handleUnmarshalError(err error) error {
-	var typeErr *json.UnmarshalTypeError
-	if errors.As(err, &typeErr) {
-		return fmt.Errorf("%w: %w", a2a.ErrInvalidParams, err)
-	}
-	return fmt.Errorf("%w: %w", a2a.ErrParseError, err)
+	return callJSONRPC(ctx, raw, h.handler.GetExtendedAgentCard)
 }
 
 func (h *jsonrpcHandler) writeJSONRPCError(ctx context.Context, rw http.ResponseWriter, err error, reqID any) {
-	jsonrpcErr := jsonrpc.ToJSONRPCError(err)
-	resp := jsonrpc.ServerResponse{JSONRPC: jsonrpc.Version, Error: jsonrpcErr, ID: reqID}
-	rw.Header().Set("Content-Type", "application/json")
+	resp := jsonrpc.NewErrorResponse(reqID, err)
+	rw.Header().Set("Content-Type", jsonrpc.ContentJSON)
 	if err := json.NewEncoder(rw).Encode(resp); err != nil {
 		log.Error(ctx, "failed to send error response", err)
 	}

--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -88,7 +88,7 @@ func NewTenantRESTHandler(tenantTemplate string, handler RequestHandler, opts ..
 
 		r2 := new(http.Request)
 		*r2 = *r
-		r2 = r2.WithContext(attachTenant(r.Context(), matchResult.Captured))
+		r2 = r2.WithContext(a2a.AttachTenant(r.Context(), matchResult.Captured))
 		r2.URL = new(url.URL)
 		*r2.URL = *r.URL
 		r2.URL.Path = matchResult.Rest
@@ -498,21 +498,8 @@ func writeRESTError(ctx context.Context, rw http.ResponseWriter, err error, task
 	}
 }
 
-type tenantKeyType struct{}
-
 func fillTenant(ctx context.Context, tenant *string) {
-	if t := tenantFromContext(ctx); t != "" {
+	if t, ok := a2a.TenantFrom(ctx); ok && t != "" {
 		*tenant = t
 	}
-}
-
-func attachTenant(parent context.Context, tenant string) context.Context {
-	return context.WithValue(parent, tenantKeyType{}, tenant)
-}
-
-func tenantFromContext(ctx context.Context) string {
-	if tenant, ok := ctx.Value(tenantKeyType{}).(string); ok {
-		return tenant
-	}
-	return ""
 }

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -182,14 +182,17 @@ func ToJSONRPCError(err error) *Error {
 	}
 }
 
+// NewResultResponse returns a JSON-RPC response with result payload.
 func NewResultResponse(reqID any, result any) ServerResponse {
 	return ServerResponse{JSONRPC: Version, ID: reqID, Result: result}
 }
 
+// NewErrorResponse returns a JSON-RPC response with error payload.
 func NewErrorResponse(reqID any, err error) ServerResponse {
 	return ServerResponse{JSONRPC: Version, Error: ToJSONRPCError(err), ID: reqID}
 }
 
+// MarshalErrorResponse marshals an error as a JSON-RPC response.
 func MarshalErrorResponse(reqID any, respErr error) ([]byte, bool) {
 	bytes, err := json.Marshal(NewErrorResponse(reqID, respErr))
 	if err != nil {
@@ -198,6 +201,7 @@ func MarshalErrorResponse(reqID any, respErr error) ([]byte, bool) {
 	return bytes, true
 }
 
+// UnmarshalError maps JSON decoding errors to A2A protocol errors.
 func UnmarshalError(err error) error {
 	var typeErr *json.UnmarshalTypeError
 	if errors.As(err, &typeErr) {
@@ -206,6 +210,7 @@ func UnmarshalError(err error) error {
 	return fmt.Errorf("%w: %w", a2a.ErrParseError, err)
 }
 
+// UnmarshalParams unmarshals JSON-RPC params into typed request params.
 func UnmarshalParams[T any](raw json.RawMessage) (*T, error) {
 	var params T
 	if err := json.Unmarshal(raw, &params); err != nil {
@@ -214,6 +219,7 @@ func UnmarshalParams[T any](raw json.RawMessage) (*T, error) {
 	return &params, nil
 }
 
+// UnmarshalResult unmarshals a JSON-RPC result into the requested type.
 func UnmarshalResult[T any](raw json.RawMessage, resultName string) (T, error) {
 	var result T
 	if err := json.Unmarshal(raw, &result); err != nil {
@@ -222,6 +228,7 @@ func UnmarshalResult[T any](raw json.RawMessage, resultName string) (T, error) {
 	return result, nil
 }
 
+// ParseSSEStream parses SSE data as JSON-RPC client responses.
 func ParseSSEStream(body io.Reader) iter.Seq2[json.RawMessage, error] {
 	return func(yield func(json.RawMessage, error) bool) {
 		for data, err := range sse.ParseDataStream(body) {

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -19,11 +19,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"iter"
 	"maps"
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
+	"github.com/a2aproject/a2a-go/v2/internal/sse"
 	"github.com/a2aproject/a2a-go/v2/internal/utils"
 )
 
@@ -176,6 +179,69 @@ func ToJSONRPCError(err error) *Error {
 		Code:    code,
 		Message: err.Error(),
 		Data:    data,
+	}
+}
+
+func NewResultResponse(reqID any, result any) ServerResponse {
+	return ServerResponse{JSONRPC: Version, ID: reqID, Result: result}
+}
+
+func NewErrorResponse(reqID any, err error) ServerResponse {
+	return ServerResponse{JSONRPC: Version, Error: ToJSONRPCError(err), ID: reqID}
+}
+
+func MarshalErrorResponse(reqID any, respErr error) ([]byte, bool) {
+	bytes, err := json.Marshal(NewErrorResponse(reqID, respErr))
+	if err != nil {
+		return nil, false
+	}
+	return bytes, true
+}
+
+func UnmarshalError(err error) error {
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		return fmt.Errorf("%w: %w", a2a.ErrInvalidParams, err)
+	}
+	return fmt.Errorf("%w: %w", a2a.ErrParseError, err)
+}
+
+func UnmarshalParams[T any](raw json.RawMessage) (*T, error) {
+	var params T
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, UnmarshalError(err)
+	}
+	return &params, nil
+}
+
+func UnmarshalResult[T any](raw json.RawMessage, resultName string) (T, error) {
+	var result T
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return result, fmt.Errorf("failed to unmarshal %s: %w", resultName, err)
+	}
+	return result, nil
+}
+
+func ParseSSEStream(body io.Reader) iter.Seq2[json.RawMessage, error] {
+	return func(yield func(json.RawMessage, error) bool) {
+		for data, err := range sse.ParseDataStream(body) {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			var resp ClientResponse
+			if err := json.Unmarshal(data, &resp); err != nil {
+				yield(nil, fmt.Errorf("failed to parse SSE data: %w", err))
+				return
+			}
+			if resp.Error != nil {
+				yield(nil, FromJSONRPCError(resp.Error))
+				return
+			}
+			if !yield(resp.Result, nil) {
+				return
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Proposed changes from Molten.Bot

This PR implements the requested changes described below.
Built using an AI augmented engineering and reviewed before submission.
Only relevant files were modified.

Original task prompt:
```text
Refactor this repository to reduce the codebase size and centralize duplicated classes, types, and shared logic.

Task:
- Use the most appropriate existing abstractions.
- Remove redundancy instead of layering new wrappers.
- Preserve behavior.
- Avoid regressions.
- Keep the diff focused on the reduction/centralization goal.

Validation:
- Validate the result with focused tests and any existing local verification the repository supports before finishing.
- If local test or validation tooling is unavailable in this runtime, for example `command not found`, do not fail solely for that. Continue with any alternative checks available and clearly report the validation gap.

Failure reporting:
- If failures occur, send a response back to the calling agent with these fields:
  `Failure:` <short failure summary>
  `Error details:` <failing command, log detail, or concrete blocker>.
```

Curious how this was built? See how AI agents can help with your own projects: [MoltenBot Code](https://molten.bot/code?source=pr)