### PR TITLE
fix(a2acompat): correct OAuth2 round-trip through compat producer/parser

### DIFF
--- a/a2acompat/a2av0/agentcard.go
+++ b/a2acompat/a2av0/agentcard.go
@@ -178,7 +178,11 @@ func mapFromCompatSecuritySchemes(schemes namedSecuritySchemes) a2a.NamedSecurit
 			if v.OAuth2 != nil {
 				result[name] = *v.OAuth2
 			} else {
-				result[name] = a2a.OAuth2SecurityScheme{Description: v.Description}
+				result[name] = a2a.OAuth2SecurityScheme{
+					Description:       v.Description,
+					Flows:             v.Flows,
+					Oauth2MetadataURL: v.Oauth2MetadataURL,
+				}
 			}
 		}
 	}
@@ -476,13 +480,17 @@ type oauth2SecurityScheme struct {
 	OAuth2            *a2a.OAuth2SecurityScheme `json:"oauth2"`
 }
 
-func (s *oauth2SecurityScheme) MarshalJSON() ([]byte, error) {
+// Value receiver so json.Marshal invokes it when the scheme is held in
+// the `map[name]any` namedSecuritySchemes (map values aren't addressable,
+// so a pointer-receiver Marshaler isn't satisfied).
+func (s oauth2SecurityScheme) MarshalJSON() ([]byte, error) {
 	type wrapper struct {
+		Type              string                    `json:"type"`
 		Description       string                    `json:"description,omitempty"`
 		Oauth2MetadataURL string                    `json:"oauth2MetadataUrl,omitempty"`
 		Flows             map[a2a.OAuthFlowName]any `json:"flows,omitempty"`
 	}
-	wrapped := wrapper{Description: s.Description, Oauth2MetadataURL: s.Oauth2MetadataURL}
+	wrapped := wrapper{Type: "oauth2", Description: s.Description, Oauth2MetadataURL: s.Oauth2MetadataURL}
 	switch v := s.Flows.(type) {
 	case a2a.AuthorizationCodeOAuthFlow:
 		wrapped.Flows = map[a2a.OAuthFlowName]any{a2a.AuthorizationCodeOAuthFlowName: v}
@@ -514,6 +522,9 @@ func (s *oauth2SecurityScheme) UnmarshalJSON(b []byte) error {
 	if len(scheme.Flows) != 1 {
 		return fmt.Errorf("expected exactly one OAuth flow, got %d", len(scheme.Flows))
 	}
+
+	s.Description = scheme.Description
+	s.Oauth2MetadataURL = scheme.Oauth2MetadataURL
 
 	for name, rawMessage := range scheme.Flows {
 		switch name {

--- a/a2acompat/a2av0/agentcard_test.go
+++ b/a2acompat/a2av0/agentcard_test.go
@@ -225,3 +225,122 @@ type staticCardProducer struct {
 func (s *staticCardProducer) Card(ctx context.Context) (*a2a.AgentCard, error) {
 	return s.card, nil
 }
+
+// oauth2Card returns a minimal AgentCard with a single OAuth2 scheme
+// using the given flow. newAgentCard above only covers OpenIDConnect,
+// which doesn't go through the OAuth2-specific marshal path.
+func oauth2Card(flow a2a.OAuthFlows) *a2a.AgentCard {
+	return &a2a.AgentCard{
+		Name:    "OAuth2 Agent",
+		Version: "1.0.0",
+		SupportedInterfaces: []*a2a.AgentInterface{{
+			URL:             "https://example.com/a2a/v1",
+			ProtocolBinding: a2a.TransportProtocolJSONRPC,
+			ProtocolVersion: Version,
+		}},
+		SecuritySchemes: a2a.NamedSecuritySchemes{
+			"oauth2": a2a.OAuth2SecurityScheme{
+				Description:       "OAuth2",
+				Oauth2MetadataURL: "https://example.com/.well-known/oauth-authorization-server",
+				Flows:             flow,
+			},
+		},
+		SecurityRequirements: a2a.SecurityRequirementsOptions{
+			a2a.SecurityRequirements{"oauth2": {"openid", "profile"}},
+		},
+	}
+}
+
+func TestAgentCard_OAuth2_AllFlows_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name    string
+		flow    a2a.OAuthFlows
+		flowKey a2a.OAuthFlowName
+	}{
+		{"authorizationCode", a2a.AuthorizationCodeOAuthFlow{
+			AuthorizationURL: "https://example.com/authorize",
+			TokenURL:         "https://example.com/token",
+			Scopes:           map[string]string{"openid": "OpenID Connect"},
+		}, a2a.AuthorizationCodeOAuthFlowName},
+		{"clientCredentials", a2a.ClientCredentialsOAuthFlow{
+			TokenURL: "https://example.com/token",
+			Scopes:   map[string]string{"api": "API access"},
+		}, a2a.ClientCredentialsOAuthFlowName},
+		{"implicit", a2a.ImplicitOAuthFlow{
+			AuthorizationURL: "https://example.com/authorize",
+			Scopes:           map[string]string{"profile": "User profile"},
+		}, a2a.ImplicitOAuthFlowName},
+		{"password", a2a.PasswordOAuthFlow{
+			TokenURL: "https://example.com/token",
+			Scopes:   map[string]string{"openid": "OpenID Connect"},
+		}, a2a.PasswordOAuthFlowName},
+		{"deviceCode", a2a.DeviceCodeOAuthFlow{
+			DeviceAuthorizationURL: "https://example.com/device",
+			TokenURL:               "https://example.com/token",
+			Scopes:                 map[string]string{"openid": "OpenID Connect"},
+		}, a2a.DeviceCodeOAuthFlowName},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			card := oauth2Card(tc.flow)
+
+			prod := &compatProducer{&staticCardProducer{card: card}}
+			body, err := prod.CardJSON(context.Background())
+			if err != nil {
+				t.Fatalf("CardJSON: %v", err)
+			}
+
+			// The producer's wire format must wrap the flow under its
+			// canonical name; otherwise the parser counts the bare flow's
+			// fields as flow keys.
+			var raw struct {
+				SecuritySchemes map[string]struct {
+					Type  string                     `json:"type"`
+					Flows map[string]json.RawMessage `json:"flows"`
+				} `json:"securitySchemes"`
+			}
+			if err := json.Unmarshal(body, &raw); err != nil {
+				t.Fatalf("unmarshal raw: %v", err)
+			}
+			scheme := raw.SecuritySchemes["oauth2"]
+			if scheme.Type != "oauth2" {
+				t.Errorf("scheme.type = %q, want %q (parser dispatch needs the discriminator)", scheme.Type, "oauth2")
+			}
+			if got := len(scheme.Flows); got != 1 {
+				t.Errorf("flows: want exactly 1 entry, got %d (%v)\nbody:\n%s",
+					got, keysOf(scheme.Flows), string(body))
+			}
+			if _, ok := scheme.Flows[string(tc.flowKey)]; !ok {
+				t.Errorf("flows: missing key %q, got %v", tc.flowKey, keysOf(scheme.Flows))
+			}
+
+			// The parser must accept its own producer's output and recover
+			// the OAuth2 scheme with all fields intact.
+			parser := NewAgentCardParser()
+			got, err := parser(body)
+			if err != nil {
+				t.Fatalf("parser round-trip: %v", err)
+			}
+			gotScheme, ok := got.SecuritySchemes["oauth2"].(a2a.OAuth2SecurityScheme)
+			if !ok {
+				t.Fatalf("scheme oauth2: type %T, want a2a.OAuth2SecurityScheme", got.SecuritySchemes["oauth2"])
+			}
+			wantScheme := card.SecuritySchemes["oauth2"]
+			if diff := cmp.Diff(wantScheme, gotScheme); diff != "" {
+				t.Errorf("scheme round-trip mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

The compat OAuth2 path was unreachable end-to-end: a card containing an `OAuth2SecurityScheme` couldn't round-trip through `compatProducer.CardJSON` → `NewAgentCardParser()` without erroring or losing fields. This PR makes the round-trip work and adds coverage.

The bug surface had been latent because no test in the package — including the existing `TestAgentCard_CompatToNew` and the `e2e/compat` suite — exercises OAuth2; the fixtures use OpenIDConnect. Once a test puts an OAuth2 scheme through `compatProducer`, four issues stack on the same code path. Fixing them is one logical change (correct the OAuth2 marshal+unmarshal+map-from), but it's worth describing each layer because they're independent edits.

## The chain

Producing a card with `OAuth2SecurityScheme{Flows: AuthorizationCodeOAuthFlow{...}}` and feeding the bytes back to `NewAgentCardParser()` fails in the following sequence (each fix uncovers the next):

1. **`oauth2SecurityScheme.MarshalJSON` had a pointer receiver.** Schemes are stored by value in `namedSecuritySchemes` (`map[name]any`); map values aren't addressable, so a pointer-receiver `Marshaler` isn't satisfied by `encoding/json`. Reflection took over and serialized the `Flows` interface field as the bare flow's struct fields (`{authorizationUrl, tokenUrl, scopes}`) instead of the spec-required `{flowName: {...}}` wrapping. **Fix:** change to value receiver.

2. **The wrapper struct in `MarshalJSON` omitted `type`.** Once 1 was fixed, the parser still couldn't dispatch — the compat parser's `switch st.Type` requires the discriminator, and every other scheme (ApiKey, HTTPAuth, etc.) emits it via reflection because their structs declare a `Type` field. OAuth2 is the only scheme with a hand-written wrapper, and it didn't include one. **Fix:** add `Type: "oauth2"` to the wrapper.

3. **`oauth2SecurityScheme.UnmarshalJSON` dropped `Description` and `Oauth2MetadataURL`.** It read them into a local wrapper struct and never assigned them back to the receiver — only `s.Flows` was populated. Latent because 1 made the unmarshal fail at the "got 3" check before reaching the field-assign step. **Fix:** assign both fields.

4. **`mapFromCompatSecuritySchemes`'s OAuth2 fallback only copied `Description`.** With 1 fixed, the producer no longer emits the legacy nested `oauth2: {...}` field, so `v.OAuth2` is now reliably nil and the fallback is the common path. The fallback dropped `Flows` and `Oauth2MetadataURL`. The parallel fallbacks for `apiKey`/`http`/`openIdConnect` copy all their relevant fields; only OAuth2's was minimal. **Fix:** copy `Flows` and `Oauth2MetadataURL` too.

## Wire-format change

Before (reflection-leaked):

```json
{
  "type": "oauth2",
  "description": "...",
  "flows": {"authorizationUrl": "...", "tokenUrl": "...", "scopes": {...}},
  "oauth2": {"<inner v2 OAuth2SecurityScheme>": "..."}
}
```

After (v0.3 spec):

```json
{
  "type": "oauth2",
  "description": "...",
  "oauth2MetadataUrl": "...",
  "flows": {"authorizationCode": {"authorizationUrl": "...", "tokenUrl": "...", "scopes": {}}}
}
```

The new shape matches the v0.3 spec's OAuth flows object (OpenAPI-style, indexed by flow name). No clients should depend on the previous shape — it didn't satisfy v0.3 spec *or* v2 (the v2 SDK's strict `OAuth2SecurityScheme.UnmarshalJSON` would have rejected it with "expected exactly one OAuth flow, got N").

## Tests

Added `TestAgentCard_OAuth2_AllFlows_RoundTrip` in `a2acompat/a2av0/`. For each of the five flow types (`AuthorizationCode`, `ClientCredentials`, `Implicit`, `Password`, `DeviceCode`) it asserts:

- the producer emits exactly one `flows` entry, keyed by the canonical flow name
- the wire includes the `type: "oauth2"` discriminator
- the parser recovers the OAuth2 scheme with `Description`, `Flows`, `Oauth2MetadataURL` intact