### PR TITLE
fix: workqueue implementation missed events

### DIFF
--- a/a2acompat/a2av0/conversions.go
+++ b/a2acompat/a2av0/conversions.go
@@ -301,6 +301,9 @@ func FromV1Message(m *a2a.Message) *a2alegacy.Message {
 
 // ToV1Part converts a legacy part to a v1 part.
 func ToV1Part(p a2alegacy.Part) *a2a.Part {
+	if p == nil {
+		return nil
+	}
 	switch c := p.(type) {
 	case a2alegacy.TextPart:
 		return &a2a.Part{

--- a/a2acompat/a2av0/conversions_test.go
+++ b/a2acompat/a2av0/conversions_test.go
@@ -15,90 +15,98 @@
 package a2av0
 
 import (
-	"reflect"
 	"testing"
 
 	a2alegacy "github.com/a2aproject/a2a-go/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/google/go-cmp/cmp"
 )
 
-func TestToCompatParts_PrimitiveData(t *testing.T) {
-	val := "hello"
-	parts := a2a.ContentParts{a2a.NewDataPart(val)}
-	compatParts := FromV1Parts(parts)
-
-	if len(compatParts) != 1 {
-		t.Fatalf("Expected 1 part, got %d", len(compatParts))
-	}
-
-	dp, ok := compatParts[0].(a2alegacy.DataPart)
-	if !ok {
-		t.Fatalf("Expected DataPart, got %T", compatParts[0])
-	}
-
-	// Verify it's wrapped in a map
-	m := dp.Data
-
-	if m["value"] != val {
-		t.Errorf("Expected value %q, got %v", val, m["value"])
-	}
-
-	// Verify metadata flag
-	if compat, ok := dp.Metadata["data_part_compat"].(bool); !ok || !compat {
-		t.Errorf("Expected data_part_compat=true in metadata")
-	}
-}
-
-func TestToCoreParts_PrimitiveDataUnwrap(t *testing.T) {
-	val := "hello"
-	compatParts := a2alegacy.ContentParts{
-		a2alegacy.DataPart{
-			Data:     map[string]any{"value": val},
-			Metadata: map[string]any{"data_part_compat": true},
+func TestToV1Part(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   a2alegacy.Part
+		want *a2a.Part
+	}{
+		{
+			name: "nil part",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "text part",
+			in:   a2alegacy.TextPart{Text: "hello"},
+			want: &a2a.Part{Content: a2a.Text("hello")},
+		},
+		{
+			name: "data part with compat metadata unwraps value",
+			in: a2alegacy.DataPart{
+				Data:     map[string]any{"value": "hello"},
+				Metadata: map[string]any{"data_part_compat": true},
+			},
+			want: &a2a.Part{Content: a2a.Data{Value: "hello"}, Metadata: map[string]any{}},
+		},
+		{
+			name: "data part without compat metadata keeps map",
+			in: a2alegacy.DataPart{
+				Data:     map[string]any{"key": "value"},
+				Metadata: map[string]any{"other": "meta"},
+			},
+			want: &a2a.Part{
+				Content:  a2a.Data{Value: map[string]any{"key": "value"}},
+				Metadata: map[string]any{"other": "meta"},
+			},
+		},
+		{
+			name: "data part with nil metadata",
+			in:   a2alegacy.DataPart{Data: map[string]any{"key": "value"}},
+			want: &a2a.Part{Content: a2a.Data{Value: map[string]any{"key": "value"}}},
 		},
 	}
 
-	coreParts, err := ToV1Parts(compatParts)
-	if err != nil {
-		t.Fatalf("ToV1Parts() error = %v", err)
-	}
-
-	if len(coreParts) != 1 {
-		t.Fatalf("Expected 1 part, got %d", len(coreParts))
-	}
-
-	dataVal := coreParts[0].Data()
-	if dataVal != val {
-		t.Errorf("Expected data value %q, got %v", val, dataVal)
-	}
-
-	// Verify metadata flag is removed (optional but good practice)
-	if _, ok := coreParts[0].Metadata["data_part_compat"]; ok {
-		t.Errorf("Expected data_part_compat to be removed from metadata")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ToV1Part(tc.in)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("ToV1Part() wrong result (-want +got) diff = %s", diff)
+			}
+		})
 	}
 }
 
-func TestToCompatParts_MapDataNoWrap(t *testing.T) {
-	val := map[string]any{"key": "value"}
-	parts := a2a.ContentParts{a2a.NewDataPart(val)}
-	compatParts := FromV1Parts(parts)
-
-	if len(compatParts) != 1 {
-		t.Fatalf("Expected 1 part, got %d", len(compatParts))
+func TestFromV1Part(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   *a2a.Part
+		want a2alegacy.Part
+	}{
+		{
+			name: "primitive data wraps with compat flag",
+			in:   a2a.NewDataPart("hello"),
+			want: a2alegacy.DataPart{
+				Data:     map[string]any{"value": "hello"},
+				Metadata: map[string]any{"data_part_compat": true},
+			},
+		},
+		{
+			name: "map data not wrapped",
+			in:   a2a.NewDataPart(map[string]any{"key": "value"}),
+			want: a2alegacy.DataPart{
+				Data: map[string]any{"key": "value"},
+			},
+		},
 	}
 
-	dp, ok := compatParts[0].(a2alegacy.DataPart)
-	if !ok {
-		t.Fatalf("Expected DataPart, got %T", compatParts[0])
-	}
-
-	// Verify it's NOT wrapped
-	if !reflect.DeepEqual(dp.Data, val) {
-		t.Errorf("Expected data %v, got %v", val, dp.Data)
-	}
-
-	// Verify metadata flag is NOT present
-	if _, ok := dp.Metadata["data_part_compat"]; ok {
-		t.Errorf("Expected data_part_compat to NOT be present")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := FromV1Part(tc.in)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("FromV1Part() wrong result (-want +got) diff = %s", diff)
+			}
+		})
 	}
 }

--- a/internal/taskexec/distributed_manager.go
+++ b/internal/taskexec/distributed_manager.go
@@ -119,6 +119,13 @@ func (m *distributedManager) Execute(ctx context.Context, req *a2a.SendMessageRe
 		return nil, err
 	}
 
+	// Subscribe before submitting work so that a fast (eg. in-memory) workqueue
+	// implementation cannot broadcast an event before there's a reader
+	queue, err := m.queueManager.CreateReader(ctx, requestedTaskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe to execution events: %w", err)
+	}
+
 	taskID, err := m.workQueue.Write(ctx, &workqueue.Payload{
 		Type:           workqueue.PayloadTypeExecute,
 		TaskID:         requestedTaskID,
@@ -126,19 +133,22 @@ func (m *distributedManager) Execute(ctx context.Context, req *a2a.SendMessageRe
 		CallContext:    encodedCtx,
 	})
 	if err != nil {
+		safeCloseReader(ctx, queue)
 		return nil, fmt.Errorf("failed to create work item: %w", err)
 	}
 
 	if taskID != requestedTaskID {
+		safeCloseReader(ctx, queue)
+
 		if req.Message.TaskID != "" {
 			return nil, fmt.Errorf("bug: work queue task id override only allowed for new tasks")
 		}
 		log.Info(ctx, "work queue task id override", "provided", string(requestedTaskID), "used", taskID)
-	}
 
-	queue, err := m.queueManager.CreateReader(ctx, taskID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to subscribe to execution events: %w", err)
+		queue, err = m.queueManager.CreateReader(ctx, taskID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to subscribe to execution events after task id override: %w", err)
+		}
 	}
 
 	return newRemoteSubscription(queue, m.taskStore, taskID), nil
@@ -225,4 +235,10 @@ func (m *distributedManager) encodeContext(ctx context.Context) (map[string]any,
 		return nil, fmt.Errorf("context encoding failed: %w", err)
 	}
 	return r, nil
+}
+
+func safeCloseReader(ctx context.Context, r eventqueue.Reader) {
+	if closeErr := r.Close(); closeErr != nil {
+		log.Warn(ctx, "event queue reader close failed", "error", closeErr)
+	}
 }


### PR DESCRIPTION
Moved CreateReader to before a Message is published to a workqueue. Fixes a possibility of readers missing events with in-memory workqueue implementations (flaky nightly runs).

Also updated a2acompat part converter to handle nil parts.