### PR TITLE
fix: parse direct OAuth2 security schemes

### DIFF
--- a/a2a/auth.go
+++ b/a2a/auth.go
@@ -117,12 +117,16 @@ func (s NamedSecuritySchemes) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
-	var schemes map[SecuritySchemeName]securityScheme
+	var schemes map[SecuritySchemeName]json.RawMessage
 	if err := json.Unmarshal(b, &schemes); err != nil {
 		return err
 	}
 	result := make(NamedSecuritySchemes, len(schemes))
-	for name, wrapper := range schemes {
+	for name, raw := range schemes {
+		var wrapper securityScheme
+		if err := json.Unmarshal(raw, &wrapper); err != nil {
+			return err
+		}
 		var n int
 		if wrapper.APIKey != nil {
 			result[name] = *wrapper.APIKey
@@ -145,11 +149,14 @@ func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
 			n++
 		}
 		if n == 0 {
-			var raw map[SecuritySchemeName]json.RawMessage
-			if err := json.Unmarshal(b, &raw); err != nil {
-				return fmt.Errorf("unknown security scheme for %s: %w", name, err)
+			if scheme, ok, err := unmarshalDirectSecurityScheme(raw); ok {
+				if err != nil {
+					return err
+				}
+				result[name] = scheme
+				continue
 			}
-			return fmt.Errorf("unknown security scheme type for %s: %v", name, jsonKeys([]byte(raw[name])))
+			return fmt.Errorf("unknown security scheme type for %s: %v", name, jsonKeys(raw))
 		}
 		if n != 1 {
 			return fmt.Errorf("expected exactly one security scheme type for %s, got %d", name, n)
@@ -158,6 +165,23 @@ func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
 
 	*s = result
 	return nil
+}
+
+func unmarshalDirectSecurityScheme(raw json.RawMessage) (SecurityScheme, bool, error) {
+	var fields struct {
+		Flows json.RawMessage `json:"flows"`
+	}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, false, err
+	}
+	if len(fields.Flows) == 0 {
+		return nil, false, nil
+	}
+	var scheme OAuth2SecurityScheme
+	if err := json.Unmarshal(raw, &scheme); err != nil {
+		return nil, true, err
+	}
+	return scheme, true, nil
 }
 
 // SecurityScheme is a sealed discriminated type union for supported security schemes.

--- a/a2a/json_test.go
+++ b/a2a/json_test.go
@@ -120,6 +120,74 @@ func TestSecuritySchemeJSONCodec(t *testing.T) {
 	}
 }
 
+func TestSecuritySchemeJSONUnmarshalDirectOAuth2Scheme(t *testing.T) {
+	const cardJSON = `{
+		"name": "A2AT-Test-Agent",
+		"description": "Helps with event",
+		"version": "1.0.0",
+		"capabilities": {
+			"streaming": true,
+			"pushNotifications": true,
+			"extendedAgentCard": false
+		},
+		"defaultInputModes": ["text"],
+		"defaultOutputModes": ["text"],
+		"skills": [{
+			"id": "event_publish",
+			"name": "Event publish",
+			"description": "Helps with event publish",
+			"tags": ["event"],
+			"examples": ["push current event"]
+		}],
+		"securitySchemes": {
+			"oauth2SecurityScheme": {
+				"flows": {
+					"authorizationCode": null,
+					"clientCredentials": {
+						"refreshUrl": null,
+						"scopes": {
+							"profile": "profile",
+							"openid": "openid"
+						},
+						"tokenUrl": "http://a2a-agent-backend:27561/auth"
+					},
+					"deviceCode": null
+				},
+				"description": "Enables client credentials flow for authentication and authorization",
+				"oauth2MetadataUrl": null
+			}
+		},
+		"securityRequirements": null,
+		"supportedInterfaces": [{
+			"protocolBinding": "HTTP+JSON",
+			"url": "http://a2a-agent-backend:27561",
+			"tenant": "",
+			"protocolVersion": "1.0"
+		}]
+	}`
+
+	var card AgentCard
+	mustUnmarshal(t, []byte(cardJSON), &card)
+
+	scheme, ok := card.SecuritySchemes["oauth2SecurityScheme"].(OAuth2SecurityScheme)
+	if !ok {
+		t.Fatalf("scheme oauth2SecurityScheme: type %T, want OAuth2SecurityScheme", card.SecuritySchemes["oauth2SecurityScheme"])
+	}
+	if scheme.Description != "Enables client credentials flow for authentication and authorization" {
+		t.Fatalf("scheme description = %q", scheme.Description)
+	}
+	flow, ok := scheme.Flows.(ClientCredentialsOAuthFlow)
+	if !ok {
+		t.Fatalf("scheme flow: type %T, want ClientCredentialsOAuthFlow", scheme.Flows)
+	}
+	if flow.TokenURL != "http://a2a-agent-backend:27561/auth" {
+		t.Fatalf("flow token URL = %q", flow.TokenURL)
+	}
+	if !reflect.DeepEqual(flow.Scopes, map[string]string{"openid": "openid", "profile": "profile"}) {
+		t.Fatalf("flow scopes = %v", flow.Scopes)
+	}
+}
+
 func TestSecuritySchemeJSONUnmarshalUnknownType(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- allow AgentCard securitySchemes values that are direct OAuth2 security scheme objects with `flows`
- preserve existing wrapped security-scheme decoding and unknown-type errors
- add a regression test for the Java SDK AgentCard shape from #347

Fixes #347

## Tests
- go test ./a2a -run 'TestSecuritySchemeJSON(UnmarshalDirectOAuth2Scheme|Codec|UnmarshalUnknownType)|TestAgentCardParsing'\n- go test ./a2a ./a2acompat/a2av0\n- go test ./...\n- git diff --check