### PR TITLE
feat: provide generic pull event queue

### DIFF
--- a/a2asrv/eventqueue/pull_event_queue_impl.go
+++ b/a2asrv/eventqueue/pull_event_queue_impl.go
@@ -51,8 +51,6 @@ type Puller interface {
 type PullerProvider func(ctx context.Context, taskID a2a.TaskID) (Puller, error)
 
 // NewStaticPullerProvider returns a PullerProvider that always returns the same Puller.
-// The returned Puller's Close method is a no-op to prevent premature closing when
-// multiple readers share the same puller.
 func NewStaticPullerProvider(es Puller) PullerProvider {
 	return func(ctx context.Context, taskID a2a.TaskID) (Puller, error) {
 		return es, nil
@@ -147,40 +145,39 @@ func (m *pullQueueManager) Destroy(ctx context.Context, taskID a2a.TaskID) error
 var _ Reader = (*pullReader)(nil)
 
 type pullReader struct {
-	taskID      a2a.TaskID
-	snapshot    *Message
-	puller      Puller
-	manager     *pullQueueManager
-	eventsChan  chan *Message
-	closed      chan struct{}
-	closeSignal chan struct{}
+	taskID     a2a.TaskID
+	snapshot   *Message
+	puller     Puller
+	manager    *pullQueueManager
+	eventsChan chan *Message
+	closed     chan struct{}
+	ctxCancel  context.CancelFunc
 
 	emittedSnapshot bool
 }
 
 func newPullReader(p Puller, taskID a2a.TaskID, queueManager *pullQueueManager, snapshot *Message) *pullReader {
+	ctx, cancel := context.WithCancel(context.Background())
 	reader := &pullReader{
-		taskID:      taskID,
-		snapshot:    snapshot,
-		puller:      p,
-		manager:     queueManager,
-		eventsChan:  make(chan *Message),
-		closed:      make(chan struct{}),
-		closeSignal: make(chan struct{}),
+		taskID:     taskID,
+		snapshot:   snapshot,
+		puller:     p,
+		manager:    queueManager,
+		eventsChan: make(chan *Message),
+		closed:     make(chan struct{}),
+		ctxCancel:  cancel,
 	}
-	go reader.poll()
+	go reader.poll(ctx)
 	return reader
 }
 
-func (r *pullReader) poll() {
-	bgCtx, cancelBg := context.WithCancel(context.Background())
+func (r *pullReader) poll(ctx context.Context) {
 	ticker := time.NewTicker(r.manager.cfg.PollInterval)
 
 	defer func() {
 		ticker.Stop()
-		cancelBg()
 		if err := r.puller.Close(context.Background()); err != nil {
-			log.Warn(bgCtx, "Error closing puller: %v", err)
+			log.Warn(context.Background(), "Error closing puller: %v", err)
 		}
 		close(r.eventsChan)
 		close(r.closed)
@@ -188,17 +185,20 @@ func (r *pullReader) poll() {
 
 	var cursor PullCursor
 	for {
-		resp, err := r.puller.Pull(bgCtx, r.taskID, cursor)
+		resp, err := r.puller.Pull(ctx, r.taskID, cursor)
 		if err != nil {
-			log.Warn(bgCtx, "Error polling for events: %v", err)
+			if ctx.Err() != nil {
+				return
+			}
+			log.Warn(ctx, "Error polling for events: %v", err)
 		} else {
 			cursor = resp.Cursor
-			if r.dispatchMessages(resp) {
+			if r.dispatchMessages(ctx, resp) {
 				return
 			}
 		}
 		select {
-		case <-r.closeSignal:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
 		}
@@ -207,7 +207,7 @@ func (r *pullReader) poll() {
 
 type stopPolling bool
 
-func (r *pullReader) dispatchMessages(resp *PullResponse) stopPolling {
+func (r *pullReader) dispatchMessages(ctx context.Context, resp *PullResponse) stopPolling {
 	if resp == nil {
 		return false
 	}
@@ -221,7 +221,7 @@ func (r *pullReader) dispatchMessages(resp *PullResponse) stopPolling {
 		}
 		select {
 		case r.eventsChan <- msg:
-		case <-r.closeSignal:
+		case <-ctx.Done():
 			return true
 		}
 		if taskupdate.IsFinal(msg.Event) {
@@ -269,11 +269,7 @@ func (r *pullReader) Read(ctx context.Context) (*Message, error) {
 				return nil, fmt.Errorf("%w: failed to call inactivity callback:%w", ErrInactivityTimeout, err)
 			}
 			if task != nil {
-				msg, err := newMessage(task)
-				if err != nil {
-					return nil, fmt.Errorf("failed to create new snapshot: %w", err)
-				}
-				r.snapshot = msg
+				r.snapshot = newMessage(task)
 				r.emittedSnapshot = false
 			}
 		}
@@ -283,12 +279,7 @@ func (r *pullReader) Read(ctx context.Context) (*Message, error) {
 
 // Close implements Reader.Close. It stops the polling goroutine and closes the underlying puller.
 func (r *pullReader) Close() error {
-	select {
-	case r.closeSignal <- struct{}{}:
-	case <-r.closed:
-		return nil
-	}
-
+	r.ctxCancel()
 	<-r.closed
 	return nil
 }
@@ -339,14 +330,10 @@ func closePullerOnError(ctx context.Context, puller Puller) {
 	}
 }
 
-func newMessage(event a2a.Event) (*Message, error) {
-	task, ok := event.(*a2a.Task)
-	if !ok {
-		return nil, fmt.Errorf("event is not a task: %T", event)
-	}
+func newMessage(task *a2a.Task) *Message {
 	return &Message{
 		Event:       task,
 		TaskVersion: taskstore.TaskVersionMissing,
 		Protocol:    a2a.Version,
-	}, nil
+	}
 }

--- a/a2asrv/eventqueue/pull_event_queue_impl.go
+++ b/a2asrv/eventqueue/pull_event_queue_impl.go
@@ -1,0 +1,352 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventqueue
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
+	"github.com/a2aproject/a2a-go/v2/internal/taskupdate"
+	"github.com/a2aproject/a2a-go/v2/log"
+)
+
+const (
+	defaultPollInterval      = 30 * time.Second
+	defaultInactivityTimeout = 5 * time.Minute
+)
+
+// PullCursor is an opaque type representing a cursor for the puller.
+type PullCursor any
+
+// PullResponse represents a response from the puller.
+type PullResponse struct {
+	Messages []*Message
+	Cursor   PullCursor
+}
+
+// Puller is an interface for pulling events from the event queue.
+type Puller interface {
+	// Pull returns a response with messages and a cursor for the next pull.
+	Pull(ctx context.Context, taskID a2a.TaskID, cursor PullCursor) (*PullResponse, error)
+	// Close closes the puller.
+	Close(ctx context.Context) error
+}
+
+// PullerProvider is a function that returns a puller for the given task ID.
+type PullerProvider func(ctx context.Context, taskID a2a.TaskID) (Puller, error)
+
+// NewStaticPullerProvider returns a PullerProvider that always returns the same Puller.
+// The returned Puller's Close method is a no-op to prevent premature closing when
+// multiple readers share the same puller.
+func NewStaticPullerProvider(es Puller) PullerProvider {
+	return func(ctx context.Context, taskID a2a.TaskID) (Puller, error) {
+		return es, nil
+	}
+}
+
+// PullConfig configures the behavior of a pull-based event queue manager.
+type PullConfig struct {
+	// PollInterval is the interval at which the puller is polled for new events.
+	// Defaults to 30 seconds if not specified or <= 0.
+	PollInterval time.Duration
+	// InactivityTimeout is the duration of inactivity after which the reader will time out.
+	// Defaults to 5 minutes. Set to 0 to disable inactivity timeout.
+	InactivityTimeout time.Duration
+	// AccessCheck is an optional callback executed before emitting the initial snapshot
+	// of a task to verify that the calling context has permission to access the task.
+	AccessCheck func(context.Context, *a2a.Task) error
+	// OnInactivity is an optional callback function that is called when a task has exceeded the
+	// InactivityTimeout. It's only triggered from Reader.Read().
+	// The returned task is used to update the snapshot.
+	OnInactivity func(context.Context, Puller, a2a.TaskID) (*a2a.Task, error)
+	// UseInMemory is an optional function that returns true if the manager should bypass the puller
+	// and use the in-memory queue instead for a given request context.
+	UseInMemory func(context.Context) bool
+}
+
+var _ Manager = (*pullQueueManager)(nil)
+
+type pullQueueManager struct {
+	inner Manager
+	pp    PullerProvider
+	cfg   PullConfig
+}
+
+// NewPullQueueManager creates a new Manager that manages pull-based event queues.
+// It uses the provided PullerProvider to instantiate pullers for tasks, and applies
+// the configuration in PullConfig.
+func NewPullQueueManager(pp PullerProvider, cfg PullConfig) Manager {
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = defaultPollInterval
+	}
+	if cfg.InactivityTimeout < 0 {
+		cfg.InactivityTimeout = defaultInactivityTimeout
+	}
+	if cfg.UseInMemory == nil {
+		cfg.UseInMemory = func(context.Context) bool {
+			return false
+		}
+	}
+
+	return &pullQueueManager{
+		inner: NewInMemoryManager(),
+		pp:    pp,
+		cfg:   cfg,
+	}
+}
+
+// CreateReader implements Manager.CreateReader. It creates a new Reader for the given task ID.
+// If UseInMemory is configured and returns true, it delegates to the in-memory manager.
+// Otherwise, it uses the PullerProvider to get a Puller, fetches the initial task snapshot,
+// and returns a pull-based Reader.
+func (m *pullQueueManager) CreateReader(ctx context.Context, taskID a2a.TaskID) (Reader, error) {
+	if m.cfg.UseInMemory(ctx) {
+		return m.inner.CreateReader(ctx, taskID)
+	}
+	if m.pp == nil {
+		return nil, fmt.Errorf("manager is missing puller provider")
+	}
+	puller, err := m.pp(ctx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get puller: %w", err)
+	}
+
+	snapshot, err := getSnapshot(ctx, puller, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get snapshot: %w", err)
+	}
+
+	return newPullReader(puller, taskID, m, snapshot), nil
+}
+
+// CreateWriter implements Manager.CreateWriter. It delegates to the in-memory manager.
+func (m *pullQueueManager) CreateWriter(ctx context.Context, taskID a2a.TaskID) (Writer, error) {
+	return m.inner.CreateWriter(ctx, taskID)
+}
+
+// Destroy implements Manager.Destroy. It delegates to the in-memory manager.
+func (m *pullQueueManager) Destroy(ctx context.Context, taskID a2a.TaskID) error {
+	return m.inner.Destroy(ctx, taskID)
+}
+
+var _ Reader = (*pullReader)(nil)
+
+type pullReader struct {
+	taskID      a2a.TaskID
+	snapshot    *Message
+	puller      Puller
+	manager     *pullQueueManager
+	eventsChan  chan *Message
+	closed      chan struct{}
+	closeSignal chan struct{}
+
+	emittedSnapshot bool
+}
+
+func newPullReader(p Puller, taskID a2a.TaskID, queueManager *pullQueueManager, snapshot *Message) *pullReader {
+	reader := &pullReader{
+		taskID:      taskID,
+		snapshot:    snapshot,
+		puller:      p,
+		manager:     queueManager,
+		eventsChan:  make(chan *Message),
+		closed:      make(chan struct{}),
+		closeSignal: make(chan struct{}),
+	}
+	go reader.poll()
+	return reader
+}
+
+func (r *pullReader) poll() {
+	bgCtx, cancelBg := context.WithCancel(context.Background())
+	ticker := time.NewTicker(r.manager.cfg.PollInterval)
+
+	defer func() {
+		ticker.Stop()
+		cancelBg()
+		if err := r.puller.Close(context.Background()); err != nil {
+			log.Warn(bgCtx, "Error closing puller: %v", err)
+		}
+		close(r.eventsChan)
+		close(r.closed)
+	}()
+
+	var cursor PullCursor
+	for {
+		resp, err := r.puller.Pull(bgCtx, r.taskID, cursor)
+		if err != nil {
+			log.Warn(bgCtx, "Error polling for events: %v", err)
+		} else {
+			cursor = resp.Cursor
+			if r.dispatchMessages(resp) {
+				return
+			}
+		}
+		select {
+		case <-r.closeSignal:
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+type stopPolling bool
+
+func (r *pullReader) dispatchMessages(resp *PullResponse) stopPolling {
+	if resp == nil {
+		return false
+	}
+	for _, msg := range resp.Messages {
+		if msg == nil || msg.Event == nil {
+			continue
+		}
+		// Snapshot is emitted directly from r.snapshot by Read, so filter out to not send duplicate.
+		if _, isTask := msg.Event.(*a2a.Task); isTask {
+			continue
+		}
+		select {
+		case r.eventsChan <- msg:
+		case <-r.closeSignal:
+			return true
+		}
+		if taskupdate.IsFinal(msg.Event) {
+			return true
+		}
+	}
+	return false
+}
+
+// Read implements Reader.Read. It returns the next message from the puller.
+// The first call returns the initial task snapshot (after performing the optional AccessCheck).
+// Subsequent calls block and return events polled from the puller.
+// If the inactivity timeout is reached, it will trigger the OnInactivity callback if configured,
+// and return ErrInactivityTimeout.
+func (r *pullReader) Read(ctx context.Context) (*Message, error) {
+	if !r.emittedSnapshot {
+		if err := r.accessCheck(ctx); err != nil {
+			return nil, err
+		}
+		r.emittedSnapshot = true
+		return r.snapshot, nil
+	}
+	if taskupdate.IsFinal(r.snapshot.Event) {
+		return nil, ErrQueueClosed
+	}
+
+	var timeout <-chan time.Time
+	if r.manager.cfg.InactivityTimeout > 0 {
+		timer := time.NewTimer(r.manager.cfg.InactivityTimeout)
+		defer timer.Stop()
+		timeout = timer.C
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case msg, ok := <-r.eventsChan:
+		if !ok {
+			return nil, ErrQueueClosed
+		}
+		return msg, nil
+	case <-timeout:
+		if r.manager.cfg.OnInactivity != nil {
+			task, err := r.manager.cfg.OnInactivity(ctx, r.puller, r.taskID)
+			if err != nil {
+				return nil, fmt.Errorf("%w: failed to call inactivity callback:%w", ErrInactivityTimeout, err)
+			}
+			if task != nil {
+				msg, err := newMessage(task)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create new snapshot: %w", err)
+				}
+				r.snapshot = msg
+				r.emittedSnapshot = false
+			}
+		}
+		return nil, fmt.Errorf("%w after %v", ErrInactivityTimeout, r.manager.cfg.InactivityTimeout)
+	}
+}
+
+// Close implements Reader.Close. It stops the polling goroutine and closes the underlying puller.
+func (r *pullReader) Close() error {
+	select {
+	case r.closeSignal <- struct{}{}:
+	case <-r.closed:
+		return nil
+	}
+
+	<-r.closed
+	return nil
+}
+
+func (r *pullReader) accessCheck(ctx context.Context) error {
+	if r.manager.cfg.AccessCheck == nil {
+		return nil
+	}
+	task, ok := r.snapshot.Event.(*a2a.Task)
+	if !ok {
+		return fmt.Errorf("snapshot event is not a task: %T", r.snapshot.Event)
+	}
+	return r.manager.cfg.AccessCheck(ctx, task)
+}
+
+func getSnapshot(ctx context.Context, puller Puller, taskID a2a.TaskID) (*Message, error) {
+	resp, err := puller.Pull(ctx, taskID, nil)
+	if err != nil {
+		closePullerOnError(ctx, puller)
+		return nil, fmt.Errorf("snapshot pull failed for task %v: %w", taskID, err)
+	}
+	if resp == nil || len(resp.Messages) == 0 {
+		closePullerOnError(ctx, puller)
+		return nil, fmt.Errorf("puller returned no snapshot for task %v", taskID)
+	}
+	snapshotMsg := resp.Messages[0]
+	if snapshotMsg == nil || snapshotMsg.Event == nil {
+		closePullerOnError(ctx, puller)
+		return nil, fmt.Errorf("pull queue: puller returned nil snapshot message for task %q", taskID)
+	}
+	task, ok := snapshotMsg.Event.(*a2a.Task)
+	if !ok {
+		closePullerOnError(ctx, puller)
+		return nil, fmt.Errorf("pull queue: puller's first message for task %q is %T, want *a2a.Task",
+			taskID, snapshotMsg.Event)
+	}
+	if task.ID != taskID {
+		closePullerOnError(ctx, puller)
+		return nil, fmt.Errorf("pull queue: task ID mismatch in snapshot for task %q: got %q",
+			taskID, task.ID)
+	}
+	return snapshotMsg, nil
+}
+
+func closePullerOnError(ctx context.Context, puller Puller) {
+	if err := puller.Close(ctx); err != nil {
+		log.Warn(ctx, "Error closing puller: %v", err)
+	}
+}
+
+func newMessage(event a2a.Event) (*Message, error) {
+	task, ok := event.(*a2a.Task)
+	if !ok {
+		return nil, fmt.Errorf("event is not a task: %T", event)
+	}
+	return &Message{
+		Event:       task,
+		TaskVersion: taskstore.TaskVersionMissing,
+		Protocol:    a2a.Version,
+	}, nil
+}

--- a/a2asrv/eventqueue/pull_event_queue_impl_test.go
+++ b/a2asrv/eventqueue/pull_event_queue_impl_test.go
@@ -1,0 +1,413 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eventqueue_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/eventqueue"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/workqueue"
+	"github.com/a2aproject/a2a-go/v2/internal/testutil"
+	"github.com/a2aproject/a2a-go/v2/internal/testutil/testexecutor"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestPullQueue_SubscribeToTask(t *testing.T) {
+	t.Parallel()
+
+	mockPullerErr := errors.New("puller error on snapshot fetch")
+
+	testCases := []struct {
+		name         string
+		snapshotFn   func(taskID a2a.TaskID) *a2a.Task
+		eventsFn     func(taskID a2a.TaskID) []*eventqueue.Message
+		wantEventsFn func(taskID a2a.TaskID) []a2a.Event
+		wantErr      error
+		snapshotErr  error
+		accessCheck  func(context.Context, *a2a.Task) error
+	}{
+		{
+			name: "snapshot then final completed event",
+			snapshotFn: func(taskID a2a.TaskID) *a2a.Task {
+				return &a2a.Task{
+					ID:     taskID,
+					Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+				}
+			},
+			eventsFn: func(taskID a2a.TaskID) []*eventqueue.Message {
+				return []*eventqueue.Message{
+					{
+						Event:       newFinalEvent(taskID, "Done"),
+						TaskVersion: 2,
+					},
+				}
+			},
+			wantEventsFn: func(taskID a2a.TaskID) []a2a.Event {
+				return []a2a.Event{
+					&a2a.Task{ID: taskID, Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+					newFinalEvent(taskID, "Done"),
+				}
+			},
+		},
+		{
+			name: "multiple events",
+			snapshotFn: func(taskID a2a.TaskID) *a2a.Task {
+				return &a2a.Task{
+					ID:     taskID,
+					Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+				}
+			},
+			eventsFn: func(taskID a2a.TaskID) []*eventqueue.Message {
+				return []*eventqueue.Message{
+					{
+						Event:       &a2a.TaskStatusUpdateEvent{TaskID: taskID, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
+						TaskVersion: 2,
+					},
+					{
+						Event:       &a2a.TaskArtifactUpdateEvent{TaskID: taskID, Artifact: &a2a.Artifact{ID: "artifactId", Parts: []*a2a.Part{a2a.NewDataPart(map[string]string{"foo": "bar"})}}},
+						TaskVersion: 3,
+					},
+					{
+						Event:       newFinalEvent(taskID, "Done"),
+						TaskVersion: 4,
+					},
+				}
+			},
+			wantEventsFn: func(taskID a2a.TaskID) []a2a.Event {
+				return []a2a.Event{
+					&a2a.Task{ID: taskID, Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+					&a2a.TaskStatusUpdateEvent{TaskID: taskID, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
+					&a2a.TaskArtifactUpdateEvent{TaskID: taskID, Artifact: &a2a.Artifact{ID: "artifactId", Parts: []*a2a.Part{a2a.NewDataPart(map[string]string{"foo": "bar"})}}},
+					newFinalEvent(taskID, "Done"),
+				}
+			},
+		},
+		{
+			name: "terminal snapshot",
+			snapshotFn: func(taskID a2a.TaskID) *a2a.Task {
+				return &a2a.Task{
+					ID:     taskID,
+					Status: a2a.TaskStatus{State: a2a.TaskStateCompleted},
+				}
+			},
+			wantEventsFn: func(taskID a2a.TaskID) []a2a.Event {
+				return []a2a.Event{
+					&a2a.Task{ID: taskID, Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
+				}
+			},
+		},
+		{
+			name: "input required snapshot",
+			snapshotFn: func(taskID a2a.TaskID) *a2a.Task {
+				return &a2a.Task{
+					ID:     taskID,
+					Status: a2a.TaskStatus{State: a2a.TaskStateInputRequired},
+				}
+			},
+			wantEventsFn: func(taskID a2a.TaskID) []a2a.Event {
+				return []a2a.Event{
+					&a2a.Task{ID: taskID, Status: a2a.TaskStatus{State: a2a.TaskStateInputRequired}},
+				}
+			},
+			wantErr: eventqueue.ErrQueueClosed,
+		},
+		{
+			name: "stream ending with message",
+			snapshotFn: func(taskID a2a.TaskID) *a2a.Task {
+				return &a2a.Task{
+					ID:     taskID,
+					Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+				}
+			},
+			eventsFn: func(taskID a2a.TaskID) []*eventqueue.Message {
+				return []*eventqueue.Message{
+					{
+						Event:       a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hi")),
+						TaskVersion: 2,
+					},
+				}
+			},
+			wantEventsFn: func(taskID a2a.TaskID) []a2a.Event {
+				return []a2a.Event{
+					&a2a.Task{ID: taskID, Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+					a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hi")),
+				}
+			},
+		},
+		{
+			name: "snapshot error",
+			snapshotFn: func(taskID a2a.TaskID) *a2a.Task {
+				return &a2a.Task{
+					ID:     taskID,
+					Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+				}
+			},
+			snapshotErr: mockPullerErr,
+			wantErr:     mockPullerErr,
+		},
+		{
+			name: "access check fails",
+			// remoteSubscription yields the snapshot before the Read loop,
+			// then AccessCheck rejects on the first Read and prevents subsequent events
+			// from reaching the subscriber.
+			snapshotFn: func(taskID a2a.TaskID) *a2a.Task {
+				return &a2a.Task{
+					ID:     taskID,
+					Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+				}
+			},
+			eventsFn: func(taskID a2a.TaskID) []*eventqueue.Message {
+				return []*eventqueue.Message{
+					{
+						Event:       a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hi")),
+						TaskVersion: 2,
+					},
+				}
+			},
+			wantEventsFn: func(taskID a2a.TaskID) []a2a.Event {
+				return []a2a.Event{
+					&a2a.Task{ID: taskID, Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+				}
+			},
+			accessCheck: func(ctx context.Context, task *a2a.Task) error {
+				return a2a.ErrUnauthorized
+			},
+			wantErr: a2a.ErrUnauthorized,
+		},
+	}
+	wantCloseCount := int32(1)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+
+			taskID := a2a.NewTaskID()
+			var snapshot *a2a.Task
+			var events []*eventqueue.Message
+			var wantEvents []a2a.Event
+			if tc.snapshotFn != nil {
+				snapshot = tc.snapshotFn(taskID)
+			}
+			if tc.eventsFn != nil {
+				events = tc.eventsFn(taskID)
+			}
+			if tc.wantEventsFn != nil {
+				wantEvents = tc.wantEventsFn(taskID)
+			}
+
+			env := setupTest(t, &testEnvOptions{
+				snapshot:    snapshot,
+				events:      events,
+				snapshotErr: tc.snapshotErr,
+				accessCheck: tc.accessCheck,
+			})
+			reqHandler := *env.handler
+			var gotEvents []a2a.Event
+			var gotErr error
+			for ev, err := range reqHandler.SubscribeToTask(ctx, &a2a.SubscribeToTaskRequest{ID: taskID}) {
+				if err != nil {
+					gotErr = err
+					break
+				}
+				gotEvents = append(gotEvents, ev)
+			}
+
+			if !errors.Is(gotErr, tc.wantErr) {
+				t.Fatalf("SubscribeToTask() error = %v, want %v", gotErr, tc.wantErr)
+			}
+
+			opts := []cmp.Option{
+				cmpopts.IgnoreFields(a2a.Message{}, "ID"),
+			}
+			if diff := cmp.Diff(wantEvents, gotEvents, opts...); diff != "" {
+				t.Fatalf("SubscribeToTask() events mismatch (-want +got):\n%s", diff)
+			}
+			gotCloseCount := env.puller.closeCount.Load()
+			if gotCloseCount != wantCloseCount {
+				t.Fatalf("SubscribeToTask() close count = %d, want %d", gotCloseCount, wantCloseCount)
+			}
+		})
+	}
+}
+
+func TestPullQueue_InactivityTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancelTimeout := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancelTimeout()
+
+	tid := a2a.NewTaskID()
+	testEnv := setupTest(t, &testEnvOptions{
+		snapshot:          &a2a.Task{ID: tid},
+		inactivityTimeout: 5 * time.Millisecond,
+	})
+	reqHandler := *testEnv.handler
+
+	eventCount := 0
+	req := &a2a.SubscribeToTaskRequest{ID: tid}
+	var gotErr error
+	for ev, err := range reqHandler.SubscribeToTask(ctx, req) {
+		if err != nil {
+			gotErr = err
+		} else if ev != nil {
+			eventCount++
+		}
+	}
+
+	if eventCount != 1 {
+		t.Fatalf("expected 1 event (snapshot), got %d", eventCount)
+	}
+	if !errors.Is(gotErr, eventqueue.ErrInactivityTimeout) {
+		t.Fatalf("reqHandler.OnResubscribeToTask() error = %v, want %v", gotErr, eventqueue.ErrInactivityTimeout)
+	}
+}
+
+func TestPullQueue_SubscribeToNonExistentTask(t *testing.T) {
+	t.Parallel()
+
+	taskID := a2a.NewTaskID()
+	snapshot := &a2a.Task{ID: taskID}
+	testEnv := setupTest(t, &testEnvOptions{
+		snapshot: snapshot,
+	})
+	reqHandler := *testEnv.handler
+
+	req := &a2a.SubscribeToTaskRequest{ID: "non-existent-task"}
+
+	var gotErr error
+	for _, err := range reqHandler.SubscribeToTask(t.Context(), req) {
+		if err != nil {
+			gotErr = err
+			break
+		}
+	}
+
+	if !errors.Is(gotErr, a2a.ErrTaskNotFound) {
+		t.Fatalf("reqHandler.OnResubscribeToTask() expected error for non-existent task, got %v", gotErr)
+	}
+}
+
+type testEnv struct {
+	handler *a2asrv.RequestHandler
+	puller  *mockPuller
+}
+
+var _ eventqueue.Puller = (*mockPuller)(nil)
+
+type mockPuller struct {
+	snapshot    *a2a.Task
+	events      []*eventqueue.Message
+	snapshotErr error
+	closeCount  atomic.Int32
+}
+
+func newMockPuller(snapshot *a2a.Task, events []*eventqueue.Message, snapshotErr error) *mockPuller {
+	return &mockPuller{snapshot: snapshot, events: events, snapshotErr: snapshotErr}
+}
+
+func (m *mockPuller) Pull(ctx context.Context, taskID a2a.TaskID, cursor eventqueue.PullCursor) (*eventqueue.PullResponse, error) {
+	if m.snapshotErr != nil {
+		return nil, m.snapshotErr
+	}
+	if cursor == nil {
+		return &eventqueue.PullResponse{
+			Messages: []*eventqueue.Message{{Event: m.snapshot, TaskVersion: 1}},
+			Cursor:   1,
+		}, nil
+	}
+	idx, ok := cursor.(int)
+	if !ok {
+		return nil, fmt.Errorf("invalid cursor type %T", cursor)
+	}
+	if idx-1 >= len(m.events) {
+		return &eventqueue.PullResponse{Messages: nil, Cursor: idx}, nil
+	}
+	return &eventqueue.PullResponse{
+		Messages: []*eventqueue.Message{m.events[idx-1]},
+		Cursor:   idx + 1,
+	}, nil
+}
+
+func (m *mockPuller) Close(ctx context.Context) error {
+	m.closeCount.Add(1)
+	return nil
+}
+
+type testEnvOptions struct {
+	snapshot          *a2a.Task
+	events            []*eventqueue.Message
+	snapshotErr       error
+	inactivityTimeout time.Duration
+	accessCheck       func(context.Context, *a2a.Task) error
+}
+
+func setupTest(t *testing.T, opts *testEnvOptions) *testEnv {
+	t.Helper()
+	if opts == nil {
+		opts = &testEnvOptions{}
+	}
+	store := testutil.NewTestTaskStore()
+	if opts.snapshot != nil {
+		store.WithTasks(t, opts.snapshot)
+	}
+	puller := newMockPuller(opts.snapshot, opts.events, opts.snapshotErr)
+	pp := eventqueue.NewStaticPullerProvider(puller)
+
+	pullQueueManager := eventqueue.NewPullQueueManager(pp, eventqueue.PullConfig{
+		InactivityTimeout: opts.inactivityTimeout,
+		PollInterval:      5 * time.Millisecond,
+		UseInMemory:       useInMemory,
+		AccessCheck:       opts.accessCheck,
+	})
+	wq := workqueue.NewInMemory(nil)
+	executor := &testexecutor.TestAgentExecutor{}
+	reqHandler := a2asrv.NewHandler(
+		executor,
+		a2asrv.WithClusterMode(
+			a2asrv.ClusterConfig{
+				QueueManager: pullQueueManager,
+				WorkQueue:    wq,
+				TaskStore:    store,
+			}),
+	)
+	return &testEnv{
+		handler: &reqHandler,
+		puller:  puller,
+	}
+}
+
+func useInMemory(ctx context.Context) bool {
+	cc, ok := a2asrv.CallContextFrom(ctx)
+	if !ok {
+		return true
+	}
+	return cc.Method() != "SubscribeToTask"
+}
+
+func newFinalEvent(taskID a2a.TaskID, text string) *a2a.TaskStatusUpdateEvent {
+	return &a2a.TaskStatusUpdateEvent{
+		TaskID: taskID,
+		Status: a2a.TaskStatus{State: a2a.TaskStateCompleted, Message: a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart(text))},
+	}
+}

--- a/a2asrv/eventqueue/queue.go
+++ b/a2asrv/eventqueue/queue.go
@@ -25,6 +25,9 @@ import (
 // ErrQueueClosed indicates that the event queue has been closed.
 var ErrQueueClosed = errors.New("queue is closed")
 
+// ErrInactivityTimeout indicates that the event queue has timed out due to inactivity.
+var ErrInactivityTimeout = errors.New("queue read timeout due to inactivity")
+
 // Message represents the data broadcasted to event subscribers through event queue.
 type Message struct {
 	// Event is the event which was applied to task store.


### PR DESCRIPTION
This PR provides a generic "pull-based" queue in the eventqueue package

NewPullQueueManager creates an inner in-memory manager internally. CreateWriter always delegates to the in-memory manage inner. CreateReader delegates to inner if PullConfig.UseInMemory returns true, otherwise a pullReader is returned which:

Calls Provider to get a per-call Puller.
Spawns a polling goroutine that calls Pull every PollInterval, pushes events through a channel, and stops on taskupdate.IsFinal.
First Read emits the Snapshot task as the initial event.
Subsequent Reads either drain the channel, return eventqueue.ErrQueueClosed on final state, return ctx.Err() on
cancellation, or return inactivity error after InactivityTimeout (with optional OnInactivity callback to refresh state).
Destroy delegates to inner. The pull-side reader cleans itself up via Close on the source.
