### PR TITLE
fix(auth): accept raw security scheme JSON from non-Go SDKs (fixes #347)

### DIFF
--- a/a2a/auth.go
+++ b/a2a/auth.go
@@ -17,6 +17,7 @@ package a2a
 import (
 	"encoding/gob"
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -145,11 +146,33 @@ func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
 			n++
 		}
 		if n == 0 {
+			// No discriminator found — this may be a raw scheme object from
+			// a non-Go SDK (e.g., Java Jackson serialization). Try each known
+			// concrete type directly based on distinctive fields.
+			// MutualTLS is intentionally excluded — it has no distinctive
+			// fields and would falsely match arbitrary JSON.
 			var raw map[SecuritySchemeName]json.RawMessage
 			if err := json.Unmarshal(b, &raw); err != nil {
 				return fmt.Errorf("unknown security scheme for %s: %w", name, err)
 			}
-			return fmt.Errorf("unknown security scheme type for %s: %v", name, jsonKeys([]byte(raw[name])))
+			rawJSON := raw[name]
+			if scheme, err := tryParseOAuth2(rawJSON); err == nil {
+				result[name] = scheme
+				continue
+			}
+			if scheme, err := tryParseAPIKey(rawJSON); err == nil {
+				result[name] = scheme
+				continue
+			}
+			if scheme, err := tryParseHTTPAuth(rawJSON); err == nil {
+				result[name] = scheme
+				continue
+			}
+			if scheme, err := tryParseOpenIDConnect(rawJSON); err == nil {
+				result[name] = scheme
+				continue
+			}
+			return fmt.Errorf("unknown security scheme type for %s: %v", name, jsonKeys([]byte(rawJSON)))
 		}
 		if n != 1 {
 			return fmt.Errorf("expected exactly one security scheme type for %s, got %d", name, n)
@@ -158,6 +181,67 @@ func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
 
 	*s = result
 	return nil
+}
+
+// tryParseDirect attempts to unmarshal raw JSON as a concrete security scheme type.
+// Unlike the discriminator-based approach, this works with raw scheme objects from
+// non-Go SDKs (e.g., Java Jackson) that omit the discriminator wrapper.
+//
+// Each tryParse* function checks for the presence of a distinctive field before
+// attempting full unmarshal, avoiding false positives on empty/ambiguous payloads.
+
+func tryParseOAuth2(raw json.RawMessage) (SecurityScheme, error) {
+	if !jsonHasKey(raw, "flows") {
+		return nil, errors.New("not OAuth2: missing 'flows'")
+	}
+	var s OAuth2SecurityScheme
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func tryParseAPIKey(raw json.RawMessage) (SecurityScheme, error) {
+	if !jsonHasKey(raw, "location") {
+		return nil, errors.New("not APIKey: missing 'location'")
+	}
+	var s APIKeySecurityScheme
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func tryParseHTTPAuth(raw json.RawMessage) (SecurityScheme, error) {
+	if !jsonHasKey(raw, "scheme") {
+		return nil, errors.New("not HTTPAuth: missing 'scheme'")
+	}
+	var s HTTPAuthSecurityScheme
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func tryParseOpenIDConnect(raw json.RawMessage) (SecurityScheme, error) {
+	if !jsonHasKey(raw, "openIdConnectUrl") {
+		return nil, errors.New("not OpenIDConnect: missing 'openIdConnectUrl'")
+	}
+	var s OpenIDConnectSecurityScheme
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// jsonHasKey reports whether the JSON object contains a top-level key.
+func jsonHasKey(raw json.RawMessage, key string) bool {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return false
+	}
+	_, ok := m[key]
+	return ok
 }
 
 // SecurityScheme is a sealed discriminated type union for supported security schemes.

--- a/a2a/auth.go
+++ b/a2a/auth.go
@@ -17,7 +17,6 @@ package a2a
 import (
 	"encoding/gob"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -147,8 +146,8 @@ func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
 		}
 		if n == 0 {
 			// No discriminator found — this may be a raw scheme object from
-			// a non-Go SDK (e.g., Java Jackson serialization). Try each known
-			// concrete type directly based on distinctive fields.
+			// a non-Go SDK (e.g., Java Jackson serialization). Unmarshal once
+			// into a map of fields and dispatch based on distinctive keys.
 			// MutualTLS is intentionally excluded — it has no distinctive
 			// fields and would falsely match arbitrary JSON.
 			var raw map[SecuritySchemeName]json.RawMessage
@@ -156,23 +155,43 @@ func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
 				return fmt.Errorf("unknown security scheme for %s: %w", name, err)
 			}
 			rawJSON := raw[name]
-			if scheme, err := tryParseOAuth2(rawJSON); err == nil {
-				result[name] = scheme
-				continue
+
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal(rawJSON, &fields); err != nil {
+				return fmt.Errorf("unknown security scheme for %s: invalid JSON: %w", name, err)
 			}
-			if scheme, err := tryParseAPIKey(rawJSON); err == nil {
-				result[name] = scheme
-				continue
+
+			var scheme SecurityScheme
+			switch {
+			case fields["flows"] != nil:
+				var s OAuth2SecurityScheme
+				if err := json.Unmarshal(rawJSON, &s); err != nil {
+					return fmt.Errorf("unknown security scheme for %s: %w", name, err)
+				}
+				scheme = s
+			case fields["location"] != nil:
+				var s APIKeySecurityScheme
+				if err := json.Unmarshal(rawJSON, &s); err != nil {
+					return fmt.Errorf("unknown security scheme for %s: %w", name, err)
+				}
+				scheme = s
+			case fields["scheme"] != nil:
+				var s HTTPAuthSecurityScheme
+				if err := json.Unmarshal(rawJSON, &s); err != nil {
+					return fmt.Errorf("unknown security scheme for %s: %w", name, err)
+				}
+				scheme = s
+			case fields["openIdConnectUrl"] != nil:
+				var s OpenIDConnectSecurityScheme
+				if err := json.Unmarshal(rawJSON, &s); err != nil {
+					return fmt.Errorf("unknown security scheme for %s: %w", name, err)
+				}
+				scheme = s
+			default:
+				return fmt.Errorf("unknown security scheme type for %s: %v", name, jsonKeys([]byte(rawJSON)))
 			}
-			if scheme, err := tryParseHTTPAuth(rawJSON); err == nil {
-				result[name] = scheme
-				continue
-			}
-			if scheme, err := tryParseOpenIDConnect(rawJSON); err == nil {
-				result[name] = scheme
-				continue
-			}
-			return fmt.Errorf("unknown security scheme type for %s: %v", name, jsonKeys([]byte(rawJSON)))
+			result[name] = scheme
+			continue
 		}
 		if n != 1 {
 			return fmt.Errorf("expected exactly one security scheme type for %s, got %d", name, n)
@@ -181,67 +200,6 @@ func (s *NamedSecuritySchemes) UnmarshalJSON(b []byte) error {
 
 	*s = result
 	return nil
-}
-
-// tryParseDirect attempts to unmarshal raw JSON as a concrete security scheme type.
-// Unlike the discriminator-based approach, this works with raw scheme objects from
-// non-Go SDKs (e.g., Java Jackson) that omit the discriminator wrapper.
-//
-// Each tryParse* function checks for the presence of a distinctive field before
-// attempting full unmarshal, avoiding false positives on empty/ambiguous payloads.
-
-func tryParseOAuth2(raw json.RawMessage) (SecurityScheme, error) {
-	if !jsonHasKey(raw, "flows") {
-		return nil, errors.New("not OAuth2: missing 'flows'")
-	}
-	var s OAuth2SecurityScheme
-	if err := json.Unmarshal(raw, &s); err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
-func tryParseAPIKey(raw json.RawMessage) (SecurityScheme, error) {
-	if !jsonHasKey(raw, "location") {
-		return nil, errors.New("not APIKey: missing 'location'")
-	}
-	var s APIKeySecurityScheme
-	if err := json.Unmarshal(raw, &s); err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
-func tryParseHTTPAuth(raw json.RawMessage) (SecurityScheme, error) {
-	if !jsonHasKey(raw, "scheme") {
-		return nil, errors.New("not HTTPAuth: missing 'scheme'")
-	}
-	var s HTTPAuthSecurityScheme
-	if err := json.Unmarshal(raw, &s); err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
-func tryParseOpenIDConnect(raw json.RawMessage) (SecurityScheme, error) {
-	if !jsonHasKey(raw, "openIdConnectUrl") {
-		return nil, errors.New("not OpenIDConnect: missing 'openIdConnectUrl'")
-	}
-	var s OpenIDConnectSecurityScheme
-	if err := json.Unmarshal(raw, &s); err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
-// jsonHasKey reports whether the JSON object contains a top-level key.
-func jsonHasKey(raw json.RawMessage, key string) bool {
-	var m map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return false
-	}
-	_, ok := m[key]
-	return ok
 }
 
 // SecurityScheme is a sealed discriminated type union for supported security schemes.

--- a/a2a/java_compat_test.go
+++ b/a2a/java_compat_test.go
@@ -1,0 +1,96 @@
+package a2a
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseJavaJacksonAgentCard(t *testing.T) {
+	// Exact raw JSON from #347 — Java server using Jackson serialization
+	const javaJacksonJSON = `{
+  "name": "A2AT-Test-Agent",
+  "description": "Helps with event",
+  "provider": null,
+  "version": "1.0.0",
+  "documentationUrl": null,
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": true,
+    "extendedAgentCard": false,
+    "extensions": [
+      {
+        "description": "push notification extension",
+        "params": null,
+        "required": false,
+        "uri": "https://projects.tmforum.org/a2aproject/telecommunication/extensions/Notification-T/v1"
+      }
+    ]
+  },
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"],
+  "skills": [
+    {
+      "id": "event_publish",
+      "name": "Event publish",
+      "description": "Helps with event publish",
+      "tags": ["event"],
+      "examples": ["push current event"],
+      "inputModes": null,
+      "outputModes": null,
+      "securityRequirements": null
+    }
+  ],
+  "securitySchemes": {
+    "oauth2SecurityScheme": {
+      "flows": {
+        "authorizationCode": null,
+        "clientCredentials": {
+          "refreshUrl": null,
+          "scopes": {
+            "profile": "profile",
+            "openid": "openid"
+          },
+          "tokenUrl": "http://a2a-agent-backend:27561/auth"
+        },
+        "deviceCode": null
+      },
+      "description": "Enables client credentials flow for authentication and authorization",
+      "oauth2MetadataUrl": null
+    }
+  },
+  "securityRequirements": null,
+  "iconUrl": null,
+  "supportedInterfaces": [
+    {
+      "protocolBinding": "HTTP+JSON",
+      "url": "http://a2a-agent-backend:27561",
+      "tenant": "",
+      "protocolVersion": "1.0"
+    }
+  ],
+  "signatures": null
+}`
+
+	var card AgentCard
+	if err := json.Unmarshal([]byte(javaJacksonJSON), &card); err != nil {
+		t.Fatalf("failed to parse Java Jackson AgentCard: %v", err)
+	}
+
+	// Verify security scheme was parsed
+	if len(card.SecuritySchemes) != 1 {
+		t.Fatalf("expected 1 security scheme, got %d", len(card.SecuritySchemes))
+	}
+	scheme := card.SecuritySchemes["oauth2SecurityScheme"]
+	oauth2, ok := scheme.(OAuth2SecurityScheme)
+	if !ok {
+		t.Fatalf("expected OAuth2SecurityScheme, got %T", scheme)
+	}
+	cc, ok := oauth2.Flows.(ClientCredentialsOAuthFlow)
+	if !ok {
+		t.Fatalf("expected ClientCredentialsOAuthFlow, got %T", oauth2.Flows)
+	}
+	if cc.TokenURL != "http://a2a-agent-backend:27561/auth" {
+		t.Fatalf("tokenUrl mismatch: got %s", cc.TokenURL)
+	}
+	t.Logf("✓ parsed Java Jackson AgentCard successfully: name=%s, tokenUrl=%s", card.Name, cc.TokenURL)
+}

--- a/a2a/java_compat_test.go
+++ b/a2a/java_compat_test.go
@@ -1,3 +1,17 @@
+// Copyright 2025 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package a2a
 
 import (


### PR DESCRIPTION
## Problem

Java SDKs using Jackson serialization produce AgentCard JSON where security schemes omit the discriminator wrapper expected by a2a-go:

```json
// Jackson (Spring Boot default) — no discriminator
"oauth2SecurityScheme": {
  "flows": {
    "clientCredentials": {
      "scopes": {...},
      "tokenUrl": "..."
    }
  },
  "description": "...",
  "oauth2MetadataUrl": null
}
```

a2a-go's `NamedSecuritySchemes.UnmarshalJSON` requires the discriminator:

```json
// Gson (Go/Java SDK internal) — with discriminator ✓
"oauth2SecurityScheme": {
  "oauth2SecurityScheme": {
    "flows": {...}
  }
}
```

This causes cross-SDK interop failures when a Go sidecar fetches a Java server's AgentCard.

## Fix

Added a fallback path in `UnmarshalJSON`: when no discriminator is found, try each known concrete type based on distinctive JSON fields:

| Field | → Type |
|---|---|
| `flows` | OAuth2SecurityScheme |
| `location` | APIKeySecurityScheme |
| `scheme` | HTTPAuthSecurityScheme |
| `openIdConnectUrl` | OpenIDConnectSecurityScheme |

MutualTLS is excluded — it has no distinctive non-optional fields.

## Verification

- Added `TestParseJavaJacksonAgentCard` with the exact payload from #347
- Full repo test suite passes with `-race`: all 18 packages OK

Fixes #347