### PR TITLE
fix(a2asrv): skip TaskID mismatch check when message has no task reference (fixes #350)

### DIFF
--- a/a2asrv/agentexec.go
+++ b/a2asrv/agentexec.go
@@ -192,7 +192,7 @@ func (f *factory) loadExecutionContext(ctx context.Context, tid a2a.TaskID, para
 	}
 
 	storedTask, lastVersion := taskStoreTask.Task, taskStoreTask.Version
-	if message.TaskID != tid {
+	if message.TaskID != "" && message.TaskID != tid {
 		return nil, fmt.Errorf("bug: message task id different from executor task id")
 	}
 

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -2396,3 +2396,33 @@ func (m *cleanerAgentExecutor) Cleanup(ctx context.Context, execCtx *ExecutorCon
 		m.CleanupFunc(ctx, execCtx, result, err)
 	}
 }
+
+// TestLoadExecutionContext_EmptyTaskIDWithRetry verifies that a message
+// without a TaskID is accepted by loadExecutionContext when task retry is
+// enabled and the task exists in the store. Regression test for #350.
+func TestLoadExecutionContext_EmptyTaskIDWithRetry(t *testing.T) {
+	t.Parallel()
+
+	store := taskstore.NewInMemory(nil)
+	task := &a2a.Task{ID: a2a.NewTaskID(), ContextID: a2a.NewContextID()}
+	if _, err := store.Create(t.Context(), task); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	f := &factory{
+		taskStore:          store,
+		taskRetrySupported: true,
+	}
+
+	// Message without TaskID, but task exists in store (retry scenario).
+	msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("retry"))
+	params := &a2a.SendMessageRequest{Message: msg}
+
+	execCtx, err := f.loadExecutionContext(t.Context(), task.ID, params)
+	if err != nil {
+		t.Fatalf("loadExecutionContext() error = %v", err)
+	}
+	if execCtx == nil {
+		t.Fatal("loadExecutionContext() returned nil")
+	}
+}


### PR DESCRIPTION
## What

Fix `loadExecutionContext` to not reject messages that have no `TaskID` set.

## Why

In cluster mode with retries enabled, the function reaches the `TaskID` mismatch check at line 195 even for messages that never referenced any task (`message.TaskID == ""`). Since an empty string can never equal a real `tid`, this condition was always true, causing a false `"bug: message task id different from executor task id"` error.

## Fix

Add an empty-string guard:

```go
// Before
if message.TaskID != tid {

// After  
if message.TaskID != "" && message.TaskID != tid {
```

Messages with no task reference are now accepted (they will be handled by the subsequent context creation / history replay logic), while messages that DO reference a task but the wrong one are still correctly rejected.

Closes #350