### PR TITLE
fix: listTasks query parsing

### DIFF
--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -132,20 +132,17 @@ func (h *restHandler) handleStreamMessage(rw http.ResponseWriter, req *http.Requ
 func (h *restHandler) handleGetTask(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	taskID := req.PathValue("id")
-	historyLengthRaw := req.URL.Query().Get("historyLength")
-	var historyLength *int
-	if historyLengthRaw != "" {
-		val, err := strconv.Atoi(historyLengthRaw)
-		if err != nil {
-			writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(taskID))
-			return
-		}
-		historyLength = &val
-	}
+
 	if taskID == "" {
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
 		return
 	}
+	historyLength, err := parseHistoryLength(req.URL.Query())
+	if err != nil {
+		writeRESTError(ctx, rw, fmt.Errorf("%w: invalid historyLength %v", a2a.ErrInvalidRequest, err), a2a.TaskID(taskID))
+		return
+	}
+
 	params := &a2a.GetTaskRequest{
 		ID:            a2a.TaskID(taskID),
 		HistoryLength: historyLength,
@@ -166,53 +163,13 @@ func (h *restHandler) handleGetTask(rw http.ResponseWriter, req *http.Request) {
 func (h *restHandler) handleListTasks(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	query := req.URL.Query()
-	request := &a2a.ListTasksRequest{}
-	var parseErrors []error
-	parse := func(key string, target any) {
-		val := query.Get(key)
-		if val == "" {
-			return
-		}
-		switch t := target.(type) {
-		case *string:
-			*t = val
-		case *a2a.TaskState:
-			*t = a2a.TaskState(val)
-		case *int:
-			v, err := strconv.Atoi(val)
-			if err != nil {
-				parseErrors = append(parseErrors, fmt.Errorf("invalid %s: %w", key, err))
-				return
-			}
-			*t = v
-		case *bool:
-			v, err := strconv.ParseBool(val)
-			if err != nil {
-				parseErrors = append(parseErrors, fmt.Errorf("invalid %s: %w", key, err))
-				return
-			}
-			*t = v
-		case *time.Time:
-			parsedTime, err := time.Parse(time.RFC3339, val)
-			if err != nil {
-				parseErrors = append(parseErrors, fmt.Errorf("invalid %s: %w", key, err))
-				return
-			}
-			*t = parsedTime
-		}
-	}
-	parse("contextId", &request.ContextID)
-	parse("status", &request.Status)
-	parse("pageSize", &request.PageSize)
-	parse("pageToken", &request.PageToken)
-	parse("historyLength", &request.HistoryLength)
-	parse("statusTimestampAfter", &request.StatusTimestampAfter)
-	parse("includeArtifacts", &request.IncludeArtifacts)
-	fillTenant(ctx, &request.Tenant)
-	if len(parseErrors) > 0 {
-		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
+	request, err := parseListTasksQueryParams(query)
+	if err != nil {
+		writeRESTError(ctx, rw, err, a2a.TaskID(""))
 		return
 	}
+
+	fillTenant(ctx, &request.Tenant)
 	result, err := h.handler.ListTasks(ctx, request)
 	if err != nil {
 		writeRESTError(ctx, rw, err, a2a.TaskID(""))
@@ -496,6 +453,75 @@ func writeRESTError(ctx context.Context, rw http.ResponseWriter, err error, task
 	if err := json.NewEncoder(rw).Encode(errResp); err != nil {
 		log.Error(ctx, "failed to write error response", err)
 	}
+}
+
+func parseListTasksQueryParams(query url.Values) (*a2a.ListTasksRequest, error) {
+	request := &a2a.ListTasksRequest{}
+	contextID := query.Get("contextId")
+	if contextID != "" {
+		request.ContextID = contextID
+	}
+	status := query.Get("status")
+	if status != "" {
+		request.Status = a2a.TaskState(status)
+	}
+	pageSize := query.Get("pageSize")
+	if pageSize != "" {
+		val, err := strconv.Atoi(pageSize)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid pageSize %v", a2a.ErrInvalidRequest, err)
+		}
+		request.PageSize = val
+	}
+	pageToken := query.Get("pageToken")
+	if pageToken != "" {
+		request.PageToken = pageToken
+	}
+	includeArtifacts := query.Get("includeArtifacts")
+	if includeArtifacts != "" {
+		val, err := strconv.ParseBool(includeArtifacts)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid includeArtifacts %v", a2a.ErrInvalidRequest, err)
+		}
+		request.IncludeArtifacts = val
+	}
+	historyLength, err := parseHistoryLength(query)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid historyLength %v", a2a.ErrInvalidRequest, err)
+	}
+	request.HistoryLength = historyLength
+	statusTimestampAfter, err := parseStatusTimestampAfter(query)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid statusTimestampAfter %v", a2a.ErrInvalidRequest, err)
+	}
+	request.StatusTimestampAfter = statusTimestampAfter
+	return request, nil
+}
+
+func parseHistoryLength(query url.Values) (*int, error) {
+	historyLengthRaw := query.Get("historyLength")
+	var historyLength *int
+	if historyLengthRaw != "" {
+		val, err := strconv.Atoi(historyLengthRaw)
+		if err != nil {
+			return nil, err
+		}
+		historyLength = &val
+	}
+	return historyLength, nil
+}
+
+func parseStatusTimestampAfter(query url.Values) (*time.Time, error) {
+	statusTimestampAfterRaw := query.Get("statusTimestampAfter")
+	var statusTimestampAfter *time.Time
+	if statusTimestampAfterRaw != "" {
+		val, err := time.Parse(time.RFC3339Nano, statusTimestampAfterRaw)
+		if err != nil {
+			return nil, err
+		}
+		statusTimestampAfter = &val
+	}
+	return statusTimestampAfter, nil
 }
 
 type tenantKeyType struct{}

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -23,6 +23,7 @@ import (
 	"iter"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
 	"testing"
 	"time"
@@ -32,7 +33,9 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
 	"github.com/a2aproject/a2a-go/v2/internal/rest"
 	"github.com/a2aproject/a2a-go/v2/internal/testutil"
+	"github.com/a2aproject/a2a-go/v2/internal/utils"
 	"github.com/a2aproject/a2a-go/v2/log"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestREST_RequestRouting(t *testing.T) {
@@ -385,6 +388,14 @@ func TestREST_ListTasksParseErrors(t *testing.T) {
 			name:  "multiple invalid params",
 			query: "?pageSize=abc&includeArtifacts=notbool",
 		},
+		{
+			name:  "invalid historyLength",
+			query: "?historyLength=abc",
+		},
+		{
+			name:  "invalid statusTimestampAfter",
+			query: "?statusTimestampAfter=not-a-timestamp",
+		},
 	}
 
 	auth := func(ctx context.Context) (string, error) { return "TestUser", nil }
@@ -418,6 +429,119 @@ func TestREST_ListTasksParseErrors(t *testing.T) {
 			gotErr := rest.FromRESTError(resp)
 			if !errors.Is(gotErr, a2a.ErrInvalidRequest) {
 				t.Fatalf("rest.FromRESTError() = %v, want %v", gotErr, a2a.ErrInvalidRequest)
+			}
+		})
+	}
+}
+
+// capturingListTasksHandler is a minimal RequestHandler used only to record the
+// ListTasksRequest produced by the REST layer's query parsing.
+type capturingListTasksHandler struct {
+	RequestHandler           // embed the interface; only ListTasks is exercised
+	capturedListTasksRequest *a2a.ListTasksRequest
+}
+
+func (h *capturingListTasksHandler) ListTasks(_ context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+	h.capturedListTasksRequest = req
+	return &a2a.ListTasksResponse{}, nil
+}
+
+func TestREST_ListTasksQueryParsing(t *testing.T) {
+	t.Parallel()
+	fixedTime := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	ts := url.QueryEscape(fixedTime.Format(time.RFC3339))
+	tests := []struct {
+		name  string
+		query string
+		want  *a2a.ListTasksRequest
+	}{
+		{
+			name:  "empty query",
+			query: "",
+			want:  &a2a.ListTasksRequest{},
+		},
+		{
+			name:  "contextId",
+			query: "contextId=ctx-123",
+			want:  &a2a.ListTasksRequest{ContextID: "ctx-123"},
+		},
+		{
+			name:  "status",
+			query: "status=TASK_STATE_SUBMITTED",
+			want:  &a2a.ListTasksRequest{Status: a2a.TaskStateSubmitted},
+		},
+		{
+			name:  "pageSize",
+			query: "pageSize=11",
+			want:  &a2a.ListTasksRequest{PageSize: 11},
+		},
+		{
+			name:  "pageToken",
+			query: "pageToken=tok-abc",
+			want:  &a2a.ListTasksRequest{PageToken: "tok-abc"},
+		},
+		{
+			name:  "historyLength",
+			query: "historyLength=5",
+			want:  &a2a.ListTasksRequest{HistoryLength: utils.Ptr(5)},
+		},
+		{
+			name:  "statusTimestampAfter",
+			query: "statusTimestampAfter=" + ts,
+			want:  &a2a.ListTasksRequest{StatusTimestampAfter: utils.Ptr(fixedTime)},
+		},
+		{
+			name:  "includeArtifacts",
+			query: "includeArtifacts=true",
+			want:  &a2a.ListTasksRequest{IncludeArtifacts: true},
+		},
+		{
+			name: "all fields",
+			query: "contextId=ctx-123" +
+				"&status=TASK_STATE_SUBMITTED" +
+				"&pageSize=11" +
+				"&pageToken=tok-abc" +
+				"&historyLength=5" +
+				"&statusTimestampAfter=" + ts +
+				"&includeArtifacts=true",
+			want: &a2a.ListTasksRequest{
+				ContextID:            "ctx-123",
+				Status:               a2a.TaskStateSubmitted,
+				PageSize:             11,
+				PageToken:            "tok-abc",
+				HistoryLength:        utils.Ptr(5),
+				StatusTimestampAfter: utils.Ptr(fixedTime),
+				IncludeArtifacts:     true,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			capturingHandler := &capturingListTasksHandler{
+				RequestHandler: NewHandler(&mockAgentExecutor{}),
+			}
+			server := httptest.NewServer(NewRESTHandler(capturingHandler))
+			t.Cleanup(server.Close)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/tasks?"+tc.query, nil)
+			if err != nil {
+				t.Fatalf("http.NewRequestWithContext() error = %v", err)
+			}
+			resp, err := server.Client().Do(req)
+			if err != nil {
+				t.Fatalf("server.Client().Do() error = %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("resp.StatusCode = %d, want 200 OK; body=%s", resp.StatusCode, string(body))
+			}
+			if capturingHandler.capturedListTasksRequest == nil {
+				t.Fatalf("capturingListTasksHandler.ListTasks() not called")
+			}
+			if diff := cmp.Diff(tc.want, capturingHandler.capturedListTasksRequest); diff != "" {
+				t.Fatalf("ListTasksRequest wrong result (-want +got) diff = %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
`GET /tasks?historyLength=N` and `?statusTimestampAfter=...` were silently
dropped by the REST `ListTasks` handler. The `parse` closure dispatched on
target type with a type switch, but `*int` / `*time.Time` fields on
`ListTasksRequest` produced `**int` / `**time.Time` arguments that no case
matched — so the values never reached the request.

Replaced the type-switch `parse` closure with a typed `parseQueryParams`
  helper that returns `(*a2a.ListTasksRequest, error)`.
Extracted `parseHistoryLength` and `parseStatusTimestampAfter` helpers,
  reused by `handleGetTask` and `handleListTasks`.

Added new test to verify correctly parsed ListTasksRequest reaching to handler
Extended `TestREST_ListTasksParseErrors` with `historyLength` and
  `statusTimestampAfter` invalid-value cases.