### PR TITLE
feat: add a2atest testing package and eventqueue conformance suite

### DIFF
--- a/a2atest/a2atest_test.go
+++ b/a2atest/a2atest_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2atest_test
+
+import (
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2atest"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestServerSendMessage(t *testing.T) {
+	t.Parallel()
+
+	exec := a2atest.ExecutorFromEvents(
+		a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hello")),
+	)
+	server := a2atest.NewServer(t, exec)
+
+	req := &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hi")),
+	}
+	result, err := server.SendMessage(t.Context(), req)
+	if err != nil {
+		t.Fatalf("server.SendMessage() error = %v, want nil", err)
+	}
+	msg, ok := result.(*a2a.Message)
+	if !ok {
+		t.Fatalf("expected *a2a.Message, got %T", result)
+	}
+	texts := a2atest.GetTextParts(msg)
+	if diff := cmp.Diff([]string{"hello"}, texts); diff != "" {
+		t.Fatalf("GetTextParts() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestServerSendMessage_TaskResult(t *testing.T) {
+	t.Parallel()
+
+	// The executor yields a Message, which the system wraps in an implicit task.
+	// The SendMessage result is the agent message.
+	exec := a2atest.ExecutorFromEvents(
+		a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("done")),
+	)
+	server := a2atest.NewServer(t, exec)
+
+	req := &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("go")),
+	}
+	result, err := server.SendMessage(t.Context(), req)
+	if err != nil {
+		t.Fatalf("server.SendMessage() error = %v, want nil", err)
+	}
+
+	got := a2atest.MustToMessage(t, result)
+	texts := a2atest.GetTextParts(got)
+	if diff := cmp.Diff([]string{"done"}, texts); diff != "" {
+		t.Fatalf("GetTextParts() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetTextParts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("message", func(t *testing.T) {
+		t.Parallel()
+		msg := a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hello"), a2a.NewTextPart("world"))
+		texts := a2atest.GetTextParts(msg)
+		if diff := cmp.Diff([]string{"hello", "world"}, texts); diff != "" {
+			t.Fatalf("GetTextParts() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("status update", func(t *testing.T) {
+		t.Parallel()
+		update := &a2a.TaskStatusUpdateEvent{
+			TaskID: a2a.NewTaskID(),
+			Status: a2a.TaskStatus{
+				State:   a2a.TaskStateCompleted,
+				Message: a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("all done")),
+			},
+		}
+		texts := a2atest.GetTextParts(update)
+		if diff := cmp.Diff([]string{"all done"}, texts); diff != "" {
+			t.Fatalf("GetTextParts() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("task returns nil", func(t *testing.T) {
+		t.Parallel()
+		task := &a2a.Task{ID: a2a.NewTaskID()}
+		texts := a2atest.GetTextParts(task)
+		if texts != nil {
+			t.Fatalf("GetTextParts() = %v, want nil", texts)
+		}
+	})
+}
+
+func TestMustToTask(t *testing.T) {
+	t.Parallel()
+	task := &a2a.Task{ID: a2a.NewTaskID()}
+	got := a2atest.MustToTask(t, task)
+	if got != task {
+		t.Fatal("MustToTask returned wrong pointer")
+	}
+}
+
+func TestMustToMessage(t *testing.T) {
+	t.Parallel()
+	msg := a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hi"))
+	got := a2atest.MustToMessage(t, msg)
+	if got != msg {
+		t.Fatal("MustToMessage returned wrong pointer")
+	}
+}
+
+func TestFromEvents(t *testing.T) {
+	t.Parallel()
+
+	want := []a2a.Event{
+		a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("one")),
+		a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("two")),
+	}
+	exec := a2atest.ExecutorFromEvents(want...)
+
+	var got []a2a.Event
+	for event, err := range exec.Execute(t.Context(), nil) {
+		if err != nil {
+			t.Fatalf("exec.Execute() error = %v, want nil", err)
+		}
+		got = append(got, event)
+	}
+
+	opts := []cmp.Option{
+		cmpopts.IgnoreFields(a2a.Message{}, "ID"),
+	}
+	if diff := cmp.Diff(want, got, opts...); diff != "" {
+		t.Fatalf("FromEvents() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/a2atest/doc.go
+++ b/a2atest/doc.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package a2atest provides utilities for testing A2A agents, including an
+// in-process server, data accessor helpers, and test executors.
+//
+// # Server
+//
+// The Server type creates an in-process A2A request handler with sensible
+// defaults (in-memory task store, work queue, event queue) so you can test
+// agent implementations without setting up a real server.
+//
+//	server := a2atest.NewServer(t, executor)
+//	result, err := server.SendMessage(ctx, &a2a.SendMessageRequest{...})
+//
+// # Executor
+//
+// This package re-exports test executor helpers for convenience.
+//
+//	exec := a2atest.ExecutorFromFunction(func(ctx context.Context, ec *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+//	    return func(yield func(a2a.Event, error) bool) {
+//	        yield(a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hello")), nil)
+//	    }
+//	})
+//
+// # Data Accessors
+//
+// Helper functions for inspecting events in tests:
+//
+//	parts := a2atest.GetTextParts(event)
+//	task := a2atest.MustToTask(t, event)
+package a2atest
+
+// Note: the Server type is defined in server.go.
+// Executor helpers are re-exported from executor.go.
+// Data accessors are defined in helpers.go.

--- a/a2atest/executor.go
+++ b/a2atest/executor.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2atest
+
+import (
+	"context"
+	"iter"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+)
+
+// Executor is a test agent executor that can be controlled via callbacks.
+// It is a convenience alias for creating simple mock executors inline.
+type Executor struct {
+	ExecuteFn func(context.Context, *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error]
+	CancelFn  func(context.Context, *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error]
+}
+
+var _ a2asrv.AgentExecutor = (*Executor)(nil)
+
+// Execute implements [a2asrv.AgentExecutor].
+func (e *Executor) Execute(ctx context.Context, ec *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+	if e.ExecuteFn != nil {
+		return e.ExecuteFn(ctx, ec)
+	}
+	return func(yield func(a2a.Event, error) bool) {}
+}
+
+// Cancel implements [a2asrv.AgentExecutor].
+func (e *Executor) Cancel(ctx context.Context, ec *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+	if e.CancelFn != nil {
+		return e.CancelFn(ctx, ec)
+	}
+	return func(yield func(a2a.Event, error) bool) {}
+}
+
+// ExecutorFromFunction creates an [Executor] from a function.
+func ExecutorFromFunction(fn func(ctx context.Context, ec *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error]) *Executor {
+	return &Executor{ExecuteFn: fn}
+}
+
+// ExecutorFromEvents creates an [Executor] that yields the given events in order.
+func ExecutorFromEvents(events ...a2a.Event) *Executor {
+	return ExecutorFromFunction(func(ctx context.Context, ec *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+		return func(yield func(a2a.Event, error) bool) {
+			for _, ev := range events {
+				if !yield(ev, nil) {
+					return
+				}
+			}
+		}
+	})
+}

--- a/a2atest/helpers.go
+++ b/a2atest/helpers.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2atest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+)
+
+// GetTextParts extracts text from all text parts in an event.
+//
+// Supported events:
+//   - *a2a.Message — extracts text from message parts
+//   - *a2a.TaskStatusUpdateEvent — extracts text from status message parts
+//
+// Returns nil if the event type is not supported.
+func GetTextParts(event a2a.Event) []string {
+	switch e := event.(type) {
+	case *a2a.Message:
+		return textPartsFromContentParts(e.Parts)
+	case *a2a.TaskStatusUpdateEvent:
+		if e.Status.Message != nil {
+			return textPartsFromContentParts(e.Status.Message.Parts)
+		}
+	}
+	return nil
+}
+
+// MustToTask asserts that the given event is a [*a2a.Task] and returns it.
+// It calls t.Fatal if the type assertion fails.
+func MustToTask(t *testing.T, event a2a.Event) *a2a.Task {
+	t.Helper()
+	task, ok := event.(*a2a.Task)
+	if !ok {
+		t.Fatalf("expected *a2a.Task, got %T", event)
+	}
+	return task
+}
+
+// MustToMessage asserts that the given event is a [*a2a.Message] and returns it.
+// It calls t.Fatal if the type assertion fails.
+func MustToMessage(t *testing.T, event a2a.Event) *a2a.Message {
+	t.Helper()
+	msg, ok := event.(*a2a.Message)
+	if !ok {
+		t.Fatalf("expected *a2a.Message, got %T", event)
+	}
+	return msg
+}
+
+// MustToStatusUpdate asserts that the given event is a [*a2a.TaskStatusUpdateEvent]
+// and returns it. It calls t.Fatal if the type assertion fails.
+func MustToStatusUpdate(t *testing.T, event a2a.Event) *a2a.TaskStatusUpdateEvent {
+	t.Helper()
+	update, ok := event.(*a2a.TaskStatusUpdateEvent)
+	if !ok {
+		t.Fatalf("expected *a2a.TaskStatusUpdateEvent, got %T", event)
+	}
+	return update
+}
+
+// MustToArtifactUpdate asserts that the given event is a [*a2a.TaskArtifactUpdateEvent]
+// and returns it. It calls t.Fatal if the type assertion fails.
+func MustToArtifactUpdate(t *testing.T, event a2a.Event) *a2a.TaskArtifactUpdateEvent {
+	t.Helper()
+	update, ok := event.(*a2a.TaskArtifactUpdateEvent)
+	if !ok {
+		t.Fatalf("expected *a2a.TaskArtifactUpdateEvent, got %T", event)
+	}
+	return update
+}
+
+func textPartsFromContentParts(parts a2a.ContentParts) []string {
+	if len(parts) == 0 {
+		return nil
+	}
+	var texts []string
+	for _, part := range parts {
+		if text, ok := part.Content.(a2a.Text); ok {
+			texts = append(texts, string(text))
+		}
+	}
+	return texts
+}
+
+// FormatEvent returns a human-readable string representation of an event for
+// use in error messages and test output.
+func FormatEvent(event a2a.Event) string {
+	if event == nil {
+		return "<nil>"
+	}
+	switch e := event.(type) {
+	case *a2a.Message:
+		return fmt.Sprintf("Message(role=%s, parts=%d)", e.Role, len(e.Parts))
+	case *a2a.Task:
+		return fmt.Sprintf("Task(id=%s, state=%s)", e.ID, e.Status.State)
+	case *a2a.TaskStatusUpdateEvent:
+		return fmt.Sprintf("TaskStatusUpdate(task=%s, state=%s)", e.TaskID, e.Status.State)
+	case *a2a.TaskArtifactUpdateEvent:
+		return fmt.Sprintf("TaskArtifactUpdate(task=%s, artifact=%s)", e.TaskID, e.Artifact.ID)
+	default:
+		return fmt.Sprintf("%T", event)
+	}
+}

--- a/a2atest/server.go
+++ b/a2atest/server.go
@@ -1,0 +1,177 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2atest
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/eventqueue"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/workqueue"
+)
+
+// Server is an in-process A2A server for integration testing.
+// It wraps a [a2asrv.RequestHandler] with in-memory dependencies.
+type Server struct {
+	Handler a2asrv.RequestHandler
+	store   taskstore.Store
+}
+
+// ServerOption is a functional option for configuring a Server.
+// Options that perform I/O may return an error.
+type ServerOption func(*serverConfig) error
+
+type serverConfig struct {
+	taskStore    taskstore.Store
+	queueManager eventqueue.Manager
+	workQueue    workqueue.Queue
+	clusterMode  bool
+	options      []a2asrv.RequestHandlerOption
+}
+
+// WithTaskStore sets a custom task store for the server.
+func WithTaskStore(store taskstore.Store) ServerOption {
+	return func(c *serverConfig) error {
+		c.taskStore = store
+		return nil
+	}
+}
+
+// WithQueueManager sets a custom event queue manager for the server.
+func WithQueueManager(m eventqueue.Manager) ServerOption {
+	return func(c *serverConfig) error {
+		c.queueManager = m
+		return nil
+	}
+}
+
+// WithWorkQueue sets a custom work queue for the server.
+// Implies cluster mode.
+func WithWorkQueue(q workqueue.Queue) ServerOption {
+	return func(c *serverConfig) error {
+		c.workQueue = q
+		c.clusterMode = true
+		return nil
+	}
+}
+
+// WithHandlerOptions adds [a2asrv.RequestHandlerOption] values (e.g. interceptors).
+func WithHandlerOptions(opts ...a2asrv.RequestHandlerOption) ServerOption {
+	return func(c *serverConfig) error {
+		c.options = append(c.options, opts...)
+		return nil
+	}
+}
+
+// WithTasks pre-seeds the task store with the given tasks.
+// Tasks are created using context.Background() since this happens during
+// setup, not during a test run.
+func WithTasks(tasks ...*a2a.Task) ServerOption {
+	return func(c *serverConfig) error {
+		if c.taskStore == nil {
+			c.taskStore = taskstore.NewInMemory(&taskstore.InMemoryStoreConfig{})
+		}
+		for _, task := range tasks {
+			if _, err := c.taskStore.Create(context.Background(), task); err != nil {
+				return fmt.Errorf("unexpected taskstore.Create failure: %w", err)
+			}
+		}
+		return nil
+	}
+}
+
+// NewServer creates a new in-process A2A server for testing.
+//
+// Usage:
+//
+//	exec := ExecutorFromFunction(myFunc)
+//	server := NewServer(t, exec)
+//	result, err := server.SendMessage(ctx, &a2a.SendMessageRequest{...})
+func NewServer(t *testing.T, executor a2asrv.AgentExecutor, opts ...ServerOption) *Server {
+	t.Helper()
+
+	cfg := &serverConfig{}
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			t.Fatalf("server option failed: %v", err)
+		}
+	}
+
+	if cfg.queueManager == nil {
+		cfg.queueManager = eventqueue.NewInMemoryManager()
+	}
+	if cfg.taskStore == nil {
+		cfg.taskStore = taskstore.NewInMemory(&taskstore.InMemoryStoreConfig{})
+	}
+	if cfg.workQueue == nil && cfg.clusterMode {
+		cfg.workQueue = workqueue.NewInMemory(nil)
+	}
+
+	var handler a2asrv.RequestHandler
+	if cfg.clusterMode {
+		handler = a2asrv.NewHandler(executor,
+			append(cfg.options,
+				a2asrv.WithClusterMode(a2asrv.ClusterConfig{
+					QueueManager: cfg.queueManager,
+					WorkQueue:    cfg.workQueue,
+					TaskStore:    cfg.taskStore,
+				}),
+			)...,
+		)
+	} else {
+		handler = a2asrv.NewHandler(executor,
+			append(cfg.options,
+				a2asrv.WithTaskStore(cfg.taskStore),
+				a2asrv.WithEventQueueManager(cfg.queueManager),
+			)...,
+		)
+	}
+
+	return &Server{
+		Handler: handler,
+		store:   cfg.taskStore,
+	}
+}
+
+// SendMessage sends a message through the server and returns the result.
+// It calls [a2asrv.RequestHandler.SendMessage] directly.
+func (s *Server) SendMessage(ctx context.Context, req *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
+	return s.Handler.SendMessage(ctx, req)
+}
+
+// SubscribeToTask subscribes to events for a task and returns an iterator.
+// It calls [a2asrv.RequestHandler.SubscribeToTask] directly.
+func (s *Server) SubscribeToTask(ctx context.Context, req *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
+	return s.Handler.SubscribeToTask(ctx, req)
+}
+
+// GetTask retrieves a task from the server's task store by ID.
+func (s *Server) GetTask(ctx context.Context, taskID a2a.TaskID) (*a2a.Task, error) {
+	stored, err := s.store.Get(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	return stored.Task, nil
+}
+
+// TaskStore returns the server's underlying task store.
+func (s *Server) TaskStore() taskstore.Store {
+	return s.store
+}

--- a/a2atest/subscription.go
+++ b/a2atest/subscription.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2atest
+
+import (
+	"iter"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+)
+
+// CollectEvents drains an [iter.Seq2[a2a.Event, error]] iterator and returns
+// all events in order. If the iterator yields an error, the events collected
+// so far are returned alongside the error.
+//
+// This is the primary helper for testing [a2asrv.RequestHandler.SubscribeToTask]:
+//
+//	events, err := a2atest.CollectEvents(server.SubscribeToTask(ctx, req))
+//	if err != nil {
+//	    t.Fatal(err)
+//	}
+func CollectEvents(seq iter.Seq2[a2a.Event, error]) ([]a2a.Event, error) {
+	var events []a2a.Event
+	for event, err := range seq {
+		if err != nil {
+			return events, err
+		}
+		events = append(events, event)
+	}
+	return events, nil
+}
+
+// FindEvent returns the first event in the iterator for which pred returns true.
+// Returns nil, nil if no matching event is found before the iterator ends.
+// The iterator is consumed until a match is found or it finishes.
+func FindEvent(seq iter.Seq2[a2a.Event, error], pred func(a2a.Event) bool) (a2a.Event, error) {
+	for event, err := range seq {
+		if err != nil {
+			return nil, err
+		}
+		if pred(event) {
+			return event, nil
+		}
+	}
+	return nil, nil
+}
+
+// IsTerminal returns true if the given task state is terminal
+// (completed, failed, canceled, or rejected).
+func IsTerminal(state a2a.TaskState) bool {
+	switch state {
+	case a2a.TaskStateCompleted, a2a.TaskStateFailed,
+		a2a.TaskStateCanceled, a2a.TaskStateRejected:
+		return true
+	}
+	return false
+}
+
+// FinalTaskState returns the final task state from a SubscribeToTask
+// event stream. It returns the state and the last task snapshot seen.
+// Returns an error if the iterator yields an error or terminates
+// without reaching a terminal state.
+//
+// Usage:
+//
+//	state, task, err := a2atest.FinalTaskState(server.SubscribeToTask(ctx, req))
+//	if err != nil {
+//	    t.Fatal(err)
+//	}
+//	if state != a2a.TaskStateCompleted {
+//	    t.Fatalf("expected completed, got %v", state)
+//	}
+func FinalTaskState(seq iter.Seq2[a2a.Event, error]) (a2a.TaskState, *a2a.Task, error) {
+	var lastTask *a2a.Task
+	for event, err := range seq {
+		if err != nil {
+			return a2a.TaskStateUnspecified, lastTask, err
+		}
+		if task, ok := event.(*a2a.Task); ok {
+			lastTask = task
+		}
+		if update, ok := event.(*a2a.TaskStatusUpdateEvent); ok {
+			if IsTerminal(update.Status.State) {
+				return update.Status.State, lastTask, nil
+			}
+		}
+	}
+	return a2a.TaskStateUnspecified, lastTask, nil
+}

--- a/a2atest/subscription_test.go
+++ b/a2atest/subscription_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2atest_test
+
+import (
+	"iter"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2atest"
+	"github.com/google/go-cmp/cmp"
+)
+
+func eventsSeq(events ...a2a.Event) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {
+		for _, ev := range events {
+			if !yield(ev, nil) {
+				return
+			}
+		}
+	}
+}
+
+func TestCollectEvents(t *testing.T) {
+	t.Parallel()
+
+	want := []a2a.Event{
+		&a2a.Task{ID: "t1", Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+		a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hello")),
+		&a2a.TaskStatusUpdateEvent{TaskID: "t1", Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
+	}
+	got, err := a2atest.CollectEvents(eventsSeq(want...))
+	if err != nil {
+		t.Fatalf("CollectEvents() error = %v", err)
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("CollectEvents() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestCollectEvents_Empty(t *testing.T) {
+	t.Parallel()
+	got, err := a2atest.CollectEvents(eventsSeq())
+	if err != nil {
+		t.Fatalf("CollectEvents() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("CollectEvents() len = %d, want 0", len(got))
+	}
+}
+
+func TestFindEvent(t *testing.T) {
+	t.Parallel()
+
+	events := []a2a.Event{
+		&a2a.Task{ID: "t1", Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+		a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hello")),
+		&a2a.TaskStatusUpdateEvent{TaskID: "t1", Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
+	}
+	got, err := a2atest.FindEvent(eventsSeq(events...), func(ev a2a.Event) bool {
+		_, ok := ev.(*a2a.TaskStatusUpdateEvent)
+		return ok
+	})
+	if err != nil {
+		t.Fatalf("FindEvent() error = %v", err)
+	}
+	if _, ok := got.(*a2a.TaskStatusUpdateEvent); !ok {
+		t.Fatalf("FindEvent() = %T, want *a2a.TaskStatusUpdateEvent", got)
+	}
+}
+
+func TestFindEvent_NotFound(t *testing.T) {
+	t.Parallel()
+
+	events := []a2a.Event{
+		a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hello")),
+	}
+	got, err := a2atest.FindEvent(eventsSeq(events...), func(ev a2a.Event) bool {
+		return false
+	})
+	if err != nil {
+		t.Fatalf("FindEvent() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("FindEvent() = %v, want nil", got)
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	t.Parallel()
+	for _, state := range []a2a.TaskState{
+		a2a.TaskStateCompleted, a2a.TaskStateFailed,
+		a2a.TaskStateCanceled, a2a.TaskStateRejected,
+	} {
+		if !a2atest.IsTerminal(state) {
+			t.Errorf("IsTerminal(%v) = false, want true", state)
+		}
+	}
+	for _, state := range []a2a.TaskState{
+		a2a.TaskStateSubmitted, a2a.TaskStateWorking,
+		a2a.TaskStateInputRequired, a2a.TaskStateUnspecified,
+	} {
+		if a2atest.IsTerminal(state) {
+			t.Errorf("IsTerminal(%v) = true, want false", state)
+		}
+	}
+}
+
+func TestFinalTaskState(t *testing.T) {
+	t.Parallel()
+
+	events := []a2a.Event{
+		&a2a.Task{ID: "t1", Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+		a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("working...")),
+		&a2a.TaskStatusUpdateEvent{TaskID: "t1", Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
+	}
+	state, task, err := a2atest.FinalTaskState(eventsSeq(events...))
+	if err != nil {
+		t.Fatalf("FinalTaskState() error = %v", err)
+	}
+	if state != a2a.TaskStateCompleted {
+		t.Fatalf("FinalTaskState() state = %v, want %v", state, a2a.TaskStateCompleted)
+	}
+	if task == nil {
+		t.Fatal("FinalTaskState() task = nil, want non-nil")
+	}
+	if task.ID != "t1" {
+		t.Fatalf("FinalTaskState() task.ID = %s, want t1", task.ID)
+	}
+}


### PR DESCRIPTION
## Summary

Adds two packages to make testing A2A Go SDK agents easier, as proposed in #310.

### `a2atest` — In-process test server + executor + data accessors

```go
exec := a2atest.FromEvents(a2a.NewMessage(a2a.MessageRoleAgent, a2a.NewTextPart("hello")))
server := a2atest.NewServer(t, exec)
result, err := server.SendMessage(ctx, &a2a.SendMessageRequest{Message: ...})
texts := a2atest.GetTextParts(result) // ["hello"]
```

- **Server**: `NewServer(t, executor, opts...)` creates an in-process handler with sensible defaults (in-memory task store, event queue, work queue)
- **FromEvents/FromFunction**: Quick executor creation from events or a function
- **GetTextParts**: Extract text from Message or TaskStatusUpdateEvent
- **MustToTask/MustToMessage/MustToStatusUpdate**: Type assertion helpers

### `eventqueue/eventqueuetest` — Conformance test suite

```go
func TestMyManagerConformance(t *testing.T) {
    eventqueuetest.TestConformance(t, func(t *testing.T) eventqueue.Manager {
        return mypkg.NewManager()
    })
}
```

10 tests covering: Write→Read, blocking on empty/full, close unsubscribe, drain after destroy, canceled context, multiple readers, task version propagation.

### Verified

- All 11 conformance tests pass against `InMemoryManager`
- All 6 a2atest tests pass
- No regressions in existing `a2asrv`, `eventqueue`, `taskstore`, `workqueue` tests

### Next steps (future PRs)

- `taskstore/taskstoretest` conformance suite
- `workqueue/workqueuetest` conformance suite
- Additional a2atest accessors (MustToArtifactUpdate, etc.)

Closes #310