### PR TITLE
feat(a2aext/trace): add cross-agent audit trail for task delegation chains

### DIFF
--- a/a2aext/trace/client.go
+++ b/a2aext/trace/client.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/a2aext/trace/client.go
+++ b/a2aext/trace/client.go
@@ -158,7 +158,7 @@ func ParseTraceHeader(val string) *TraceSpan {
 		return nil
 	}
 	parts := strings.Split(val, ";")
-	if len(parts) < 3 {
+	if len(parts) < 3 || parts[0] == "" || parts[1] == "" {
 		return nil
 	}
 	return &TraceSpan{

--- a/a2aext/trace/client.go
+++ b/a2aext/trace/client.go
@@ -1,0 +1,185 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+)
+
+const (
+	// SvcParamTrace is the ServiceParam key for trace propagation headers.
+	// Values are formatted as: trace_id;span_id;parent_span_id;agent_id
+	SvcParamTrace = "a2a-trace"
+)
+
+// ClientConfig configures the client-side trace interceptor.
+type ClientConfig struct {
+	// AgentID is the identifier injected into child spans when no parent span
+	// exists. This handles the case where the client is the root caller.
+	AgentID string
+
+	// Logger receives span propagation events. If nil, slog.Default() is used.
+	Logger *slog.Logger
+}
+
+// NewClientInterceptor returns a client interceptor that propagates trace
+// context to outgoing A2A calls via ServiceParams headers. If a parent
+// [TraceSpan] is present in the context (set by a [ServerInterceptor] on a
+// prior inbound call), a child span is created and propagated. Otherwise,
+// a new root span is created.
+//
+// Usage:
+//
+//	client, err := a2aclient.NewFromCard(ctx, card,
+//	    a2aclient.WithCallInterceptors(trace.NewClientInterceptor(trace.ClientConfig{
+//	        AgentID: "sg-architect",
+//	    })),
+//	)
+func NewClientInterceptor(cfg ClientConfig) a2aclient.CallInterceptor {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &clientInterceptor{cfg: cfg}
+}
+
+type clientInterceptor struct {
+	a2aclient.PassthroughInterceptor
+	cfg ClientConfig
+}
+
+func (c *clientInterceptor) Before(ctx context.Context, req *a2aclient.Request) (context.Context, any, error) {
+	parent := SpanFrom(ctx)
+
+	var span *TraceSpan
+	if parent != nil {
+		span = NewChildSpan(parent, c.cfg.AgentID, "", "")
+		c.cfg.Logger.DebugContext(ctx, "trace: child span propagated", "span", span.String())
+	} else {
+		span = NewRootSpan(c.cfg.AgentID, "", "")
+		c.cfg.Logger.DebugContext(ctx, "trace: root span propagated", "span", span.String())
+	}
+
+	req.ServiceParams.Append(SvcParamTrace, span.Encode())
+	return WithSpan(ctx, span), nil, nil
+}
+
+// ServerConfig configures the server-side trace interceptor.
+type ServerConfig struct {
+	// AgentID is the identifier injected into every span created by this server.
+	// If empty, the interceptor is a no-op.
+	AgentID string
+
+	// Logger receives span creation events. If nil, slog.Default() is used.
+	Logger *slog.Logger
+}
+
+// NewServerInterceptor returns a server interceptor that creates a new
+// [TraceSpan] for every incoming A2A call. The span is attached to the context
+// and can be retrieved by downstream interceptors or executors via [SpanFrom].
+//
+// If the incoming request carries a trace header (SvcParamTrace), the new span
+// is created as a child, linking the caller's span as the parent. TaskID and
+// ContextID are extracted from the request payload when available.
+//
+// Usage:
+//
+//	handler := a2asrv.NewHandler(executor,
+//	    a2asrv.WithCallInterceptors(trace.NewServerInterceptor(trace.ServerConfig{
+//	        AgentID: "do-developer",
+//	    })),
+//	)
+func NewServerInterceptor(cfg ServerConfig) a2asrv.CallInterceptor {
+	if cfg.AgentID == "" {
+		return a2asrv.PassthroughCallInterceptor{}
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &serverInterceptor{cfg: cfg}
+}
+
+type serverInterceptor struct {
+	a2asrv.PassthroughCallInterceptor
+	cfg ServerConfig
+}
+
+func (s *serverInterceptor) Before(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) (context.Context, any, error) {
+	taskID, contextID := extractTaskInfo(req.Payload)
+	headerValue := s.readTraceHeader(callCtx)
+
+	var span *TraceSpan
+	if parent := ParseTraceHeader(headerValue); parent != nil {
+		span = NewChildSpan(parent, s.cfg.AgentID, taskID, contextID)
+	} else {
+		span = NewRootSpan(s.cfg.AgentID, taskID, contextID)
+	}
+	s.cfg.Logger.DebugContext(ctx, "trace: span created", "span", span.String())
+	return WithSpan(ctx, span), nil, nil
+}
+
+// readTraceHeader reads the SvcParamTrace value from the incoming call.
+func (s *serverInterceptor) readTraceHeader(callCtx *a2asrv.CallContext) string {
+	values, ok := callCtx.ServiceParams().Get(SvcParamTrace)
+	if !ok || len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+// Encode serializes the span into a ServiceParams header value.
+// Format: trace_id;span_id;parent_span_id;agent_id
+func (s *TraceSpan) Encode() string {
+	return strings.Join([]string{s.TraceID, s.SpanID, s.ParentSpanID, s.AgentID}, ";")
+}
+
+// ParseTraceHeader decodes a trace header value into a partial TraceSpan
+// suitable as a parent reference. Returns nil if the header value is
+// empty or has fewer than 3 semicolon-separated parts.
+func ParseTraceHeader(val string) *TraceSpan {
+	if val == "" {
+		return nil
+	}
+	parts := strings.Split(val, ";")
+	if len(parts) < 3 {
+		return nil
+	}
+	return &TraceSpan{
+		TraceID:      parts[0],
+		SpanID:       parts[1],
+		ParentSpanID: parts[2],
+		AgentID:      optionalPart(parts, 3),
+	}
+}
+
+func extractTaskInfo(payload any) (taskID, contextID string) {
+	if provider, ok := payload.(a2a.TaskInfoProvider); ok {
+		info := provider.TaskInfo()
+		return string(info.TaskID), info.ContextID
+	}
+	return "", ""
+}
+
+func optionalPart(parts []string, idx int) string {
+	if idx < len(parts) {
+		return parts[idx]
+	}
+	return ""
+}

--- a/a2aext/trace/context.go
+++ b/a2aext/trace/context.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/a2aext/trace/context.go
+++ b/a2aext/trace/context.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// spanCtxKey is the context key for [TraceSpan].
+type spanCtxKey struct{}
+
+// SpanFrom extracts the current trace span from the context.
+// Returns nil if no span is present.
+func SpanFrom(ctx context.Context) *TraceSpan {
+	span, ok := ctx.Value(spanCtxKey{}).(*TraceSpan)
+	if !ok {
+		return nil
+	}
+	return span
+}
+
+// WithSpan attaches a [TraceSpan] to the context.
+func WithSpan(ctx context.Context, span *TraceSpan) context.Context {
+	return context.WithValue(ctx, spanCtxKey{}, span)
+}
+
+// TraceSpan records a single step in a cross-agent task chain.
+//
+// A span is created by a [ServerInterceptor] when an A2A call arrives.
+// The [ClientInterceptor] reads the span and links it as the parent of any
+// further outgoing calls.
+type TraceSpan struct {
+	// TraceID identifies the end-to-end delegation chain.
+	// All spans within the same chain share the same TraceID.
+	// Generated when no parent span exists (the root of the chain).
+	TraceID string
+
+	// SpanID is a unique identifier for this individual call.
+	SpanID string
+
+	// ParentSpanID is the SpanID of the calling agent's span, or empty
+	// if this is the root of the chain.
+	ParentSpanID string
+
+	// AgentID identifies the agent that handled this call.
+	AgentID string
+
+	// TaskID is the A2A task identifier associated with this call.
+	TaskID string
+
+	// ContextID is the A2A context identifier grouping related interactions.
+	ContextID string
+
+	// Timestamp records when this span was created.
+	Timestamp time.Time
+}
+
+// NewRootSpan creates a root span with a new TraceID and no parent.
+func NewRootSpan(agentID, taskID, contextID string) *TraceSpan {
+	return &TraceSpan{
+		TraceID:      newID(16),
+		SpanID:       newID(8),
+		ParentSpanID: "",
+		AgentID:      agentID,
+		TaskID:       taskID,
+		ContextID:    contextID,
+		Timestamp:    time.Now(),
+	}
+}
+
+// NewChildSpan creates a child span inheriting the parent's TraceID.
+func NewChildSpan(parent *TraceSpan, agentID, taskID, contextID string) *TraceSpan {
+	return &TraceSpan{
+		TraceID:      parent.TraceID,
+		SpanID:       newID(8),
+		ParentSpanID: parent.SpanID,
+		AgentID:      agentID,
+		TaskID:       taskID,
+		ContextID:    contextID,
+		Timestamp:    time.Now(),
+	}
+}
+
+// Chain returns the causal chain as a human-readable string:
+//
+//	agent-a:span₀ → agent-b:span₁ → agent-c:span₂
+func (s *TraceSpan) Chain() string {
+	return fmt.Sprintf("%s:%s", s.AgentID, s.SpanID)
+}
+
+// String returns a compact representation suitable for log lines.
+func (s *TraceSpan) String() string {
+	if s.ParentSpanID == "" {
+		return fmt.Sprintf("[trace=%s span=%s agent=%s task=%s]", s.TraceID, s.SpanID, s.AgentID, s.TaskID)
+	}
+	return fmt.Sprintf("[trace=%s span=%s parent=%s agent=%s task=%s]", s.TraceID, s.SpanID, s.ParentSpanID, s.AgentID, s.TaskID)
+}
+
+// newID generates a random hex string with n bytes of entropy.
+func newID(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("trace: failed to read random bytes: %v", err))
+	}
+	return hex.EncodeToString(b)
+}

--- a/a2aext/trace/context.go
+++ b/a2aext/trace/context.go
@@ -97,9 +97,9 @@ func NewChildSpan(parent *TraceSpan, agentID, taskID, contextID string) *TraceSp
 	}
 }
 
-// Chain returns the causal chain as a human-readable string:
+// Chain returns the current span's identifier in the causal chain:
 //
-//	agent-a:span₀ → agent-b:span₁ → agent-c:span₂
+//	agent-a:span₀
 func (s *TraceSpan) Chain() string {
 	return fmt.Sprintf("%s:%s", s.AgentID, s.SpanID)
 }

--- a/a2aext/trace/doc.go
+++ b/a2aext/trace/doc.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/a2aext/trace/doc.go
+++ b/a2aext/trace/doc.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package trace provides an audit trail for A2A task execution chains.
+//
+// When Agent A delegates to Agent B, trace attaches a span to the outgoing call
+// and records a span on the incoming side. The result is a causal chain of
+// [TraceSpan] values — who called whom, for what task, at what time — that
+// can be collected and queried for post-hoc audit.
+//
+// # Design
+//
+// A [ServerInterceptor] (on the callee) creates a new span for every incoming A2A
+// call, stashing it in the context. A [ClientInterceptor] (on the caller) reads
+// the span from the context and attaches it as the parent to any outgoing calls.
+//
+// Multiple hops accumulate a chain:
+//
+//	Agent A  ──call──►  Agent B  ──call──►  Agent C
+//	span₀               span₁(parent=₀)      span₂(parent=₁)
+//
+// # Relationship to a2aext propagator
+//
+// The a2aext propagator carries extension metadata; trace carries task-level
+// provenance. They are complementary and can be combined in the same interceptor
+// chain. The propagator's context key is distinct, so no interference occurs.
+package trace

--- a/a2aext/trace/server.go
+++ b/a2aext/trace/server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/a2aext/trace/server.go
+++ b/a2aext/trace/server.go
@@ -1,0 +1,18 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+// ServerConfig and NewServerInterceptor are defined in client.go alongside
+// ClientConfig to keep the dual-interceptor design cohesive.

--- a/a2aext/trace/trace_test.go
+++ b/a2aext/trace/trace_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/a2aext/trace/trace_test.go
+++ b/a2aext/trace/trace_test.go
@@ -1,0 +1,393 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace_test
+
+import (
+	"context"
+	"iter"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2aext/trace"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/internal/testutil/testexecutor"
+)
+
+func TestTripleHopTrace(t *testing.T) {
+	t.Parallel()
+
+	// Agent C: a leaf server that records the span it receives and the
+	// trace header from ServiceParams.
+	var capturedSpan *trace.TraceSpan
+	var capturedTraceHeader string
+	agentC := testexecutor.FromFunction(func(ctx context.Context, ec *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+		return func(yield func(a2a.Event, error) bool) {
+			capturedSpan = trace.SpanFrom(ctx)
+			if vals, ok := ec.ServiceParams.Get(trace.SvcParamTrace); ok && len(vals) > 0 {
+				capturedTraceHeader = vals[0]
+			}
+			event := a2a.NewSubmittedTask(ec, ec.Message)
+			event.Status = a2a.TaskStatus{State: a2a.TaskStateCompleted}
+			yield(event, nil)
+		}
+	})
+
+	handlerC := a2asrv.NewHandler(agentC,
+		a2asrv.WithCallInterceptors(trace.NewServerInterceptor(trace.ServerConfig{
+			AgentID: "agent-c",
+		})),
+	)
+	serverC := httptest.NewServer(a2asrv.NewJSONRPCHandler(handlerC))
+	t.Cleanup(serverC.Close)
+
+	cardC := &a2a.AgentCard{
+		Name: "agent-c",
+		SupportedInterfaces: []*a2a.AgentInterface{
+			a2a.NewAgentInterface(serverC.URL, a2a.TransportProtocolJSONRPC),
+		},
+	}
+
+	// Agent B: receives a call from Agent A, then delegates to Agent C.
+	var agentBSpan *trace.TraceSpan
+	agentB := testexecutor.FromFunction(func(ctx context.Context, ec *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+		return func(yield func(a2a.Event, error) bool) {
+			agentBSpan = trace.SpanFrom(ctx)
+
+			client, err := a2aclient.NewFromCard(ctx, cardC,
+				a2aclient.WithCallInterceptors(trace.NewClientInterceptor(trace.ClientConfig{
+					AgentID: "agent-b",
+				})),
+			)
+			if err != nil {
+				t.Errorf("a2aclient.NewFromCard() for agent C error = %v", err)
+				return
+			}
+
+			_, err = client.SendMessage(ctx, &a2a.SendMessageRequest{
+				Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("forwarded")),
+			})
+			if err != nil {
+				t.Errorf("client.SendMessage() to agent C error = %v", err)
+				return
+			}
+
+			event := a2a.NewSubmittedTask(ec, ec.Message)
+			event.Status = a2a.TaskStatus{State: a2a.TaskStateCompleted}
+			yield(event, nil)
+		}
+	})
+
+	handlerB := a2asrv.NewHandler(agentB,
+		a2asrv.WithCallInterceptors(trace.NewServerInterceptor(trace.ServerConfig{
+			AgentID: "agent-b",
+		})),
+	)
+	serverB := httptest.NewServer(a2asrv.NewJSONRPCHandler(handlerB))
+	t.Cleanup(serverB.Close)
+
+	cardB := &a2a.AgentCard{
+		Name: "agent-b",
+		SupportedInterfaces: []*a2a.AgentInterface{
+			a2a.NewAgentInterface(serverB.URL, a2a.TransportProtocolJSONRPC),
+		},
+	}
+
+	// Agent A: the root caller.
+	ctx := t.Context()
+	clientA, err := a2aclient.NewFromCard(ctx, cardB,
+		a2aclient.WithCallInterceptors(trace.NewClientInterceptor(trace.ClientConfig{
+			AgentID: "agent-a",
+		})),
+	)
+	if err != nil {
+		t.Fatalf("a2aclient.NewFromCard() for agent B error = %v", err)
+	}
+
+	_, err = clientA.SendMessage(ctx, &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hello")),
+	})
+	if err != nil {
+		t.Fatalf("clientA.SendMessage() error = %v", err)
+	}
+
+	// Assertions.
+
+	if agentBSpan == nil {
+		t.Fatal("agent B span is nil — server interceptor did not create it")
+	}
+	if capturedSpan == nil {
+		t.Fatal("agent C span is nil — server interceptor did not create it")
+	}
+
+	// Agent C must share the same TraceID as Agent B (same delegation chain).
+	if agentBSpan.TraceID != capturedSpan.TraceID {
+		t.Errorf("TraceID mismatch: B=%s, C=%s", agentBSpan.TraceID, capturedSpan.TraceID)
+	}
+
+	// Agent C's span must have a non-empty parent (it was created as a child).
+	if capturedSpan.ParentSpanID == "" {
+		t.Error("Agent C ParentSpanID is empty — should be a child of a span from Agent B")
+	}
+
+	// The trace header received at Agent C should encode B's client span.
+	// The chain is: A_client → B_server → B_client → C_server.
+	// C's parent is B_client (the span created when B delegated to C).
+	if capturedTraceHeader == "" {
+		t.Error("capturedTraceHeader is empty — trace was not propagated")
+	}
+	t.Logf("trace header at Agent C: %s", capturedTraceHeader)
+
+	// AgentIDs.
+	if agentBSpan.AgentID != "agent-b" {
+		t.Errorf("Agent B AgentID = %s, want agent-b", agentBSpan.AgentID)
+	}
+	if capturedSpan.AgentID != "agent-c" {
+		t.Errorf("Agent C AgentID = %s, want agent-c", capturedSpan.AgentID)
+	}
+
+	// IDs must have correct lengths.
+	if len(agentBSpan.TraceID) != 32 {
+		t.Errorf("TraceID length = %d, want 32", len(agentBSpan.TraceID))
+	}
+	if len(agentBSpan.SpanID) != 16 {
+		t.Errorf("SpanID length = %d, want 16", len(agentBSpan.SpanID))
+	}
+}
+
+func TestNewRootSpan(t *testing.T) {
+	t.Parallel()
+
+	span := trace.NewRootSpan("test-agent", "task-1", "ctx-1")
+
+	if span.TraceID == "" {
+		t.Error("TraceID is empty")
+	}
+	if span.SpanID == "" {
+		t.Error("SpanID is empty")
+	}
+	if span.ParentSpanID != "" {
+		t.Errorf("ParentSpanID = %s, want empty", span.ParentSpanID)
+	}
+	if span.AgentID != "test-agent" {
+		t.Errorf("AgentID = %s, want test-agent", span.AgentID)
+	}
+	if span.TaskID != "task-1" {
+		t.Errorf("TaskID = %s, want task-1", span.TaskID)
+	}
+	if span.ContextID != "ctx-1" {
+		t.Errorf("ContextID = %s, want ctx-1", span.ContextID)
+	}
+	if span.Timestamp.IsZero() {
+		t.Error("Timestamp is zero")
+	}
+}
+
+func TestNewChildSpan(t *testing.T) {
+	t.Parallel()
+
+	parent := trace.NewRootSpan("parent-agent", "task-p", "ctx-p")
+	child := trace.NewChildSpan(parent, "child-agent", "task-c", "ctx-c")
+
+	if child.TraceID != parent.TraceID {
+		t.Errorf("Child TraceID = %s, want %s (parent's)", child.TraceID, parent.TraceID)
+	}
+	if child.ParentSpanID != parent.SpanID {
+		t.Errorf("Child ParentSpanID = %s, want %s (parent's SpanID)", child.ParentSpanID, parent.SpanID)
+	}
+	if child.SpanID == parent.SpanID {
+		t.Error("Child SpanID should differ from parent SpanID")
+	}
+	if child.AgentID != "child-agent" {
+		t.Errorf("Child AgentID = %s, want child-agent", child.AgentID)
+	}
+}
+
+func TestSpanFromNilContext(t *testing.T) {
+	t.Parallel()
+
+	span := trace.SpanFrom(context.Background())
+	if span != nil {
+		t.Errorf("SpanFrom(empty context) = %v, want nil", span)
+	}
+}
+
+func TestNoopServerInterceptor(t *testing.T) {
+	t.Parallel()
+
+	si := trace.NewServerInterceptor(trace.ServerConfig{})
+	_, ok := si.(a2asrv.PassthroughCallInterceptor)
+	if !ok {
+		t.Errorf("NewServerInterceptor with empty AgentID should return PassthroughCallInterceptor, got %T", si)
+	}
+}
+
+func TestSpanString(t *testing.T) {
+	t.Parallel()
+
+	root := &trace.TraceSpan{
+		TraceID:      "abc123",
+		SpanID:       "def456",
+		ParentSpanID: "",
+		AgentID:      "sg-architect",
+		TaskID:       "task-xyz",
+	}
+	if root.String() == "" {
+		t.Error("root String() returned empty")
+	}
+
+	child := &trace.TraceSpan{
+		TraceID:      "abc123",
+		SpanID:       "ghi789",
+		ParentSpanID: "def456",
+		AgentID:      "do-developer",
+		TaskID:       "task-xyz",
+	}
+	if child.String() == "" {
+		t.Error("child String() returned empty")
+	}
+}
+
+func TestSpanChain(t *testing.T) {
+	t.Parallel()
+
+	span := &trace.TraceSpan{
+		AgentID: "agent-a",
+		SpanID:  "span0",
+	}
+	want := "agent-a:span0"
+	if got := span.Chain(); got != want {
+		t.Errorf("Chain() = %s, want %s", got, want)
+	}
+}
+
+func TestEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	original := trace.NewRootSpan("test-agent", "task-1", "ctx-1")
+	encoded := original.Encode()
+
+	decoded := trace.ParseTraceHeader(encoded)
+	if decoded == nil {
+		t.Fatal("ParseTraceHeader returned nil")
+	}
+	if decoded.TraceID != original.TraceID {
+		t.Errorf("TraceID = %s, want %s", decoded.TraceID, original.TraceID)
+	}
+	if decoded.SpanID != original.SpanID {
+		t.Errorf("SpanID = %s, want %s", decoded.SpanID, original.SpanID)
+	}
+	if decoded.ParentSpanID != original.ParentSpanID {
+		t.Errorf("ParentSpanID = %s, want %s", decoded.ParentSpanID, original.ParentSpanID)
+	}
+	if decoded.AgentID != original.AgentID {
+		t.Errorf("AgentID = %s, want %s", decoded.AgentID, original.AgentID)
+	}
+}
+
+func TestParseTraceHeaderInvalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"too few parts", "abc;def"},
+		{"single part", "abc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := trace.ParseTraceHeader(tc.input); got != nil {
+				t.Errorf("ParseTraceHeader(%q) = %v, want nil", tc.input, got)
+			}
+		})
+	}
+}
+
+func TestTraceHeaderPropagation(t *testing.T) {
+	t.Parallel()
+
+	// Agent B: verifies that the incoming SvcParamTrace header carries the
+	// caller's trace context and that the server interceptor creates a child span.
+	var receivedSpan *trace.TraceSpan
+	var receivedTraceHeader string
+	agentB := testexecutor.FromFunction(func(ctx context.Context, ec *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+		return func(yield func(a2a.Event, error) bool) {
+			receivedSpan = trace.SpanFrom(ctx)
+			if vals, ok := ec.ServiceParams.Get(trace.SvcParamTrace); ok && len(vals) > 0 {
+				receivedTraceHeader = vals[0]
+			}
+			event := a2a.NewSubmittedTask(ec, ec.Message)
+			event.Status = a2a.TaskStatus{State: a2a.TaskStateCompleted}
+			yield(event, nil)
+		}
+	})
+
+	handler := a2asrv.NewHandler(agentB,
+		a2asrv.WithCallInterceptors(trace.NewServerInterceptor(trace.ServerConfig{
+			AgentID: "agent-b",
+		})),
+	)
+	server := httptest.NewServer(a2asrv.NewJSONRPCHandler(handler))
+	t.Cleanup(server.Close)
+
+	card := &a2a.AgentCard{
+		Name: "agent-b",
+		SupportedInterfaces: []*a2a.AgentInterface{
+			a2a.NewAgentInterface(server.URL, a2a.TransportProtocolJSONRPC),
+		},
+	}
+
+	ctx := t.Context()
+	client, err := a2aclient.NewFromCard(ctx, card,
+		a2aclient.WithCallInterceptors(trace.NewClientInterceptor(trace.ClientConfig{
+			AgentID: "agent-a",
+		})),
+	)
+	if err != nil {
+		t.Fatalf("a2aclient.NewFromCard() error = %v", err)
+	}
+
+	_, err = client.SendMessage(ctx, &a2a.SendMessageRequest{
+		Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("ping")),
+	})
+	if err != nil {
+		t.Fatalf("client.SendMessage() error = %v", err)
+	}
+
+	// The server should have received a trace header from the client.
+	if receivedTraceHeader == "" {
+		t.Fatal("receivedTraceHeader is empty — trace was not propagated")
+	}
+	t.Logf("received trace header: %s", receivedTraceHeader)
+
+	// The server interceptor should have created a span.
+	if receivedSpan == nil {
+		t.Fatal("receivedSpan is nil — server interceptor did not create a span")
+	}
+
+	// The server span should be a child of the caller's span (non-empty parent).
+	if receivedSpan.ParentSpanID == "" {
+		t.Error("receivedSpan has empty ParentSpanID — should be a child of the caller's span")
+	}
+
+	// Server AgentID should be correct.
+	if receivedSpan.AgentID != "agent-b" {
+		t.Errorf("receivedSpan.AgentID = %s, want agent-b", receivedSpan.AgentID)
+	}
+}

--- a/a2aext/trace/trace_test.go
+++ b/a2aext/trace/trace_test.go
@@ -308,6 +308,8 @@ func TestParseTraceHeaderInvalid(t *testing.T) {
 		{"empty", ""},
 		{"too few parts", "abc;def"},
 		{"single part", "abc"},
+		{"empty trace and span IDs", ";;parent"},
+		{"empty trace ID", ";span;parent"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a2aext/trace — a distributed audit trail for A2A task delegation chains. Each agent that participates in a multi-hop delegation creates a span recording who called whom, for what task, at what time.

## Design

Follows W3C Trace Context semantics adapted for agent workflows:
- ServerInterceptor: creates a new span on every inbound A2A call
- ClientInterceptor: reads the current span from context, creates a child span, and propagates via a2a-trace ServiceParams header
- Header format: trace_id;span_id;parent_span_id;agent_id — compact, HTTP-header-compatible

Three-hop chain: Agent A -> Agent B -> Agent C, each span linked via parent_span_id.

## What this addresses

The audit trail gap discussed in A2A issue #1672 — specifically the observation that each implementation timestamps independently, making cross-system correlation hard. This package standardizes trace propagation so multi-hop delegation chains can be correlated post-hoc.

## Testing

10 tests covering:
- Three-hop propagation (a->b->c) with parent linkage
- ServiceParams header encoding/decoding
- Root vs child span creation
- No-op behavior with empty config
- Context lifecycle

All pass, zero regressions on existing a2aext/a2asrv suites.
