### PR TITLE
fix: itk grpc compatibility for v0.3 SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## 🚀 Getting Started
 
-Requires Go `1.24.4` or newer:
+Requires Go `1.25.0` or newer:
 
 ```bash
 go get github.com/a2aproject/a2a-go/v2

--- a/a2apb/v0/pbconv/from_proto.go
+++ b/a2apb/v0/pbconv/from_proto.go
@@ -90,10 +90,12 @@ func FromProtoMessage(pMsg *a2apb.Message) (*a2a.Message, error) {
 func fromProtoFilePart(pPart *a2apb.FilePart, meta map[string]any) (a2a.Part, error) {
 	switch f := pPart.GetFile().(type) {
 	case *a2apb.FilePart_FileWithBytes:
-		b, err := base64.StdEncoding.DecodeString(string(f.FileWithBytes))
+		buf := make([]byte, base64.StdEncoding.DecodedLen(len(f.FileWithBytes)))
+		n, err := base64.StdEncoding.Decode(buf, []byte(f.FileWithBytes))
 		if err != nil {
 			return a2a.Part{}, fmt.Errorf("failed to decode base64 string: %w", err)
 		}
+		b := buf[:n]
 		return a2a.Part{
 			Content:   a2a.Raw(b),
 			MediaType: pPart.GetMimeType(),

--- a/a2apb/v0/pbconv/from_proto.go
+++ b/a2apb/v0/pbconv/from_proto.go
@@ -15,6 +15,7 @@
 package pbconv
 
 import (
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -89,8 +90,12 @@ func FromProtoMessage(pMsg *a2apb.Message) (*a2a.Message, error) {
 func fromProtoFilePart(pPart *a2apb.FilePart, meta map[string]any) (a2a.Part, error) {
 	switch f := pPart.GetFile().(type) {
 	case *a2apb.FilePart_FileWithBytes:
+		b, err := base64.StdEncoding.DecodeString(string(f.FileWithBytes))
+		if err != nil {
+			return a2a.Part{}, fmt.Errorf("failed to decode base64 string: %w", err)
+		}
 		return a2a.Part{
-			Content:   a2a.Raw(f.FileWithBytes),
+			Content:   a2a.Raw(b),
 			MediaType: pPart.GetMimeType(),
 			Filename:  pPart.GetName(),
 			Metadata:  meta,

--- a/a2apb/v0/pbconv/from_proto_test.go
+++ b/a2apb/v0/pbconv/from_proto_test.go
@@ -15,6 +15,7 @@
 package pbconv
 
 import (
+	"encoding/base64"
 	"reflect"
 	"testing"
 	"time"
@@ -30,6 +31,7 @@ import (
 
 func TestFromProto_fromProtoPart(t *testing.T) {
 	pData, _ := structpb.NewStruct(map[string]any{"key": "value"})
+	base64Content := base64.StdEncoding.EncodeToString([]byte("content"))
 	tests := []struct {
 		name    string
 		p       *a2apb.Part
@@ -50,7 +52,7 @@ func TestFromProto_fromProtoPart(t *testing.T) {
 			name: "file with bytes",
 			p: &a2apb.Part{Part: &a2apb.Part_File{File: &a2apb.FilePart{
 				MimeType: "text/plain",
-				File:     &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte("content")},
+				File:     &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte(base64Content)},
 			}}},
 			want: a2a.Part{
 				Content:   a2a.Raw([]byte("content")),
@@ -103,7 +105,7 @@ func TestFromProto_fromProtoPart(t *testing.T) {
 			name: "file with meta",
 			p: &a2apb.Part{
 				Part: &a2apb.Part_File{File: &a2apb.FilePart{
-					File: &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte("content")},
+					File: &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte(base64Content)},
 				}},
 				Metadata: mustMakeProtoMetadata(t, map[string]any{"hello": "world"}),
 			},

--- a/a2apb/v0/pbconv/to_proto.go
+++ b/a2apb/v0/pbconv/to_proto.go
@@ -15,6 +15,7 @@
 package pbconv
 
 import (
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"slices"
@@ -306,7 +307,7 @@ func toProtoFilePart(part *a2a.Part) (*a2apb.Part, error) {
 			Part: &a2apb.Part_File{File: &a2apb.FilePart{
 				MimeType: part.MediaType,
 				Name:     part.Filename,
-				File:     &a2apb.FilePart_FileWithBytes{FileWithBytes: fc},
+				File:     &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte(base64.StdEncoding.EncodeToString(fc))},
 			}},
 			Metadata: meta,
 		}, nil

--- a/a2apb/v0/pbconv/to_proto.go
+++ b/a2apb/v0/pbconv/to_proto.go
@@ -303,11 +303,13 @@ func toProtoFilePart(part *a2a.Part) (*a2apb.Part, error) {
 	}
 	switch fc := part.Content.(type) {
 	case a2a.Raw:
+		buf := make([]byte, base64.StdEncoding.EncodedLen(len(fc)))
+		base64.StdEncoding.Encode(buf, []byte(fc))
 		return &a2apb.Part{
 			Part: &a2apb.Part_File{File: &a2apb.FilePart{
 				MimeType: part.MediaType,
 				Name:     part.Filename,
-				File:     &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte(base64.StdEncoding.EncodeToString(fc))},
+				File:     &a2apb.FilePart_FileWithBytes{FileWithBytes: buf},
 			}},
 			Metadata: meta,
 		}, nil

--- a/a2apb/v0/pbconv/to_proto_test.go
+++ b/a2apb/v0/pbconv/to_proto_test.go
@@ -15,6 +15,7 @@
 package pbconv
 
 import (
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -159,6 +160,7 @@ func TestToProto_toProtoMessges(t *testing.T) {
 
 func TestToProto_toProtoPart(t *testing.T) {
 	pData, _ := structpb.NewStruct(map[string]any{"key": "value"})
+	base64Content := base64.StdEncoding.EncodeToString([]byte("content"))
 	tests := []struct {
 		name    string
 		p       a2a.Part
@@ -183,7 +185,7 @@ func TestToProto_toProtoPart(t *testing.T) {
 			},
 			want: &a2apb.Part{Part: &a2apb.Part_File{File: &a2apb.FilePart{
 				MimeType: "text/plain",
-				File:     &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte("content")},
+				File:     &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte(base64Content)},
 			}}},
 		},
 		{
@@ -234,7 +236,7 @@ func TestToProto_toProtoPart(t *testing.T) {
 				Metadata: map[string]any{"hello": "world"}},
 			want: &a2apb.Part{
 				Part: &a2apb.Part_File{File: &a2apb.FilePart{
-					File: &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte("content")},
+					File: &a2apb.FilePart_FileWithBytes{FileWithBytes: []byte(base64Content)},
 				}},
 				Metadata: mustMakeProtoMetadata(t, map[string]any{"hello": "world"}),
 			},

--- a/itk/main.go
+++ b/itk/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2aclient"
 	"github.com/a2aproject/a2a-go/v2/a2aclient/agentcard"
 	"github.com/a2aproject/a2a-go/v2/a2acompat/a2av0"
+	a2agrpcv0 "github.com/a2aproject/a2a-go/v2/a2agrpc/v0"
 	a2agrpc "github.com/a2aproject/a2a-go/v2/a2agrpc/v1"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 	"github.com/a2aproject/a2a-go/v2/a2asrv/push"
@@ -197,6 +198,7 @@ func (e *V10AgentExecutor) handleCallAgent(ctx context.Context, call *pb.CallAge
 	// 4. Create client using a factory
 	var factory *a2aclient.Factory
 	clientOpts := []a2aclient.FactoryOption{
+		a2agrpcv0.WithGRPCTransport(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		a2agrpc.WithGRPCTransport(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		a2av0.WithJSONRPCTransport(a2av0.JSONRPCTransportConfig{}),
 		a2av0.WithRESTTransport(a2av0.RESTTransportConfig{}),
@@ -486,6 +488,11 @@ func run() error {
 				ProtocolBinding: a2a.TransportProtocolGRPC,
 				ProtocolVersion: a2a.Version,
 			},
+			{
+				URL:             fmt.Sprintf("127.0.0.1:%d", *grpcPort),
+				ProtocolBinding: a2a.TransportProtocolGRPC,
+				ProtocolVersion: a2av0.Version,
+			},
 		},
 	}
 
@@ -534,6 +541,7 @@ func run() error {
 		grpc.UnaryInterceptor(unaryLoggingInterceptor(logger)),
 		grpc.StreamInterceptor(streamLoggingInterceptor(logger)),
 	)
+	a2agrpcv0.NewHandler(requestHandler).RegisterWith(grpcServer)
 	a2agrpc.NewHandler(requestHandler).RegisterWith(grpcServer)
 	g.Go(func() error {
 		lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *grpcPort))

--- a/itk/scenarios_full.json
+++ b/itk/scenarios_full.json
@@ -70,16 +70,16 @@
     },
     {
       "name": "Nightly - HTTP_JSON - Send Message",
-      "sdks": ["current", "go_v10", "go_v03", "python_v10", "python_v03"],
-      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "sdks": ["current", "go_v10", "python_v10", "python_v03"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
       "protocols": ["http_json"],
       "behavior": "send_message",
       "build_subtests": true
     },
     {
       "name": "Nightly - HTTP_JSON - Send Message (Streaming)",
-      "sdks": ["current", "go_v10", "go_v03", "python_v10", "python_v03"],
-      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "sdks": ["current", "go_v10", "python_v10", "python_v03"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
       "protocols": ["http_json"],
       "streaming": true,
       "behavior": "send_message",
@@ -87,16 +87,16 @@
     },
     {
       "name": "Nightly - HTTP_JSON - Push Notification",
-      "sdks": ["current", "go_v10", "go_v03", "python_v10", "python_v03"],
-      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "sdks": ["current", "go_v10", "python_v10", "python_v03"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
       "protocols": ["http_json"],
       "behavior": "push_notification",
       "build_subtests": true
     },
     {
       "name": "Nightly - HTTP_JSON - Resubscribe",
-      "sdks": ["current", "go_v10", "go_v03", "python_v10", "python_v03"],
-      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "sdks": ["current", "go_v10", "python_v10", "python_v03"],
+      "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
       "protocols": ["http_json"],
       "streaming": true,
       "behavior": "resubscribe",


### PR DESCRIPTION
- README: bump Go minimum requirement to match go.mod.
- itk/main.go: register v0.3 GRPC transport as both client and server;
  agent card now advertises GRPC at v0.3 alongside v1.0.
- itk/scenarios_full.json: drop go_v03 from HTTP_JSON test cases
  (go_v03 does not support REST).
- a2apb/v0/pbconv (to_proto / from_proto): to avoid breaking existing
  v0.3 SDK users, the ITK compatibility fix lives in the compat layer.
  Outbound conversion base64-encodes raw bytes; inbound conversion
  base64-decodes on receive. Tests updated to match.