### PR TITLE
fix(cli): emit non-null required Agent Card list fields in synthesized card (fixes #369)

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -162,6 +162,13 @@ func loadOrBuildCard(cardFile, name, desc, addr string, proto a2a.TransportProto
 		Version:             "1.0.0",
 		Capabilities:        a2a.AgentCapabilities{Streaming: true},
 		SupportedInterfaces: []*a2a.AgentInterface{a2a.NewAgentInterface(url, proto)},
+		// defaultInputModes, defaultOutputModes and skills are REQUIRED by the
+		// proto. Left as nil slices they marshal to JSON null, which is not a
+		// valid (possibly empty) list and crashes conformant peers that iterate
+		// the field. Emit non-nil slices so the synthesized card stays valid.
+		DefaultInputModes:  []string{"text"},
+		DefaultOutputModes: []string{"text"},
+		Skills:             []a2a.AgentSkill{},
 	}, nil
 }
 

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -73,9 +73,21 @@ func TestLoadOrBuildCard_RequiredListFieldsNotNull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("json.Marshal(card) error = %v", err)
 	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal(card) error = %v", err)
+	}
 	for _, key := range []string{"defaultInputModes", "defaultOutputModes", "skills"} {
-		if strings.Contains(string(data), `"`+key+`":null`) {
-			t.Errorf("marshaled card contains %q: null; REQUIRED field must not be null\n%s", key, data)
+		val, ok := raw[key]
+		switch {
+		case !ok:
+			t.Errorf("marshaled card is missing REQUIRED key %q", key)
+		case val == nil:
+			t.Errorf("marshaled card key %q is null; REQUIRED field must not be null", key)
+		default:
+			if _, isArray := val.([]any); !isArray {
+				t.Errorf("marshaled card key %q is %T; REQUIRED field must be a JSON array", key, val)
+			}
 		}
 	}
 }

--- a/internal/cli/serve_test.go
+++ b/internal/cli/serve_test.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -42,6 +43,40 @@ func TestServe_ModeValidation(t *testing.T) {
 				t.Fatal("expected error")
 			}
 		})
+	}
+}
+
+// TestLoadOrBuildCard_RequiredListFieldsNotNull guards against regressing to a
+// synthesized Agent Card that emits JSON null for the proto-REQUIRED
+// defaultInputModes/defaultOutputModes/skills fields. A null there crashes
+// conformant peers that iterate the field (e.g. the Python a2a-sdk resolver),
+// so the synthesized card must carry non-nil (possibly empty) lists.
+func TestLoadOrBuildCard_RequiredListFieldsNotNull(t *testing.T) {
+	t.Parallel()
+
+	card, err := loadOrBuildCard("", "researcher", "Gathers facts", "127.0.0.1:9199", a2a.TransportProtocolHTTPJSON)
+	if err != nil {
+		t.Fatalf("loadOrBuildCard() error = %v", err)
+	}
+
+	if card.DefaultInputModes == nil {
+		t.Error("DefaultInputModes is nil; want non-nil slice (marshals to null otherwise)")
+	}
+	if card.DefaultOutputModes == nil {
+		t.Error("DefaultOutputModes is nil; want non-nil slice (marshals to null otherwise)")
+	}
+	if card.Skills == nil {
+		t.Error("Skills is nil; want non-nil slice (marshals to null otherwise)")
+	}
+
+	data, err := json.Marshal(card)
+	if err != nil {
+		t.Fatalf("json.Marshal(card) error = %v", err)
+	}
+	for _, key := range []string{"defaultInputModes", "defaultOutputModes", "skills"} {
+		if strings.Contains(string(data), `"`+key+`":null`) {
+			t.Errorf("marshaled card contains %q: null; REQUIRED field must not be null\n%s", key, data)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #369.

### Problem

When `serve` runs without `--card` (both `--exec` and the built-in modes), `loadOrBuildCard` synthesizes an Agent Card that leaves `DefaultInputModes`, `DefaultOutputModes`, and `Skills` as nil slices. Their struct tags in `a2a/agent.go` carry no `omitempty`, so they marshal to JSON `null`:

```json
"defaultInputModes": null,
"defaultOutputModes": null,
"skills": null
```

All three fields are `REQUIRED` in the proto (`google.api.field_behavior = REQUIRED` on `default_input_modes`, `default_output_modes`, `skills` of `AgentCard`), so the synthesized card is not conformant. Go tolerates its own output, so a Go-to-Go run never notices, but a conformant peer in another language does. As reported, resolving this card with the Python `a2a-sdk` crashes outright, because `.get('skills', [])` returns the default only when the key is absent; here the key is present with value `null`, so the client iterates `None`.

### Fix

Populate the three required list fields with non-nil slices in the synthesized card:

- `DefaultInputModes` / `DefaultOutputModes` → `[]string{"text"}`, matching every example server in the repo (`examples/helloworld/*`, `examples/observability`); the built-in `serve`/`--exec` handlers deal in text.
- `Skills` → `[]a2a.AgentSkill{}` (empty, non-nil). A generic command wrapper declares no catalogued skill, and an empty list is a valid REQUIRED value. (Synthesizing a placeholder skill would also need a non-nil `Tags`, which has the same no-`omitempty` behavior, so an empty skills list is the smaller, safe change. Happy to switch the modes to an empty `[]string{}` instead if you'd prefer the card to claim nothing.)

This only affects the synthesis branch of `loadOrBuildCard`, which is reachable from plain `serve` and `serve --exec` without `--card`. The `--proxy` path never reaches it (it either parses a supplied `--card` file or derives its card from the resolved upstream via `deriveProxyCard`), so proxying is unchanged.

Resulting card:

```json
"defaultInputModes": ["text"],
"defaultOutputModes": ["text"],
"skills": []
```

### Test

Adds `TestLoadOrBuildCard_RequiredListFieldsNotNull`, which asserts the synthesized card's three fields are non-nil and that the marshaled JSON contains no `"<field>":null` for any of them.

Verified locally: `go build ./...`, `go vet ./internal/cli/`, and `go test ./internal/cli/` all pass; `gofmt` clean.
