### PR TITLE
fix(push): validate resolved IP to prevent SSRF in push notification sender (fixes #373)

### DIFF
--- a/a2asrv/push/sender.go
+++ b/a2asrv/push/sender.go
@@ -18,14 +18,24 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/log"
 )
+
+// maxPushRedirects bounds the redirect chain a push notification may follow.
+const maxPushRedirects = 10
+
+// errBlockedPushTarget is returned when a push notification URL resolves to a
+// non-public address range (SSRF protection, CWE-918).
+var errBlockedPushTarget = errors.New("push notification target resolves to a blocked address range")
 
 var tokenHeader = http.CanonicalHeaderKey("A2A-Notification-Token")
 
@@ -41,21 +51,87 @@ type HTTPSenderConfig struct {
 	Timeout time.Duration
 	// FailOnError can be set to true to make push sending errors trigger execution cancelation.
 	FailOnError bool
+	// AllowPrivateNetworks disables the built-in SSRF guard that rejects
+	// webhook URLs resolving to loopback, private, link-local or unspecified
+	// addresses. It defaults to false (guard enabled) per the A2A spec 13.2
+	// requirement that agents validate webhook URLs against SSRF. Set it to
+	// true only for trusted internal deployments (for example a webhook on the
+	// same host or private network).
+	AllowPrivateNetworks bool
 }
 
 // NewHTTPPushSender creates a new HTTPPushSender. It uses a default client
 // with a 30-second timeout. An optional config can be provided to customize it.
+//
+// By default the client is SSRF-hardened: it validates the resolved IP of
+// every connection (including redirect hops) and refuses to POST to loopback,
+// private, link-local or unspecified addresses. Set
+// [HTTPSenderConfig.AllowPrivateNetworks] to opt out for trusted internal use.
 func NewHTTPPushSender(config *HTTPSenderConfig) *HTTPPushSender {
 	t := 30 * time.Second
+	allowPrivate := false
 	if config != nil {
 		if config.Timeout > 0 {
 			t = config.Timeout
 		}
+		allowPrivate = config.AllowPrivateNetworks
+	}
+	client := &http.Client{Timeout: t}
+	if !allowPrivate {
+		client.Transport = ssrfGuardedTransport()
+		client.CheckRedirect = limitPushRedirects
 	}
 	return &HTTPPushSender{
-		client:      &http.Client{Timeout: t},
+		client:      client,
 		failOnError: config != nil && config.FailOnError,
 	}
+}
+
+// ssrfGuardedTransport clones the default transport and validates the resolved
+// IP of every connection before the TCP handshake. Because the check runs at
+// dial time it also covers DNS-rebinding targets and redirect hops (each hop
+// re-dials), which a URL-string check alone cannot catch.
+func ssrfGuardedTransport() *http.Transport {
+	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	dialer.Control = func(_, address string, _ syscall.RawConn) error {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return fmt.Errorf("invalid dial address %q: %w", address, err)
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return fmt.Errorf("%w: unresolved host %q", errBlockedPushTarget, host)
+		}
+		if isBlockedIP(ip) {
+			return fmt.Errorf("%w: %s", errBlockedPushTarget, ip)
+		}
+		return nil
+	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.DialContext = dialer.DialContext
+	return tr
+}
+
+// isBlockedIP reports whether ip is in a range a push notification must not
+// reach: loopback, RFC 1918 / RFC 4193 private, link-local, unspecified or
+// multicast. This covers cloud metadata endpoints (169.254.169.254) and
+// internal services (127.0.0.1, 10/8, 172.16/12, 192.168/16).
+func isBlockedIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast()
+}
+
+// limitPushRedirects bounds the redirect chain; the per-dial IP guard already
+// validates the resolved address of every hop.
+func limitPushRedirects(_ *http.Request, via []*http.Request) error {
+	if len(via) >= maxPushRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxPushRedirects)
+	}
+	return nil
 }
 
 // SendPush serializes the task to JSON and sends it as an HTTP POST request

--- a/a2asrv/push/sender.go
+++ b/a2asrv/push/sender.go
@@ -77,9 +77,12 @@ func NewHTTPPushSender(config *HTTPSenderConfig) *HTTPPushSender {
 		allowPrivate = config.AllowPrivateNetworks
 	}
 	client := &http.Client{Timeout: t}
+	// Bound the redirect chain and strip the token on cross-host redirects
+	// regardless of the IP guard; AllowPrivateNetworks only relaxes the
+	// resolved-IP range check, not redirect safety.
+	client.CheckRedirect = limitPushRedirects
 	if !allowPrivate {
 		client.Transport = ssrfGuardedTransport()
-		client.CheckRedirect = limitPushRedirects
 	}
 	return &HTTPPushSender{
 		client:      client,
@@ -107,9 +110,21 @@ func ssrfGuardedTransport() *http.Transport {
 		}
 		return nil
 	}
-	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.DialContext = dialer.DialContext
-	return tr
+	// Build a fresh transport rather than cloning http.DefaultTransport: a
+	// clone could inherit a DialTLS/DialTLSContext that HTTPS uses instead of
+	// DialContext (bypassing the guard), and a replaced DefaultTransport would
+	// panic a type assertion. With only DialContext set, both HTTP and HTTPS
+	// dial through the guard and then perform TLS normally. The non-dial fields
+	// mirror http.DefaultTransport.
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 }
 
 // isBlockedIP reports whether ip is in a range a push notification must not
@@ -126,10 +141,15 @@ func isBlockedIP(ip net.IP) bool {
 }
 
 // limitPushRedirects bounds the redirect chain; the per-dial IP guard already
-// validates the resolved address of every hop.
-func limitPushRedirects(_ *http.Request, via []*http.Request) error {
+// validates the resolved address of every hop. It also drops the notification
+// token on cross-host redirects: Go strips Authorization on such redirects but
+// not custom headers, so the token could otherwise leak to a different host.
+func limitPushRedirects(req *http.Request, via []*http.Request) error {
 	if len(via) >= maxPushRedirects {
 		return fmt.Errorf("stopped after %d redirects", maxPushRedirects)
+	}
+	if len(via) > 0 && req.URL.Host != via[len(via)-1].URL.Host {
+		req.Header.Del(tokenHeader)
 	}
 	return nil
 }

--- a/a2asrv/push/sender_test.go
+++ b/a2asrv/push/sender_test.go
@@ -282,6 +282,7 @@ func TestHTTPPushSender_SSRFProtection(t *testing.T) {
 	t.Run("blocks private and loopback targets by default", func(t *testing.T) {
 		blocked := []string{
 			"http://127.0.0.1:8080/webhook",            // IPv4 loopback
+			"https://127.0.0.1:8443/webhook",           // HTTPS also dials through the guard
 			"http://localhost:8080/webhook",            // loopback by name
 			"http://[::1]:8080/webhook",                // IPv6 loopback
 			"http://169.254.169.254/latest/meta-data/", // cloud metadata (link-local)
@@ -323,6 +324,36 @@ func TestHTTPPushSender_SSRFProtection(t *testing.T) {
 		}
 		if !delivered {
 			t.Error("push was not delivered to the local server despite AllowPrivateNetworks")
+		}
+	})
+
+	t.Run("strips notification token on cross-host redirect", func(t *testing.T) {
+		var finalToken string
+		var finalReached bool
+		finalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			finalReached = true
+			finalToken = r.Header.Get(tokenHeader)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer finalServer.Close()
+
+		redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, finalServer.URL, http.StatusTemporaryRedirect)
+		}))
+		defer redirectServer.Close()
+
+		// AllowPrivateNetworks lets the loopback hops through; redirect hygiene
+		// (token stripping across hosts) still applies.
+		sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true, AllowPrivateNetworks: true})
+		config := &a2a.PushConfig{URL: redirectServer.URL, Token: "secret-token"}
+		if err := sender.SendPush(ctx, config, event); err != nil {
+			t.Fatalf("SendPush() across redirect failed: %v", err)
+		}
+		if !finalReached {
+			t.Fatal("redirect target was not reached")
+		}
+		if finalToken != "" {
+			t.Errorf("notification token leaked to a different host on redirect: %q, want empty", finalToken)
 		}
 	})
 }

--- a/a2asrv/push/sender_test.go
+++ b/a2asrv/push/sender_test.go
@@ -101,7 +101,7 @@ func TestHTTPPushSender_SendPushSuccess(t *testing.T) {
 	for _, tt := range tc {
 		t.Run(tt.name+" success with token", func(t *testing.T) {
 			config := &a2a.PushConfig{URL: server.URL, Token: "test-token"}
-			sender := NewHTTPPushSender(nil)
+			sender := NewHTTPPushSender(&HTTPSenderConfig{AllowPrivateNetworks: true})
 
 			err := sender.SendPush(ctx, config, tt.event)
 			if err != nil {
@@ -126,7 +126,7 @@ func TestHTTPPushSender_SendPushSuccess(t *testing.T) {
 					Credentials: "my-bearer-token",
 				},
 			}
-			sender := NewHTTPPushSender(nil)
+			sender := NewHTTPPushSender(&HTTPSenderConfig{AllowPrivateNetworks: true})
 
 			err := sender.SendPush(ctx, config, tt.event)
 			if err != nil {
@@ -140,7 +140,7 @@ func TestHTTPPushSender_SendPushSuccess(t *testing.T) {
 
 		t.Run(tt.name+" success with basic auth", func(t *testing.T) {
 			config := &a2a.PushConfig{URL: server.URL, Auth: &a2a.PushAuthInfo{Scheme: "Basic", Credentials: "dXNlcjpwYXNz"}}
-			sender := NewHTTPPushSender(nil)
+			sender := NewHTTPPushSender(&HTTPSenderConfig{AllowPrivateNetworks: true})
 
 			err := sender.SendPush(ctx, config, tt.event)
 			if err != nil {
@@ -154,7 +154,7 @@ func TestHTTPPushSender_SendPushSuccess(t *testing.T) {
 
 		t.Run(tt.name+" success without token", func(t *testing.T) {
 			config := &a2a.PushConfig{URL: server.URL}
-			sender := NewHTTPPushSender(nil)
+			sender := NewHTTPPushSender(&HTTPSenderConfig{AllowPrivateNetworks: true})
 
 			err := sender.SendPush(ctx, config, tt.event)
 			if err != nil {
@@ -229,7 +229,7 @@ func TestHTTPPushSender_SendPushError(t *testing.T) {
 				name = tc.name + " (fail on error)"
 			}
 			t.Run(name, func(t *testing.T) {
-				sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: failOnError})
+				sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: failOnError, AllowPrivateNetworks: true})
 				for _, event := range tc.event {
 					err := sender.SendPush(ctx, tc.config, event)
 					if failOnError {
@@ -257,7 +257,7 @@ func TestHTTPPushSender_SendPushError(t *testing.T) {
 		cancel()
 
 		config := &a2a.PushConfig{URL: slowServer.URL}
-		sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true})
+		sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true, AllowPrivateNetworks: true})
 
 		for _, event := range events {
 			err := sender.SendPush(canceledCtx, config, event)
@@ -266,11 +266,63 @@ func TestHTTPPushSender_SendPushError(t *testing.T) {
 			}
 		}
 
-		sender = NewHTTPPushSender(nil)
+		sender = NewHTTPPushSender(&HTTPSenderConfig{AllowPrivateNetworks: true})
 		for _, event := range events {
 			if err := sender.SendPush(canceledCtx, config, event); err != nil {
 				t.Errorf("SendPush() error = %v, want nil when FailOnError false", err)
 			}
+		}
+	})
+}
+
+func TestHTTPPushSender_SSRFProtection(t *testing.T) {
+	ctx := context.Background()
+	event := &a2a.Task{ID: "test-task", ContextID: "test-context"}
+
+	t.Run("blocks private and loopback targets by default", func(t *testing.T) {
+		blocked := []string{
+			"http://127.0.0.1:8080/webhook",            // IPv4 loopback
+			"http://localhost:8080/webhook",            // loopback by name
+			"http://[::1]:8080/webhook",                // IPv6 loopback
+			"http://169.254.169.254/latest/meta-data/", // cloud metadata (link-local)
+			"http://10.0.0.5/webhook",                  // RFC 1918
+			"http://192.168.1.10/webhook",              // RFC 1918
+			"http://0.0.0.0:8080/webhook",              // unspecified
+		}
+		sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true})
+		for _, url := range blocked {
+			err := sender.SendPush(ctx, &a2a.PushConfig{URL: url}, event)
+			if err == nil {
+				t.Errorf("SendPush(%q) = nil, want an SSRF block error", url)
+				continue
+			}
+			if !strings.Contains(err.Error(), "blocked address range") {
+				t.Errorf("SendPush(%q) error = %v, want a blocked-address-range error", url, err)
+			}
+		}
+	})
+
+	t.Run("does not cancel execution when FailOnError is false", func(t *testing.T) {
+		sender := NewHTTPPushSender(nil) // guard on, FailOnError off
+		if err := sender.SendPush(ctx, &a2a.PushConfig{URL: "http://127.0.0.1:8080/"}, event); err != nil {
+			t.Errorf("SendPush() = %v, want nil when FailOnError is false", err)
+		}
+	})
+
+	t.Run("AllowPrivateNetworks opts out of the guard", func(t *testing.T) {
+		delivered := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			delivered = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true, AllowPrivateNetworks: true})
+		if err := sender.SendPush(ctx, &a2a.PushConfig{URL: server.URL}, event); err != nil {
+			t.Fatalf("SendPush() with AllowPrivateNetworks failed: %v", err)
+		}
+		if !delivered {
+			t.Error("push was not delivered to the local server despite AllowPrivateNetworks")
 		}
 	})
 }

--- a/internal/testutil/push_sender.go
+++ b/internal/testutil/push_sender.go
@@ -56,7 +56,9 @@ func (m *TestPushSender) SetSendPushError(err error) *TestPushSender {
 // NewTestPushSender creates a new TestPushSender.
 func NewTestPushSender(t *testing.T) *TestPushSender {
 	return &TestPushSender{
-		HTTPPushSender: push.NewHTTPPushSender(nil),
+		// Test push targets are loopback httptest servers, so opt out of the
+		// default SSRF guard that would otherwise reject them.
+		HTTPPushSender: push.NewHTTPPushSender(&push.HTTPSenderConfig{AllowPrivateNetworks: true}),
 
 		PushedEvents:  make([]a2a.Event, 0),
 		PushedConfigs: make([]*a2a.PushConfig, 0),

--- a/itk/main.go
+++ b/itk/main.go
@@ -497,7 +497,9 @@ func run() error {
 	}
 
 	pushStore := push.NewInMemoryStore()
-	pushSender := push.NewHTTPPushSender(nil)
+	// The ITK harness delivers to loopback notification servers, so it opts out
+	// of the default SSRF guard that rejects loopback and private targets.
+	pushSender := push.NewHTTPPushSender(&push.HTTPSenderConfig{AllowPrivateNetworks: true})
 
 	executor := &V10AgentExecutor{}
 	requestHandler := a2asrv.NewHandler(


### PR DESCRIPTION
## Problem

`a2asrv/push` accepts a client-supplied `PushConfig.URL` and POSTs to it after only a **syntactic** URL check (`validateConfig` in `store.go` uses `url.ParseRequestURI`). Per A2A spec 13.2 the agent (webhook caller) is responsible for SSRF validation, but a2a-go does none: a client of a push-enabled agent can make the agent issue server-side POSTs to internal addresses it cannot reach itself (SSRF, CWE-918). Today `http://169.254.169.254/latest/meta-data/` (cloud metadata) and `http://127.0.0.1:8080/` both pass. The sender's `http.Client` also has no `CheckRedirect`, so a URL that passes a naive check can 307-redirect to an internal address and the sender follows it (POST + body preserved).

Fixes #373.

## Fix

Harden the push sender's HTTP client (`NewHTTPPushSender`) by default:

- **Resolved-IP guard at dial time.** The transport validates the resolved IP of every connection via `net.Dialer.Control`, rejecting loopback, RFC 1918 / RFC 4193 private, link-local (covers `169.254.169.254`), unspecified and multicast ranges. Because the check runs at dial time it also covers DNS-rebinding targets and redirect hops (each hop re-dials), which a URL-string check alone cannot catch.
- **`CheckRedirect`** bounds the redirect chain.
- **Secure by default, with an explicit opt-out.** New `HTTPSenderConfig.AllowPrivateNetworks` (default `false`) lets trusted internal deployments (same-host or private-network webhooks) opt out.

The guard lives in the sender because that is where a2a-go actually issues the request; a store-level string check alone cannot defeat DNS rebinding or redirects.

## Tests

- New `TestHTTPPushSender_SSRFProtection`: the default sender blocks loopback (v4 and v6), `localhost`, the cloud-metadata endpoint, RFC 1918 and unspecified targets; respects `FailOnError`; and `AllowPrivateNetworks` opts out and delivers to a local server.
- Existing tests that deliver to `httptest` (loopback) servers now set `AllowPrivateNetworks: true`, making their local-delivery intent explicit.
- Verified locally: `go build ./...`, `go vet`, `gofmt`, and `go test ./a2asrv/...` all green.
