### PR TITLE
feat(a2aext/trace): W3C traceparent-based audit trail with MCP bridge hooks

### DIFF
--- a/a2aext/trace/client.go
+++ b/a2aext/trace/client.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+)
+
+// ClientConfig configures the client-side trace interceptor.
+type ClientConfig struct {
+	// AgentID is the identifier injected into spans created by this interceptor.
+	AgentID string
+
+	// Logger receives span propagation events. If nil, slog.Default() is used.
+	Logger *slog.Logger
+}
+
+// NewClientInterceptor returns a client interceptor that propagates W3C trace
+// context to outgoing A2A calls. If a parent [TraceSpan] is present in the
+// context, a child span is created and propagated. Otherwise, a new root span
+// is created.
+//
+// The trace context is sent as a W3C traceparent header via ServiceParams.
+//
+// Usage:
+//
+//	client, err := a2aclient.NewFromCard(ctx, card,
+//	    a2aclient.WithCallInterceptors(trace.NewClientInterceptor(trace.ClientConfig{
+//	        AgentID: "sg-architect",
+//	    })),
+//	)
+func NewClientInterceptor(cfg ClientConfig) a2aclient.CallInterceptor {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &clientInterceptor{cfg: cfg}
+}
+
+type clientInterceptor struct {
+	a2aclient.PassthroughInterceptor
+	cfg ClientConfig
+}
+
+func (c *clientInterceptor) Before(ctx context.Context, req *a2aclient.Request) (context.Context, any, error) {
+	parent := SpanFrom(ctx)
+
+	var span *TraceSpan
+	if parent != nil {
+		span = NewChildSpan(parent, c.cfg.AgentID, "", "")
+		c.cfg.Logger.DebugContext(ctx, "trace: child span propagated",
+			"trace_id", span.TraceID,
+			"span_id", span.SpanID,
+			"parent_span_id", span.ParentSpanID,
+		)
+	} else {
+		span = NewRootSpan(c.cfg.AgentID, "", "")
+		c.cfg.Logger.DebugContext(ctx, "trace: root span propagated",
+			"trace_id", span.TraceID,
+			"span_id", span.SpanID,
+		)
+	}
+
+	req.ServiceParams.Append(SvcParamTrace, span.EncodeTraceparent())
+	return WithSpan(ctx, span), nil, nil
+}
+
+// ServerConfig configures the server-side trace interceptor.
+type ServerConfig struct {
+	// AgentID is the identifier injected into every span created by this server.
+	// If empty, the interceptor is a no-op.
+	AgentID string
+
+	// Logger receives span creation events. If nil, slog.Default() is used.
+	Logger *slog.Logger
+}
+
+// NewServerInterceptor returns a server interceptor that creates a new
+// [TraceSpan] for every incoming A2A call. The span is attached to the context
+// and can be retrieved by downstream interceptors or executors via [SpanFrom].
+//
+// The interceptor reads the W3C traceparent from ServiceParams and creates
+// a child span linked to the caller's span.
+//
+// Usage:
+//
+//	handler := a2asrv.NewHandler(executor,
+//	    a2asrv.WithCallInterceptors(trace.NewServerInterceptor(trace.ServerConfig{
+//	        AgentID: "do-developer",
+//	    })),
+//	)
+func NewServerInterceptor(cfg ServerConfig) a2asrv.CallInterceptor {
+	if cfg.AgentID == "" {
+		return a2asrv.PassthroughCallInterceptor{}
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	return &serverInterceptor{cfg: cfg}
+}
+
+type serverInterceptor struct {
+	a2asrv.PassthroughCallInterceptor
+	cfg ServerConfig
+}
+
+func (s *serverInterceptor) Before(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) (context.Context, any, error) {
+	taskID, contextID := extractTaskInfo(req.Payload)
+	headerValue := s.readTraceHeader(callCtx)
+
+	var span *TraceSpan
+	if parent := ParseTraceHeader(headerValue); parent != nil {
+		span = NewChildSpan(parent, s.cfg.AgentID, taskID, contextID)
+	} else {
+		span = NewRootSpan(s.cfg.AgentID, taskID, contextID)
+	}
+	s.cfg.Logger.DebugContext(ctx, "trace: span created",
+		"trace_id", span.TraceID,
+		"span_id", span.SpanID,
+		"agent", span.AgentID,
+	)
+	return WithSpan(ctx, span), nil, nil
+}
+
+// readTraceHeader reads the trace context from the incoming call.
+func (s *serverInterceptor) readTraceHeader(callCtx *a2asrv.CallContext) string {
+	values, ok := callCtx.ServiceParams().Get(SvcParamTrace)
+	if !ok || len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func extractTaskInfo(payload any) (taskID, contextID string) {
+	if provider, ok := payload.(a2a.TaskInfoProvider); ok {
+		info := provider.TaskInfo()
+		return string(info.TaskID), info.ContextID
+	}
+	return "", ""
+}
+
+// BridgeToMCP extracts the current trace context for injection into
+// an MCP tools/call request's params._meta. Returns nil if no span
+// is present in the context.
+//
+// Usage:
+//
+//	if tc := trace.BridgeToMCP(ctx); tc != nil {
+//	    mcpReq.Params.Meta["traceparent"] = tc["traceparent"]
+//	}
+func BridgeToMCP(ctx context.Context) map[string]string {
+	span := SpanFrom(ctx)
+	if span == nil {
+		return nil
+	}
+	return map[string]string{
+		"traceparent": span.EncodeTraceparent(),
+	}
+}
+
+// BridgeFromMCP creates a span from an MCP traceparent and attaches
+// it to the context. Returns the new context with the span attached.
+//
+// Usage:
+//
+//	if tp, ok := mcpReq.Params.Meta["traceparent"]; ok {
+//	    ctx = trace.BridgeFromMCP(ctx, tp.(string), "agent-id")
+//	}
+func BridgeFromMCP(ctx context.Context, traceparent, agentID string) context.Context {
+	parent, err := ParseTraceparent(traceparent)
+	if err != nil {
+		// Malformed or absent traceparent — start a new root span
+		span := NewRootSpan(agentID, "", "")
+		return WithSpan(ctx, span)
+	}
+	span := NewChildSpan(parent, agentID, "", "")
+	return WithSpan(ctx, span)
+}

--- a/a2aext/trace/context.go
+++ b/a2aext/trace/context.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// spanCtxKey is the context key for [TraceSpan].
+type spanCtxKey struct{}
+
+// SpanFrom extracts the current trace span from the context.
+// Returns nil if no span is present.
+func SpanFrom(ctx context.Context) *TraceSpan {
+	span, ok := ctx.Value(spanCtxKey{}).(*TraceSpan)
+	if !ok {
+		return nil
+	}
+	return span
+}
+
+// WithSpan attaches a [TraceSpan] to the context.
+func WithSpan(ctx context.Context, span *TraceSpan) context.Context {
+	return context.WithValue(ctx, spanCtxKey{}, span)
+}
+
+// TraceSpan records a single step in a cross-agent task chain.
+//
+// A span is created by a [ServerInterceptor] when an A2A call arrives.
+// The [ClientInterceptor] reads the span and links it as the parent
+// of any further outgoing calls.
+type TraceSpan struct {
+	// TraceID identifies the end-to-end delegation chain.
+	// All spans within the same chain share the same TraceID.
+	// Format: 32 hex characters (16 bytes), per W3C Trace Context.
+	TraceID string
+
+	// SpanID is a unique identifier for this individual call.
+	// Format: 16 hex characters (8 bytes), per W3C Trace Context.
+	SpanID string
+
+	// ParentSpanID is the SpanID of the calling agent's span,
+	// or empty if this is the root of the chain.
+	ParentSpanID string
+
+	// AgentID identifies the agent that handled this call.
+	AgentID string
+
+	// TaskID is the A2A task identifier associated with this call.
+	// Child spans inherit their parent's TaskID by default.
+	TaskID string
+
+	// ContextID is the A2A context identifier grouping related interactions.
+	// Child spans inherit their parent's ContextID by default.
+	ContextID string
+
+	// Timestamp records when this span was created.
+	Timestamp time.Time
+}
+
+// NewRootSpan creates a root span with a new TraceID and no parent.
+// TraceID is 32 hex chars (16 bytes); SpanID is 16 hex chars (8 bytes).
+func NewRootSpan(agentID, taskID, contextID string) *TraceSpan {
+	return &TraceSpan{
+		TraceID:      newID(16),
+		SpanID:       newID(8),
+		ParentSpanID: "",
+		AgentID:      agentID,
+		TaskID:       taskID,
+		ContextID:    contextID,
+		Timestamp:    time.Now(),
+	}
+}
+
+// NewChildSpan creates a child span inheriting the parent's TraceID.
+// TaskID and ContextID default to the parent's values if empty.
+func NewChildSpan(parent *TraceSpan, agentID, taskID, contextID string) *TraceSpan {
+	if taskID == "" {
+		taskID = parent.TaskID
+	}
+	if contextID == "" {
+		contextID = parent.ContextID
+	}
+	return &TraceSpan{
+		TraceID:      parent.TraceID,
+		SpanID:       newID(8),
+		ParentSpanID: parent.SpanID,
+		AgentID:      agentID,
+		TaskID:       taskID,
+		ContextID:    contextID,
+		Timestamp:    time.Now(),
+	}
+}
+
+// Chain returns this span's position in the delegation chain.
+// Format: "agentID:spanID", e.g., "research-agent:b7ad6b7169203331".
+// This is the span's unique identity — call it for each span in the chain
+// to reconstruct the full delegation path.
+func (s *TraceSpan) Chain() string {
+	return fmt.Sprintf("%s:%s", s.AgentID, s.SpanID)
+}
+
+// String returns a compact representation suitable for log lines.
+func (s *TraceSpan) String() string {
+	if s.ParentSpanID == "" {
+		return fmt.Sprintf("[trace=%s span=%s agent=%s task=%s]", s.TraceID, s.SpanID, s.AgentID, s.TaskID)
+	}
+	return fmt.Sprintf("[trace=%s span=%s parent=%s agent=%s task=%s]", s.TraceID, s.SpanID, s.ParentSpanID, s.AgentID, s.TaskID)
+}
+
+// newID generates a random hex string with n bytes of entropy.
+func newID(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("trace: failed to read random bytes: %v", err))
+	}
+	return hex.EncodeToString(b)
+}

--- a/a2aext/trace/doc.go
+++ b/a2aext/trace/doc.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package trace provides a W3C Trace Context audit trail for A2A task chains.
+//
+// When Agent A delegates to Agent B, trace attaches a span to the outgoing
+// call and records a span on the incoming side. The result is a causal chain
+// that can be collected and queried for post-hoc audit.
+//
+// # Design
+//
+// A [ServerInterceptor] (callee) creates a new span for every inbound A2A
+// call. A [ClientInterceptor] (caller) reads the current span and propagates
+// it as the parent to outgoing calls via the W3C traceparent format.
+//
+// Multiple hops form a linked chain:
+//
+//	Agent A  ──call──►  Agent B  ──call──►  Agent C
+//	span₀               span₁(parent=₀)      span₂(parent=₁)
+//
+// # W3C Trace Context
+//
+// Trace context is encoded as a standard W3C traceparent header
+// (https://www.w3.org/TR/trace-context/):
+//
+//	version-trace_id-span_id-flags
+//
+// Example: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+//
+// This enables interoperability with OpenTelemetry, MCP trace context,
+// and any W3C-compliant observability stack.
+//
+// # Cross-Protocol Bridge
+//
+// The package provides [BridgeToMCP] and [BridgeFromMCP] hooks for
+// propagating trace context between A2A and MCP tool calls. See the
+// cross-protocol bridge spec at deeparchi-ai/macs for details.
+//
+// # Relationship to a2aext propagator
+//
+// The a2aext propagator carries extension metadata; trace carries task-level
+// provenance. They share complementary roles and can coexist without
+// interference.
+package trace

--- a/a2aext/trace/trace_test.go
+++ b/a2aext/trace/trace_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+)
+
+func TestNewRootSpan(t *testing.T) {
+	span := NewRootSpan("agent-a", "task-1", "ctx-1")
+	if span.TraceID == "" {
+		t.Error("TraceID must not be empty")
+	}
+	if len(span.TraceID) != 32 {
+		t.Errorf("TraceID must be 32 hex chars, got %d", len(span.TraceID))
+	}
+	if span.SpanID == "" {
+		t.Error("SpanID must not be empty")
+	}
+	if len(span.SpanID) != 16 {
+		t.Errorf("SpanID must be 16 hex chars, got %d", len(span.SpanID))
+	}
+	if span.ParentSpanID != "" {
+		t.Error("root span must have no parent")
+	}
+	if span.AgentID != "agent-a" {
+		t.Errorf("AgentID = %q, want %q", span.AgentID, "agent-a")
+	}
+}
+
+func TestNewChildSpan_Inheritance(t *testing.T) {
+	parent := NewRootSpan("agent-a", "task-1", "ctx-1")
+	// Child with empty taskID/contextID — should inherit from parent
+	child := NewChildSpan(parent, "agent-b", "", "")
+	if child.TraceID != parent.TraceID {
+		t.Error("child must share parent TraceID")
+	}
+	if child.SpanID == parent.SpanID {
+		t.Error("child must have unique SpanID")
+	}
+	if child.ParentSpanID != parent.SpanID {
+		t.Errorf("child ParentSpanID = %q, want parent SpanID = %q", child.ParentSpanID, parent.SpanID)
+	}
+	if child.TaskID != parent.TaskID {
+		t.Error("child must inherit parent TaskID when empty")
+	}
+	if child.ContextID != parent.ContextID {
+		t.Error("child must inherit parent ContextID when empty")
+	}
+}
+
+func TestNewChildSpan_Override(t *testing.T) {
+	parent := NewRootSpan("agent-a", "task-1", "ctx-1")
+	child := NewChildSpan(parent, "agent-b", "task-2", "ctx-2")
+	if child.TaskID != "task-2" {
+		t.Error("child must use explicit TaskID when provided")
+	}
+	if child.ContextID != "ctx-2" {
+		t.Error("child must use explicit ContextID when provided")
+	}
+}
+
+func TestEncodeTraceparent(t *testing.T) {
+	span := &TraceSpan{
+		TraceID: "0af7651916cd43dd8448eb211c80319c",
+		SpanID:  "b7ad6b7169203331",
+	}
+	got := span.EncodeTraceparent()
+	want := "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	if got != want {
+		t.Errorf("EncodeTraceparent() = %q, want %q", got, want)
+	}
+}
+
+func TestParseTraceparent_Valid(t *testing.T) {
+	header := "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	span, err := ParseTraceparent(header)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if span.TraceID != "0af7651916cd43dd8448eb211c80319c" {
+		t.Errorf("TraceID = %q, want %q", span.TraceID, "0af7651916cd43dd8448eb211c80319c")
+	}
+	if span.SpanID != "b7ad6b7169203331" {
+		t.Errorf("SpanID = %q, want %q", span.SpanID, "b7ad6b7169203331")
+	}
+}
+
+func TestParseTraceparent_Invalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{"empty", ""},
+		{"too few parts", "00-abc-def"},
+		{"bad version", "ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"},
+		{"short traceID", "00-abc-b7ad6b7169203331-01"},
+		{"short spanID", "00-0af7651916cd43dd8448eb211c80319c-abc-01"},
+		{"non-hex traceID", "00-ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ-b7ad6b7169203331-01"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseTraceparent(tt.header)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseTraceHeader_W3C(t *testing.T) {
+	// W3C format
+	header := "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	span := ParseTraceHeader(header)
+	if span == nil {
+		t.Fatal("expected span from W3C traceparent")
+	}
+	if span.TraceID != "0af7651916cd43dd8448eb211c80319c" {
+		t.Errorf("TraceID = %q", span.TraceID)
+	}
+}
+
+func TestParseTraceHeader_Legacy(t *testing.T) {
+	// Legacy semicolon format
+	header := "0af7651916cd43dd8448eb211c80319c;b7ad6b7169203331;aaaaaaaaaaaaaaaa;agent-a"
+	span := ParseTraceHeader(header)
+	if span == nil {
+		t.Fatal("expected span from legacy format")
+	}
+	if span.TraceID != "0af7651916cd43dd8448eb211c80319c" {
+		t.Errorf("TraceID = %q", span.TraceID)
+	}
+}
+
+func TestParseTraceHeader_Empty(t *testing.T) {
+	span := ParseTraceHeader("")
+	if span != nil {
+		t.Error("expected nil for empty header")
+	}
+}
+
+func TestThreeHopChain(t *testing.T) {
+	// Agent A creates root span
+	root := NewRootSpan("agent-a", "task-1", "ctx-1")
+	traceparentA := root.EncodeTraceparent()
+
+	// Agent B receives and creates child (TaskID/ContextID from A2A payload)
+	parentB := ParseTraceHeader(traceparentA)
+	childB := NewChildSpan(parentB, "agent-b", "task-1", "ctx-1")
+	traceparentB := childB.EncodeTraceparent()
+
+	// Agent C receives and creates child (TaskID/ContextID from A2A payload)
+	parentC := ParseTraceHeader(traceparentB)
+	childC := NewChildSpan(parentC, "agent-c", "task-1", "ctx-1")
+
+	// Verify chain
+	if childC.TraceID != root.TraceID {
+		t.Error("all spans must share same TraceID")
+	}
+	if childC.ParentSpanID != childB.SpanID {
+		t.Error("C's parent must be B")
+	}
+	if childB.ParentSpanID != root.SpanID {
+		t.Error("B's parent must be root")
+	}
+	// Verify explicit TaskID/ContextID (from A2A payload, not traceparent)
+	if childC.TaskID != "task-1" {
+		t.Errorf("C TaskID = %q, want task-1", childC.TaskID)
+	}
+	if childC.ContextID != "ctx-1" {
+		t.Errorf("C ContextID = %q, want ctx-1", childC.ContextID)
+	}
+}
+
+func TestChain(t *testing.T) {
+	span := NewRootSpan("research-agent", "task-1", "")
+	got := span.Chain()
+	if !strings.Contains(got, "research-agent:") {
+		t.Errorf("Chain() = %q, want agent:span format", got)
+	}
+}
+
+func TestSpanFrom_WithSpan(t *testing.T) {
+	ctx := context.Background()
+	if SpanFrom(ctx) != nil {
+		t.Error("SpanFrom on empty context should return nil")
+	}
+	span := NewRootSpan("agent-a", "", "")
+	ctx = WithSpan(ctx, span)
+	got := SpanFrom(ctx)
+	if got == nil {
+		t.Fatal("SpanFrom should return the span")
+	}
+	if got.SpanID != span.SpanID {
+		t.Error("SpanFrom returned wrong span")
+	}
+}
+
+func TestBridgeToMCP(t *testing.T) {
+	ctx := context.Background()
+	// No span → nil
+	if tc := BridgeToMCP(ctx); tc != nil {
+		t.Error("BridgeToMCP without span should return nil")
+	}
+	// With span → traceparent map
+	span := NewRootSpan("agent-a", "task-1", "ctx-1")
+	ctx = WithSpan(ctx, span)
+	tc := BridgeToMCP(ctx)
+	if tc == nil {
+		t.Fatal("BridgeToMCP should return non-nil")
+	}
+	if tc["traceparent"] == "" {
+		t.Error("BridgeToMCP must return traceparent")
+	}
+}
+
+func TestBridgeFromMCP(t *testing.T) {
+	ctx := context.Background()
+	// Valid traceparent
+	tp := "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+	ctx = BridgeFromMCP(ctx, tp, "agent-b")
+	span := SpanFrom(ctx)
+	if span == nil {
+		t.Fatal("BridgeFromMCP should attach a span")
+	}
+	if span.TraceID != "0af7651916cd43dd8448eb211c80319c" {
+		t.Errorf("TraceID = %q, want %q", span.TraceID, "0af7651916cd43dd8448eb211c80319c")
+	}
+	if span.AgentID != "agent-b" {
+		t.Errorf("AgentID = %q, want %q", span.AgentID, "agent-b")
+	}
+	// Malformed traceparent → new root span
+	ctx2 := BridgeFromMCP(context.Background(), "garbage", "agent-c")
+	span2 := SpanFrom(ctx2)
+	if span2 == nil {
+		t.Fatal("BridgeFromMCP should create root span on malformed input")
+	}
+	if span2.ParentSpanID != "" {
+		t.Error("malformed input should produce root span (no parent)")
+	}
+}
+
+func TestEncode(t *testing.T) {
+	span := &TraceSpan{
+		TraceID: "0af7651916cd43dd8448eb211c80319c",
+		SpanID:  "b7ad6b7169203331",
+	}
+	// Encode() should produce W3C traceparent
+	got := span.Encode()
+	if !strings.HasPrefix(got, "00-") {
+		t.Errorf("Encode() should produce W3C traceparent, got %q", got)
+	}
+}
+
+func TestString(t *testing.T) {
+	root := NewRootSpan("agent-a", "task-1", "")
+	if !strings.Contains(root.String(), "agent-a") {
+		t.Errorf("String() = %q, want agent-a", root.String())
+	}
+	child := NewChildSpan(root, "agent-b", "", "")
+	if !strings.Contains(child.String(), "parent=") {
+		t.Errorf("child String() should include parent, got %q", child.String())
+	}
+}
+
+func TestIDCollisions(t *testing.T) {
+	ids := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		id := newID(8)
+		if ids[id] {
+			t.Fatalf("ID collision at iteration %d", i)
+		}
+		ids[id] = true
+	}
+}
+
+func TestServerInterceptor_Noop(t *testing.T) {
+	si := NewServerInterceptor(ServerConfig{}) // empty AgentID
+	if _, ok := si.(a2asrv.PassthroughCallInterceptor); !ok {
+		t.Error("server interceptor with empty AgentID should be no-op")
+	}
+}

--- a/a2aext/trace/traceparent.go
+++ b/a2aext/trace/traceparent.go
@@ -1,0 +1,151 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"fmt"
+	"strings"
+)
+
+// W3C Trace Context constants.
+const (
+	// TraceParentVersion is the current W3C traceparent version (00).
+	TraceParentVersion = "00"
+
+	// TraceFlagSampled indicates the trace is sampled for recording.
+	TraceFlagSampled = "01"
+
+	// TraceFlagNotSampled indicates the trace is not sampled.
+	TraceFlagNotSampled = "00"
+
+	// TraceIDBytes is the number of bytes in a W3C Trace ID (16 bytes → 32 hex chars).
+	TraceIDBytes = 16
+
+	// SpanIDBytes is the number of bytes in a W3C Span ID (8 bytes → 16 hex chars).
+	SpanIDBytes = 8
+)
+
+// EncodeTraceparent encodes the span as a W3C traceparent header value.
+// Format: version-trace_id-span_id-flags
+// Example: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+func (s *TraceSpan) EncodeTraceparent() string {
+	flags := TraceFlagSampled
+	return fmt.Sprintf("%s-%s-%s-%s", TraceParentVersion, s.TraceID, s.SpanID, flags)
+}
+
+// ParseTraceparent decodes a W3C traceparent header value into a partial
+// TraceSpan suitable as a parent reference.
+//
+// Returns nil, error if:
+//   - The header value is empty
+//   - The version is not "00"
+//   - The trace ID is not 32 hex chars
+//   - The span ID is not 16 hex chars
+func ParseTraceparent(val string) (*TraceSpan, error) {
+	if val == "" {
+		return nil, fmt.Errorf("trace: empty traceparent")
+	}
+	parts := strings.Split(val, "-")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("trace: invalid traceparent format: got %d parts, want 4", len(parts))
+	}
+	version, traceID, spanID, flags := parts[0], parts[1], parts[2], parts[3]
+
+	if version != TraceParentVersion {
+		return nil, fmt.Errorf("trace: unsupported traceparent version %q", version)
+	}
+	if len(traceID) != 2*TraceIDBytes {
+		return nil, fmt.Errorf("trace: trace ID must be %d hex chars, got %d", 2*TraceIDBytes, len(traceID))
+	}
+	if len(spanID) != 2*SpanIDBytes {
+		return nil, fmt.Errorf("trace: span ID must be %d hex chars, got %d", 2*SpanIDBytes, len(spanID))
+	}
+	if !isHex(traceID) {
+		return nil, fmt.Errorf("trace: trace ID contains non-hex characters")
+	}
+	if !isHex(spanID) {
+		return nil, fmt.Errorf("trace: span ID contains non-hex characters")
+	}
+
+	sampled := flags == TraceFlagSampled
+	_ = sampled // reserved for future use (sampling decisions)
+
+	return &TraceSpan{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}, nil
+}
+
+// Traceparent returns the span's traceparent string, or empty if the span
+// lacks required fields.
+func (s *TraceSpan) Traceparent() string {
+	if s.TraceID == "" || s.SpanID == "" {
+		return ""
+	}
+	return s.EncodeTraceparent()
+}
+
+func isHex(s string) bool {
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+// ServiceParams key for trace propagation.
+const (
+	// SvcParamTrace is the ServiceParams key for W3C traceparent propagation.
+	// Value is a W3C traceparent string: "00-{trace_id}-{span_id}-{flags}"
+	SvcParamTrace = "a2a-traceparent"
+)
+
+// Encode encodes the span as a ServiceParams-compatible string.
+// This is the W3C traceparent format.
+func (s *TraceSpan) Encode() string {
+	return s.EncodeTraceparent()
+}
+
+// ParseTraceHeader decodes a trace header value into a partial TraceSpan
+// suitable as a parent reference.
+//
+// Accepts both W3C traceparent (preferred) and legacy semicolon format
+// for backward compatibility.
+func ParseTraceHeader(val string) *TraceSpan {
+	// Try W3C traceparent first
+	span, err := ParseTraceparent(val)
+	if err == nil {
+		return span
+	}
+	// Fall back to legacy format: trace_id;span_id;parent_span_id;agent_id
+	parts := strings.Split(val, ";")
+	if len(parts) >= 3 && parts[0] != "" && parts[1] != "" {
+		return &TraceSpan{
+			TraceID:      parts[0],
+			SpanID:       parts[1],
+			ParentSpanID: parts[2],
+			AgentID:      optionalPart(parts, 3),
+		}
+	}
+	return nil
+}
+
+func optionalPart(parts []string, idx int) string {
+	if idx < len(parts) {
+		return parts[idx]
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Alternative/complementary implementation of #365 with three key additions:

### 1. W3C traceparent format

Uses standard W3C Trace Context encoding (`00-{trace_id}-{span_id}-{flags}`) instead of a custom semicolon format. This enables interoperability with OpenTelemetry, MCP trace context, and any W3C-compliant observability stack.

Backward-compatible: `ParseTraceHeader` accepts both W3C and legacy formats.

### 2. Review fixes from #365

- **Child span inheritance**: `NewChildSpan` now defaults to parent's TaskID/ContextID when empty
- **Validation**: `ParseTraceparent` validates non-empty hex, 32-char trace ID, 16-char span ID
- **Chain() docs**: Updated to clarify it returns the current agent:span identity

### 3. Cross-protocol bridge hooks

```go
// A2A → MCP
tc := trace.BridgeToMCP(ctx)
mcpReq.Params.Meta["traceparent"] = tc["traceparent"]

// MCP → A2A
ctx = trace.BridgeFromMCP(ctx, traceparent, agentID)
```

### Testing

20 tests, zero regressions on existing a2aext/a2asrv suites.

### Relationship to #365

This is not a replacement — it is an alternative direction. #365 got the architecture right (interceptor pattern + context propagation). This PR adds W3C format + bridge hooks + review fixes. If maintainers prefer #365's approach, the bridge hooks and review fixes can be cherry-picked onto it.

Related:
- [deeparchi-ai/macs trace-bridge spec](https://github.com/deeparchi-ai/macs/blob/main/trace-bridge/spec.md)
- [a2aproject/A2A#2026](https://github.com/a2aproject/A2A/issues/2026) (trace context proposal)