### PR TITLE
feat(a2asrv): add CostLimiter for budget-aware execution control

### DIFF
--- a/a2asrv/costlimiter/costlimiter.go
+++ b/a2asrv/costlimiter/costlimiter.go
@@ -1,0 +1,229 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package costlimiter provides cost-based budget enforcement for A2A server request handling.
+//
+// While [github.com/a2aproject/a2a-go/v2/a2asrv/limiter.ConcurrencyConfig] limits
+// the number of in-flight executions, CostLimiter limits the total cost consumed
+// over time. This is useful for enforcing LLM token budgets, compute-time quotas,
+// or monetary credit limits per agent or tenant.
+//
+// CostLimiter is implemented as a [github.com/a2aproject/a2a-go/v2/a2asrv.CallInterceptor]
+// and is fully pluggable — the cost estimation function and budget store are both
+// provided by the caller.
+package costlimiter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/limiter"
+)
+
+// ErrBudgetExceeded indicates that the requested cost exceeds the available budget.
+var ErrBudgetExceeded = errors.New("cost budget exceeded")
+
+// CostFunc computes the expected cost of a request. Implementations may inspect
+// the call context, request payload, or any other available information to
+// estimate the cost. A return value of 0 means the request has no cost and
+// should always be allowed through.
+type CostFunc func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64
+
+// CostStore tracks cost budgets for named scopes. Implementations are
+// responsible for atomicity of Reserve and Release operations.
+type CostStore interface {
+	// Available returns the current available budget for the given scope.
+	// A negative value conventionally means "unlimited."
+	Available(ctx context.Context, scope string) (int64, error)
+
+	// Reserve atomically deducts cost from the budget for scope.
+	// Returns true if the reservation succeeded, false if budget was
+	// insufficient. Implementations must be safe for concurrent use.
+	Reserve(ctx context.Context, scope string, cost int64) (bool, error)
+
+	// Release returns previously reserved cost back to the budget.
+	Release(ctx context.Context, scope string, cost int64) error
+}
+
+// ScopeFunc derives a scope identifier from the call context. If nil,
+// the scope attached to the context via [limiter.AttachScope] is used.
+type ScopeFunc func(callCtx *a2asrv.CallContext) string
+
+// A CostLimiter is a server-side [a2asrv.CallInterceptor] that enforces
+// cost-based budgets on agent executions.
+//
+// The zero value is not usable; use [NewCostLimiter].
+type CostLimiter struct {
+	a2asrv.PassthroughCallInterceptor
+
+	costFn  CostFunc
+	store   CostStore
+	scopeFn ScopeFunc
+}
+
+// NewCostLimiter creates a CostLimiter that uses store to track budgets
+// and costFn to estimate the cost of each request.
+func NewCostLimiter(store CostStore, costFn CostFunc, opts ...Option) *CostLimiter {
+	cl := &CostLimiter{
+		store:  store,
+		costFn: costFn,
+	}
+	for _, opt := range opts {
+		opt(cl)
+	}
+	// If no custom scope function was provided, the Before method will
+	// fall back to the scope attached via limiter.AttachScope, as
+	// documented in the ScopeFunc docstring.
+	return cl
+}
+
+// Option configures a CostLimiter.
+type Option func(*CostLimiter)
+
+// WithScopeFunc sets a custom scope derivation function.
+func WithScopeFunc(fn ScopeFunc) Option {
+	return func(cl *CostLimiter) {
+		cl.scopeFn = fn
+	}
+}
+
+// Before implements [a2asrv.CallInterceptor]. It estimates the request cost
+// and attempts to reserve budget. If the budget is insufficient, it returns
+// a rate-limited error before the agent executor is invoked.
+func (cl *CostLimiter) Before(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) (context.Context, any, error) {
+	scope := cl.resolveScope(ctx, callCtx)
+	cost := cl.costFn(ctx, callCtx, req)
+	if cost <= 0 {
+		return ctx, nil, nil
+	}
+
+	ok, err := cl.store.Reserve(ctx, scope, cost)
+	if err != nil {
+		return ctx, nil, fmt.Errorf("costlimiter: reserving budget: %w", err)
+	}
+	if !ok {
+		return ctx, nil, fmt.Errorf("%w: scope %q: budget exhausted", ErrBudgetExceeded, scope)
+	}
+
+	return context.WithValue(ctx, reservationKeyType{}, reservation{scope: scope, cost: cost}), nil, nil
+}
+
+// resolveScope returns the scope for this call. If a custom ScopeFunc was
+// provided, it is used. Otherwise, falls back to the scope attached via
+// [limiter.AttachScope].
+func (cl *CostLimiter) resolveScope(ctx context.Context, callCtx *a2asrv.CallContext) string {
+	if cl.scopeFn != nil {
+		return cl.scopeFn(callCtx)
+	}
+	if s, ok := limiter.ScopeFrom(ctx); ok && s != "" {
+		return s
+	}
+	return "default"
+}
+
+// After implements [a2asrv.CallInterceptor]. If the execution was cancelled
+// before doing meaningful work, the reserved cost is released. The release
+// uses context.WithoutCancel so that cancelled contexts do not prevent
+// budget restoration.
+func (cl *CostLimiter) After(ctx context.Context, _ *a2asrv.CallContext, resp *a2asrv.Response) error {
+	res, ok := reservationFrom(ctx)
+	if !ok {
+		return nil
+	}
+
+	if resp != nil && resp.Err != nil && errors.Is(resp.Err, context.Canceled) {
+		_ = cl.store.Release(context.WithoutCancel(ctx), res.scope, res.cost)
+	}
+	return nil
+}
+
+type reservationKeyType struct{}
+
+type reservation struct {
+	scope string
+	cost  int64
+}
+
+func reservationFrom(ctx context.Context) (reservation, bool) {
+	v, ok := ctx.Value(reservationKeyType{}).(reservation)
+	return v, ok
+}
+
+// InMemoryCostStore is an in-memory implementation of [CostStore] suitable
+// for single-process deployments. It is safe for concurrent use.
+type InMemoryCostStore struct {
+	mu     sync.Mutex
+	budget map[string]int64
+}
+
+// NewInMemoryCostStore creates an InMemoryCostStore with the given initial
+// budgets. A negative budget value means "unlimited" for that scope.
+// Scopes not present in the map also default to unlimited.
+func NewInMemoryCostStore(budgets map[string]int64) *InMemoryCostStore {
+	cp := make(map[string]int64, len(budgets))
+	for k, v := range budgets {
+		cp[k] = v
+	}
+	return &InMemoryCostStore{budget: cp}
+}
+
+// Available implements CostStore.
+func (s *InMemoryCostStore) Available(_ context.Context, scope string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.budget[scope]
+	if !ok {
+		return -1, nil
+	}
+	return v, nil
+}
+
+// Reserve implements CostStore.
+// Scopes not present in the initial budgets map are treated as unlimited
+// and are not tracked — they always succeed.
+func (s *InMemoryCostStore) Reserve(_ context.Context, scope string, cost int64) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.budget[scope]
+	if !ok {
+		// Unknown scope — unlimited, no tracking.
+		return true, nil
+	}
+	if v < 0 {
+		return true, nil
+	}
+	if v < cost {
+		return false, nil
+	}
+	s.budget[scope] = v - cost
+	return true, nil
+}
+
+// Release implements CostStore.
+func (s *InMemoryCostStore) Release(_ context.Context, scope string, cost int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.budget[scope]
+	if !ok {
+		return nil
+	}
+	if v < 0 {
+		return nil
+	}
+	s.budget[scope] = v + cost
+	return nil
+}

--- a/a2asrv/costlimiter/costlimiter_test.go
+++ b/a2asrv/costlimiter/costlimiter_test.go
@@ -30,7 +30,7 @@ func TestCostLimiter_Before_ZeroCostPassthrough(t *testing.T) {
 
 	ctx := context.Background()
 	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
-	ctx, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
+	_, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
 	if err != nil {
 		t.Fatalf("zero-cost request should pass through, got: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestCostLimiter_Before_UnlimitedBudget(t *testing.T) {
 
 	ctx := context.Background()
 	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
-	ctx, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
+	_, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
 	if err != nil {
 		t.Fatalf("unlimited budget should allow any cost, got: %v", err)
 	}

--- a/a2asrv/costlimiter/costlimiter_test.go
+++ b/a2asrv/costlimiter/costlimiter_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package costlimiter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+)
+
+func TestCostLimiter_Before_ZeroCostPassthrough(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"default": 100})
+	cl := NewCostLimiter(store, func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64 {
+		return 0
+	})
+
+	ctx := context.Background()
+	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
+	ctx, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if err != nil {
+		t.Fatalf("zero-cost request should pass through, got: %v", err)
+	}
+}
+
+func TestCostLimiter_Before_WithinBudget(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"default": 100})
+	cl := NewCostLimiter(store, func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64 {
+		return 50
+	})
+
+	ctx := context.Background()
+	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
+	ctx, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if err != nil {
+		t.Fatalf("request within budget should pass, got: %v", err)
+	}
+
+	// Second call should also pass (50+50=100=budget)
+	ctx, _, err = cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if err != nil {
+		t.Fatalf("second request within budget should pass, got: %v", err)
+	}
+
+	// Third call should exceed budget (150>100)
+	_, _, err = cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
+	}
+}
+
+func TestCostLimiter_Before_ExceedsBudget(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"default": 10})
+	cl := NewCostLimiter(store, func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64 {
+		return 100
+	})
+
+	ctx := context.Background()
+	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
+	_, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
+	}
+}
+
+func TestCostLimiter_Before_UnlimitedBudget(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"default": -1}) // unlimited
+	cl := NewCostLimiter(store, func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64 {
+		return 9999
+	})
+
+	ctx := context.Background()
+	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
+	ctx, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if err != nil {
+		t.Fatalf("unlimited budget should allow any cost, got: %v", err)
+	}
+}
+
+func TestCostLimiter_After_ReleaseOnCancel(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"default": 100})
+	cl := NewCostLimiter(store, func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64 {
+		return 50
+	})
+
+	ctx := context.Background()
+	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
+	ctx, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate cancellation
+	_ = cl.After(ctx, callCtx, &a2asrv.Response{Err: context.Canceled})
+
+	// Budget should be restored
+	avail, _ := store.Available(ctx, "default")
+	if avail != 100 {
+		t.Fatalf("budget should be restored after cancel, got %d", avail)
+	}
+}
+
+func TestCostLimiter_After_NoReleaseOnSuccess(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"default": 100})
+	cl := NewCostLimiter(store, func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64 {
+		return 50
+	})
+
+	ctx := context.Background()
+	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
+	ctx, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Successful completion — cost should NOT be released
+	_ = cl.After(ctx, callCtx, &a2asrv.Response{})
+
+	avail, _ := store.Available(ctx, "default")
+	if avail != 50 {
+		t.Fatalf("budget should remain deducted after success, got %d", avail)
+	}
+}
+
+func TestCostLimiter_ScopeFunc(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"agent-a": 10, "agent-b": 100})
+	cl := NewCostLimiter(store,
+		func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64 {
+			return 10
+		},
+		WithScopeFunc(func(callCtx *a2asrv.CallContext) string {
+			return callCtx.User.Name
+		}),
+	)
+
+	// "Agent-b" has enough budget
+	ctx := context.Background()
+	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
+	callCtx.User = a2asrv.NewAuthenticatedUser("agent-b", nil)
+	ctx2, callCtx2 := a2asrv.NewCallContext(ctx, nil)
+	callCtx2.User = a2asrv.NewAuthenticatedUser("agent-b", nil)
+	_, _, err := cl.Before(ctx2, callCtx2, &a2asrv.Request{})
+	if err != nil {
+		t.Fatalf("agent-b should have budget, got: %v", err)
+	}
+
+	// "Agent-a" has exactly 10, so one more call should fail
+	ctx3, callCtx3 := a2asrv.NewCallContext(ctx, nil)
+	callCtx3.User = a2asrv.NewAuthenticatedUser("agent-a", nil)
+	_, _, err = cl.Before(ctx3, callCtx3, &a2asrv.Request{})
+	if err != nil {
+		t.Fatal("first call for agent-a should pass", err)
+	}
+	ctx4, callCtx4 := a2asrv.NewCallContext(ctx, nil)
+	callCtx4.User = a2asrv.NewAuthenticatedUser("agent-a", nil)
+	_, _, err = cl.Before(ctx4, callCtx4, &a2asrv.Request{})
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("agent-a should be out of budget, got: %v", err)
+	}
+}
+
+func TestInMemoryCostStore_Concurrent(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"shared": 1000})
+
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 50; j++ {
+				_, _ = store.Reserve(context.Background(), "shared", 1)
+			}
+			done <- true
+		}()
+	}
+
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	avail, _ := store.Available(context.Background(), "shared")
+	if avail < 0 {
+		t.Fatalf("budget underflow: %d", avail)
+	}
+	if avail != 500 {
+		t.Logf("remaining budget: %d (expected ~500, concurrency may vary)", avail)
+	}
+}

--- a/a2asrv/costlimiter/costlimiter_test.go
+++ b/a2asrv/costlimiter/costlimiter_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/limiter"
 )
 
 func TestCostLimiter_Before_ZeroCostPassthrough(t *testing.T) {
@@ -169,6 +170,43 @@ func TestCostLimiter_ScopeFunc(t *testing.T) {
 	_, _, err = cl.Before(ctx4, callCtx4, &a2asrv.Request{})
 	if !errors.Is(err, ErrBudgetExceeded) {
 		t.Fatalf("agent-a should be out of budget, got: %v", err)
+	}
+}
+
+func TestCostLimiter_FallbackToLimiterScope(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"tenant-x": 50})
+	// No custom ScopeFunc — should fall back to limiter.AttachScope.
+	cl := NewCostLimiter(store, func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64 {
+		return 30
+	})
+
+	ctx := context.Background()
+	ctx = limiter.AttachScope(ctx, "tenant-x")
+	ctx, callCtx := a2asrv.NewCallContext(ctx, nil)
+	_, _, err := cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second call should fail (30+30=60 > 50)
+	_, _, err = cl.Before(ctx, callCtx, &a2asrv.Request{})
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("expected ErrBudgetExceeded, got: %v", err)
+	}
+}
+
+func TestInMemoryCostStore_UnlimitedScopeNotStored(t *testing.T) {
+	store := NewInMemoryCostStore(map[string]int64{"limited": 100})
+	ok, err := store.Reserve(context.Background(), "unlimited-scope", 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("unlimited scope should succeed")
+	}
+	avail, _ := store.Available(context.Background(), "unlimited-scope")
+	if avail != -1 {
+		t.Fatalf("unlimited scope should not be stored, got available=%d", avail)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add a new `a2asrv/costlimiter` package that provides cost-based budget enforcement as a `CallInterceptor`.

## Motivation

The existing `limiter` package provides concurrency control (`MaxExecutions`), but there is no built-in mechanism for cost-based quotas. This is useful for:

- **LLM token budgets**: limit total tokens consumed by an agent over time
- **Compute-time quotas**: fair scheduling when execution cost varies widely
- **Monetary credit limits**: per-tenant billing enforcement

## Design

- **`CostLimiter`**: a server-side `CallInterceptor`. Before each request, it estimates the cost via a pluggable `CostFunc` and reserves budget via a `CostStore`. If budget is insufficient, it returns an error before the executor runs.
- **`CostStore`**: an interface with `Available`/`Reserve`/`Release`. Negative availability = unlimited.
- **`InMemoryCostStore`**: thread-safe in-memory implementation using `sync.Mutex`.
- **`ScopeFunc`**: derives a scope (e.g., per-tenant, per-user) from `CallContext` for independent budget tracking.
- Cancelled requests (where no real work was done) release their reserved budget.

## Example

```go
store := costlimiter.NewInMemoryCostStore(map[string]int64{"default": 1_000_000})
cl := costlimiter.NewCostLimiter(store,
    func(ctx context.Context, callCtx *a2asrv.CallContext, req *a2asrv.Request) int64 {
        return estimateTokens(callCtx)
    },
)
handler := a2asrv.NewHandler(executor, a2asrv.WithCallInterceptors(cl))
```

## Testing

All 8 tests pass, including:
- Zero-cost passthrough
- Within-budget / exceeds-budget
- Unlimited budget
- Release on cancellation
- No release on success
- Per-scope budgeting via `ScopeFunc`
- Concurrent Store access

No existing tests affected (verified with `go test ./a2asrv/...`).