### PR TITLE
fix: allow empty request bodies and enable GET method for task subscriptions

### DIFF
--- a/a2aclient/rest.go
+++ b/a2aclient/rest.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"iter"
 	"net/http"
 	"net/url"
@@ -79,9 +80,15 @@ type restRequest struct {
 // It returns the HTTP response with the Body OPEN.
 // The caller is responsible for closing the response body.
 func (t *RESTTransport) sendRequest(ctx context.Context, req *restRequest) (*http.Response, error) {
-	reqBody, err := json.Marshal(req.payload)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w: %w", err, a2a.ErrInvalidRequest)
+	var bodyReader io.Reader
+	var reqBody []byte
+	if req.payload != nil {
+		var err error
+		reqBody, err = json.Marshal(req.payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request: %w: %w", err, a2a.ErrInvalidRequest)
+		}
+		bodyReader = bytes.NewReader(reqBody)
 	}
 
 	rel, err := url.Parse(req.path)
@@ -97,11 +104,13 @@ func (t *RESTTransport) sendRequest(ctx context.Context, req *restRequest) (*htt
 	}
 	u.RawQuery = rel.RawQuery
 	fullURL := u.String()
-	httpReq, err := http.NewRequestWithContext(ctx, req.method, fullURL, bytes.NewBuffer(reqBody))
+	httpReq, err := http.NewRequestWithContext(ctx, req.method, fullURL, bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
+	if len(reqBody) > 0 {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
 	if req.streaming {
 		httpReq.Header.Set("Accept", sse.ContentEventStream)
 	} else {

--- a/a2aclient/rest_test.go
+++ b/a2aclient/rest_test.go
@@ -16,6 +16,7 @@ package a2aclient
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -124,6 +125,16 @@ func TestRESTTransport_CancelTask(t *testing.T) {
 		}
 		if r.URL.Path != "/tasks/task-123:cancel" {
 			t.Errorf("expected path /tasks/task-123:cancel, got %s", r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("io.ReadAll(r.Body) error = %v, want nil", err)
+		}
+		if len(body) != 0 {
+			t.Errorf("request body = %q, want empty", string(body))
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "" {
+			t.Errorf("Content-Type = %q, want unset for empty-body request", ct)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -50,9 +50,9 @@ func NewRESTHandler(handler RequestHandler, opts ...TransportOption) http.Handle
 	// TODO: handle tenant
 	mux.HandleFunc("POST "+rest.MakeSendMessagePath(), h.handleSendMessage)
 	mux.HandleFunc("POST "+rest.MakeStreamMessagePath(), h.handleStreamMessage)
-	mux.HandleFunc("GET "+rest.MakeGetTaskPath("{id}"), h.handleGetTask)
 	mux.HandleFunc("GET "+rest.MakeListTasksPath(), h.handleListTasks)
-	mux.HandleFunc("POST /tasks/{idAndAction}", h.handlePOSTTasks)
+	mux.HandleFunc("GET /tasks/{idAndAction}", h.handleGetOrSubscribeTask)
+	mux.HandleFunc("POST /tasks/{idAndAction}", h.handleCancelOrSubscribeTask)
 	mux.HandleFunc("POST "+rest.MakeCreatePushConfigPath("{id}"), h.handleCreateTaskPushConfig)
 	mux.HandleFunc("GET "+rest.MakeGetPushConfigPath("{id}", "{configId}"), h.handleGetTaskPushConfig)
 	mux.HandleFunc("GET "+rest.MakeListPushConfigsPath("{id}"), h.handleListTaskPushConfigs)
@@ -129,9 +129,8 @@ func (h *restHandler) handleStreamMessage(rw http.ResponseWriter, req *http.Requ
 	h.handleStreamingRequest(h.handler.SendStreamingMessage(ctx, &message), rw, req)
 }
 
-func (h *restHandler) handleGetTask(rw http.ResponseWriter, req *http.Request) {
+func (h *restHandler) handleGetTask(taskID string, rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	taskID := req.PathValue("id")
 	if taskID == "" {
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
 		return
@@ -209,26 +208,38 @@ func (h *restHandler) handleListTasks(rw http.ResponseWriter, req *http.Request)
 	}
 }
 
-func (h *restHandler) handlePOSTTasks(rw http.ResponseWriter, req *http.Request) {
+func (h *restHandler) handleCancelOrSubscribeTask(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	idAndAction := req.PathValue("idAndAction")
 	if idAndAction == "" {
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
 		return
 	}
-
 	if before, ok := strings.CutSuffix(idAndAction, ":cancel"); ok {
-		taskID := before
-		h.handleCancelTask(taskID, rw, req)
-	} else if before, ok := strings.CutSuffix(idAndAction, ":subscribe"); ok {
-		taskID := before
-		req2 := &a2a.SubscribeToTaskRequest{ID: a2a.TaskID(taskID)}
-		fillTenant(ctx, &req2.Tenant)
-		h.handleStreamingRequest(h.handler.SubscribeToTask(ctx, req2), rw, req)
-	} else {
-		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
+		h.handleCancelTask(before, rw, req)
 		return
 	}
+	if before, ok := strings.CutSuffix(idAndAction, ":subscribe"); ok {
+		h.handleSubscribeToTask(before, rw, req)
+		return
+	}
+	writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
+}
+
+func (h *restHandler) handleGetOrSubscribeTask(rw http.ResponseWriter, req *http.Request) {
+	idAndAction := req.PathValue("idAndAction")
+	if before, ok := strings.CutSuffix(idAndAction, ":subscribe"); ok {
+		h.handleSubscribeToTask(before, rw, req)
+		return
+	}
+	h.handleGetTask(idAndAction, rw, req)
+}
+
+func (h *restHandler) handleSubscribeToTask(taskID string, rw http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	subReq := &a2a.SubscribeToTaskRequest{ID: a2a.TaskID(taskID)}
+	fillTenant(ctx, &subReq.Tenant)
+	h.handleStreamingRequest(h.handler.SubscribeToTask(ctx, subReq), rw, req)
 }
 
 func (h *restHandler) handleCancelTask(taskID string, rw http.ResponseWriter, req *http.Request) {

--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -237,6 +237,10 @@ func (h *restHandler) handleGetOrSubscribeTask(rw http.ResponseWriter, req *http
 
 func (h *restHandler) handleSubscribeToTask(taskID string, rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+	if taskID == "" {
+		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
+		return
+	}
 	subReq := &a2a.SubscribeToTaskRequest{ID: a2a.TaskID(taskID)}
 	fillTenant(ctx, &subReq.Tenant)
 	h.handleStreamingRequest(h.handler.SubscribeToTask(ctx, subReq), rw, req)

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -214,7 +214,7 @@ func TestREST_Validations(t *testing.T) {
 		},
 		{
 			name:    "ResubscribeToTask",
-			methods: []string{http.MethodPost},
+			methods: []string{http.MethodGet, http.MethodPost},
 			path:    "/tasks/" + string(taskID) + ":subscribe",
 		},
 		{


### PR DESCRIPTION
Fixes REST resubscribe interop with Rust v1.0 and Java v1.0 SDKs.

Rust v1.0 REST client sends GET on `/tasks/{id}:subscribe`; our server only
accepted POST, so requests were misrouted to get-task and returned
"task not found". Register both GET and POST for `:subscribe`. Same change done recently (#371) in compat layer.

Our REST client marshaled a nil payload as the JSON literal `null`, which
Java Vert.x rejects on empty-body endpoints (`:cancel`, `:subscribe`).
Send no body and no Content-Type when the payload is nil.

Closes #380 