### PR TITLE
chore(lint): enable modernize linter and apply suggested refactorings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   enable:
     - goheader
     - revive
+    - modernize
   settings:
     revive:
       rules:

--- a/a2acompat/a2av0/migration.go
+++ b/a2acompat/a2av0/migration.go
@@ -267,10 +267,7 @@ func toLegacyCallContext(ctx context.Context, v1 *a2asrv.CallContext) (context.C
 	if v1 == nil {
 		return ctx, nil
 	}
-	params := make(map[string][]string)
-	for k, v := range v1.ServiceParams().List() {
-		params[k] = v
-	}
+	params := maps.Collect(v1.ServiceParams().List())
 	legacyMeta := legacysrv.NewRequestMeta(params)
 	newCtx, legacyCallCtx := legacysrv.WithCallContext(ctx, legacyMeta)
 	if v1.User != nil {

--- a/a2acompat/a2av0/rest_compat_test.go
+++ b/a2acompat/a2av0/rest_compat_test.go
@@ -234,8 +234,8 @@ func TestREST_ServerStreamMessage(t *testing.T) {
 	var dataLine string
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "data:") {
-			dataLine = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if after, ok := strings.CutPrefix(line, "data:"); ok {
+			dataLine = strings.TrimSpace(after)
 			break
 		}
 	}

--- a/a2asrv/eventqueue/manager_in_memory_impl_test.go
+++ b/a2asrv/eventqueue/manager_in_memory_impl_test.go
@@ -73,7 +73,7 @@ func TestInMemoryManager_ConcurrentCreation(t *testing.T) {
 	numGoroutines, numTaskIDs := 100, 10
 
 	created := make(chan taskQueue, numGoroutines)
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/a2asrv/push/store_test.go
+++ b/a2asrv/push/store_test.go
@@ -384,7 +384,7 @@ func TestInMemoryPushConfigStore_ConcurrenctCreation(t *testing.T) {
 	numGoroutines := 100
 	created := make(chan *a2a.PushConfig, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/a2asrv/taskstore/inmemory.go
+++ b/a2asrv/taskstore/inmemory.go
@@ -319,7 +319,7 @@ func toListTasksResult(tasks []*storedTask, req *a2a.ListTasksRequest) ([]*a2a.T
 
 func encodePageToken(updatedTime time.Time, taskID a2a.TaskID) string {
 	timeStrNano := updatedTime.Format(time.RFC3339Nano)
-	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%s_%s", timeStrNano, taskID)))
+	return base64.URLEncoding.EncodeToString(fmt.Appendf(nil, "%s_%s", timeStrNano, taskID))
 }
 
 func decodePageToken(nextPageToken string) (time.Time, a2a.TaskID, error) {

--- a/a2asrv/taskstore/store_test.go
+++ b/a2asrv/taskstore/store_test.go
@@ -249,7 +249,7 @@ func TestInMemoryTaskStore_List_StoredImmutability(t *testing.T) {
 
 func createPageToken(updatedTime time.Time, taskID a2a.TaskID) string {
 	timeStrNano := updatedTime.Format(time.RFC3339Nano)
-	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%s_%s", timeStrNano, taskID)))
+	return base64.URLEncoding.EncodeToString(fmt.Appendf(nil, "%s_%s", timeStrNano, taskID))
 }
 
 func TestInMemoryTaskStore_List_WithFilters(t *testing.T) {


### PR DESCRIPTION
## Summary

Enable the [`modernize`](https://golangci-lint.run/docs/linters/configuration/#modernize) linter in `.golangci.yml` and apply the refactorings it suggests across the codebase.

## Changes

- **`.golangci.yml`**: enable `modernize` in the linter list; also fix missing trailing newline.
- **`a2acompat/a2av0/migration.go`**: replace manual map copy loop with `maps.Collect`.
- **`a2acompat/a2av0/rest_compat_test.go`**: replace `strings.HasPrefix` + `strings.TrimPrefix` pair with `strings.CutPrefix`.
- **`a2asrv/eventqueue/manager_in_memory_impl_test.go`** and **`a2asrv/push/store_test.go`**: replace `for i := 0; i < n; i++` with `for i := range n`.
- **`a2asrv/taskstore/inmemory.go`** and **`a2asrv/taskstore/store_test.go`**: replace `[]byte(fmt.Sprintf(...))` with `fmt.Appendf(nil, ...)`.

## Verification

- `go vet ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `go test -count=1 ./...` — all 29 packages pass