### PR TITLE
docs(security): use GitHub Security Advisories for reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+To report a security issue, please use GitHub Security Advisories:
+[Security Advisories · a2aproject/a2a-go](https://github.com/a2aproject/a2a-go/security/advisories)
+
+We use GitHub Security Advisories for private intake, coordination, and disclosure.


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` directing security reports to GitHub Security Advisories on this repository.
- Mirrors the updated policy in [`a2aproject/A2A`](https://github.com/a2aproject/A2A/blob/main/SECURITY.md), pointing to [Security Advisories · a2aproject/a2a-go](https://github.com/a2aproject/a2a-go/security/advisories).