### PR TITLE
fix(tck): advertise extended agent card support

### DIFF
--- a/e2e/tck/sut.go
+++ b/e2e/tck/sut.go
@@ -78,27 +78,7 @@ func main() {
 		preferredTransport = a2a.TransportProtocolJSONRPC
 	}
 
-	agentCard := &a2a.AgentCard{
-		Name:        "TCK Core Agent",
-		Description: "A complete A2A agent implementation designed specifically for testing with the A2A Technology Compatibility Kit (TCK)",
-		SupportedInterfaces: []*a2a.AgentInterface{
-			a2a.NewAgentInterface(cardUrl, preferredTransport),
-		},
-		Version:            "1.0.0",
-		DefaultInputModes:  []string{"text"},
-		DefaultOutputModes: []string{"text"},
-		Capabilities:       a2a.AgentCapabilities{Streaming: true},
-		// security
-		Skills: []a2a.AgentSkill{
-			{
-				ID:          "tck_core_agent",
-				Name:        "TCK Core Agent",
-				Description: "A complete A2A agent implementation designed for TCK testing",
-				Tags:        []string{"hello world", "how are you", "goodbye", "hi"},
-				Examples:    []string{"tck", "testing", "core", "complete"},
-			},
-		},
-	}
+	agentCard := newAgentCard(cardUrl, preferredTransport)
 
 	requestHandler := a2asrv.NewHandler(agentExecutor, a2asrv.WithExtendedAgentCard(agentCard), a2asrv.WithCallInterceptors(&intercepter{}))
 
@@ -113,6 +93,33 @@ func main() {
 		log.Fatalf("Server shutdown: %v", err)
 	}
 
+}
+
+func newAgentCard(cardURL string, preferredTransport a2a.TransportProtocol) *a2a.AgentCard {
+	return &a2a.AgentCard{
+		Name:        "TCK Core Agent",
+		Description: "A complete A2A agent implementation designed specifically for testing with the A2A Technology Compatibility Kit (TCK)",
+		SupportedInterfaces: []*a2a.AgentInterface{
+			a2a.NewAgentInterface(cardURL, preferredTransport),
+		},
+		Version:            "1.0.0",
+		DefaultInputModes:  []string{"text"},
+		DefaultOutputModes: []string{"text"},
+		Capabilities: a2a.AgentCapabilities{
+			Streaming:         true,
+			ExtendedAgentCard: true,
+		},
+		// security
+		Skills: []a2a.AgentSkill{
+			{
+				ID:          "tck_core_agent",
+				Name:        "TCK Core Agent",
+				Description: "A complete A2A agent implementation designed for TCK testing",
+				Tags:        []string{"hello world", "how are you", "goodbye", "hi"},
+				Examples:    []string{"tck", "testing", "core", "complete"},
+			},
+		},
+	}
 }
 
 func startGRPCServer(port int, handler a2asrv.RequestHandler) error {

--- a/e2e/tck/sut_test.go
+++ b/e2e/tck/sut_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+)
+
+func TestNewAgentCardAdvertisesExtendedCard(t *testing.T) {
+	t.Parallel()
+
+	card := newAgentCard("http://localhost:9999", a2a.TransportProtocolJSONRPC)
+
+	if !card.Capabilities.ExtendedAgentCard {
+		t.Fatal("newAgentCard().Capabilities.ExtendedAgentCard = false, want true")
+	}
+}


### PR DESCRIPTION
## Summary

- advertise extended agent card support from the TCK SUT's public agent card
- keep the public card construction in one helper so the advertised capabilities stay testable
- add regression coverage for clients that gate extended-card discovery on the public capability

Fixes #390

## Testing

- `go test ./e2e/tck`
- `go vet ./e2e/tck`
- `go test ./...` (most packages passed; the Windows run was not fully green because several temporary test binaries were denied execution and `internal/cli` requires `sh`)