### PR TITLE
fix: handle negative historyLength and sanitize push config save error

### DIFF
--- a/a2asrv/agentexec.go
+++ b/a2asrv/agentexec.go
@@ -154,7 +154,7 @@ func (f *factory) CreateExecutor(ctx context.Context, tid a2a.TaskID, params *a2
 			return nil, nil, nil, fmt.Errorf("bug: message with push config received bug push is not configured: %w", a2a.ErrPushNotificationNotSupported)
 		}
 		if _, err := f.pushConfigStore.Save(ctx, tid, params.Config.PushConfig); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to save push config %v: %w", params.Config.PushConfig, err)
+			return nil, nil, nil, fmt.Errorf("failed to save push config for task %s: %w", tid, err)
 		}
 	}
 

--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -265,9 +265,9 @@ func (h *defaultRequestHandler) GetTask(ctx context.Context, req *a2a.GetTaskReq
 	if req.HistoryLength != nil {
 		historyLength := *req.HistoryLength
 
-		if historyLength == 0 {
+		if historyLength <= 0 {
 			task.History = []*a2a.Message{}
-		} else if historyLength > 0 && historyLength < len(task.History) {
+		} else if historyLength < len(task.History) {
 			task.History = task.History[len(task.History)-historyLength:]
 		}
 	}

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -1370,7 +1370,7 @@ func TestRequestHandler_GetTask(t *testing.T) {
 		{
 			name:  "get task with negative HistoryLength",
 			query: &a2a.GetTaskRequest{ID: existingTaskID, HistoryLength: ptr(-1)},
-			want:  &a2a.Task{ID: existingTaskID, History: history},
+			want:  &a2a.Task{ID: existingTaskID, History: make([]*a2a.Message, 0)},
 		},
 	}
 

--- a/a2asrv/taskstore/inmemory.go
+++ b/a2asrv/taskstore/inmemory.go
@@ -303,9 +303,9 @@ func toListTasksResult(tasks []*storedTask, req *a2a.ListTasksRequest) ([]*a2a.T
 		if req.HistoryLength != nil {
 			historyLength = *req.HistoryLength
 		}
-		if historyLength == 0 {
+		if historyLength <= 0 {
 			taskCopy.History = []*a2a.Message{}
-		} else if historyLength > 0 && len(taskCopy.History) > historyLength {
+		} else if len(taskCopy.History) > historyLength {
 			taskCopy.History = taskCopy.History[len(taskCopy.History)-historyLength:]
 		}
 		if !req.IncludeArtifacts {

--- a/a2asrv/taskstore/store_test.go
+++ b/a2asrv/taskstore/store_test.go
@@ -305,7 +305,7 @@ func TestInMemoryTaskStore_List_WithFilters(t *testing.T) {
 			name:         "with negative HistoryLength filter",
 			givenTasks:   []*a2a.Task{{ID: id1, History: []*a2a.Message{{ID: "messageId1"}, {ID: "messageId2"}, {ID: "messageId3"}}}, {ID: id2, History: []*a2a.Message{{ID: "messageId4"}, {ID: "messageId5"}}}},
 			request:      &a2a.ListTasksRequest{HistoryLength: utils.Ptr(-1)},
-			wantResponse: &a2a.ListTasksResponse{Tasks: []*a2a.Task{{ID: id2, History: []*a2a.Message{{ID: "messageId4"}, {ID: "messageId5"}}}, {ID: id1, History: []*a2a.Message{{ID: "messageId1"}, {ID: "messageId2"}, {ID: "messageId3"}}}}},
+			wantResponse: &a2a.ListTasksResponse{Tasks: []*a2a.Task{{ID: id2, History: []*a2a.Message{}}, {ID: id1, History: []*a2a.Message{}}}},
 		},
 		{
 			name:         "PageSize filter",


### PR DESCRIPTION
## What changed

1. Treat non-positive historyLength as an empty history

Problem: GetTask and ListTasks parsed historyLength only through `== 0` and
`> 0` branches, so a negative value fell through both and returned the full
task history. The spec defines historyLength semantics only for unset, zero
and positive values, so a negative value is invalid input that must not
bypass the limit.

Fix (a2asrv/handler.go GetTask, a2asrv/taskstore/inmemory.go toListTasksResult):

- Both paths now treat `historyLength <= 0` as a request for empty history,
  matching the JS SDK's behavior.
- Existing tests that asserted the old behavior were updated.

Behavior change: `historyLength < 0` previously returned the complete task
history; it now returns a task with no history.

2. Stop dumping PushConfig into the push config save error

Problem: agentexec.go formatted the save error with `%v` on
`params.Config.PushConfig`, embedding the full struct — including `token`
and `authentication.credentials` — into the error message returned to the
caller.

Fix (a2asrv/agentexec.go factory.CreateExecutor):

- The error message now includes only the task ID.

## Testing

- Ran the full suite: 29 packages passing (`go test ./...`).
- Adapted the GetTask and ListTasks tests that previously pinned the
  negative-historyLength behavior.
