### PR TITLE
fix(push): harden SSRF (CGNAT/benchmark + create-time URL reject)

### DIFF
--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -779,8 +779,10 @@ func TestRequestHandler_TaskExecutionFailOnPush(t *testing.T) {
 	ctx := t.Context()
 
 	pushConfig := &a2a.PushConfig{URL: "http://localhost:1"}
-	pushConfigStore := push.NewInMemoryStore()
-	sender := push.NewHTTPPushSender(&push.HTTPSenderConfig{FailOnError: true})
+	// Localhost must be stored so dial-time FailOnError can fail the task; create-time
+	// SSRF defaults to reject private targets.
+	pushConfigStore := push.NewInMemoryStoreWithConfig(&push.StoreConfig{AllowPrivateNetworks: true})
+	sender := push.NewHTTPPushSender(&push.HTTPSenderConfig{FailOnError: true, AllowPrivateNetworks: true})
 
 	taskSeed := &a2a.Task{ID: a2a.NewTaskID(), ContextID: a2a.NewContextID()}
 	input := &a2a.SendMessageRequest{

--- a/a2asrv/push/sender.go
+++ b/a2asrv/push/sender.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"syscall"
 	"time"
@@ -175,12 +176,27 @@ func limitPushRedirects(req *http.Request, via []*http.Request) error {
 	return nil
 }
 
+func isHTTPPushScheme(scheme string) bool {
+	s := strings.ToLower(scheme)
+	return s == "http" || s == "https"
+}
+
 // SendPush serializes the task to JSON and sends it as an HTTP POST request
-// to the URL specified in the push configuration.
+// to the URL specified in the push configuration. Non-http(s) URLs are ignored.
 func (s *HTTPPushSender) SendPush(ctx context.Context, config *a2a.PushConfig, event a2a.Event) error {
 	jsonData, err := json.Marshal(a2a.StreamResponse{Event: event})
 	if err != nil {
 		return s.handleError(ctx, fmt.Errorf("failed to serialize event to JSON: %w", err))
+	}
+	if config == nil {
+		return s.handleError(ctx, errors.New("push config cannot be nil"))
+	}
+	u, err := url.ParseRequestURI(config.URL)
+	if err != nil {
+		return s.handleError(ctx, fmt.Errorf("failed to parse push notification URL: %w", err))
+	}
+	if !isHTTPPushScheme(u.Scheme) {
+		return nil
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, config.URL, bytes.NewBuffer(jsonData))

--- a/a2asrv/push/sender.go
+++ b/a2asrv/push/sender.go
@@ -127,13 +127,34 @@ func ssrfGuardedTransport() *http.Transport {
 	}
 }
 
+// Extra IPv4 ranges that net.IP.IsPrivate does not cover but must not be
+// reachable as push targets: RFC 6598 CGNAT / shared address space and
+// RFC 2544 benchmarking (often used for lab/interconnect and traffic
+// generators). Python's ipaddress.is_private treats these as non-global;
+// keep Go push SSRF aligned with that floor.
+var (
+	cgnatSharedNet   = mustCIDR("100.64.0.0/10")
+	benchmarkTestNet = mustCIDR("198.18.0.0/15")
+)
+
+func mustCIDR(cidr string) *net.IPNet {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic("push: invalid CIDR " + cidr + ": " + err.Error())
+	}
+	return network
+}
+
 // isBlockedIP reports whether ip is in a range a push notification must not
-// reach: loopback, RFC 1918 / RFC 4193 private, link-local, unspecified or
-// multicast. This covers cloud metadata endpoints (169.254.169.254) and
-// internal services (127.0.0.1, 10/8, 172.16/12, 192.168/16).
+// reach: loopback, RFC 1918 / RFC 4193 private, RFC 6598 CGNAT, RFC 2544
+// benchmarking, link-local, unspecified or multicast. This covers cloud
+// metadata endpoints (169.254.169.254) and internal services
+// (127.0.0.1, 10/8, 172.16/12, 192.168/16, 100.64/10).
 func isBlockedIP(ip net.IP) bool {
 	return ip.IsLoopback() ||
 		ip.IsPrivate() ||
+		cgnatSharedNet.Contains(ip) ||
+		benchmarkTestNet.Contains(ip) ||
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||
 		ip.IsUnspecified() ||

--- a/a2asrv/push/sender_test.go
+++ b/a2asrv/push/sender_test.go
@@ -288,6 +288,8 @@ func TestHTTPPushSender_SSRFProtection(t *testing.T) {
 			"http://169.254.169.254/latest/meta-data/", // cloud metadata (link-local)
 			"http://10.0.0.5/webhook",                  // RFC 1918
 			"http://192.168.1.10/webhook",              // RFC 1918
+			"http://100.64.0.1/webhook",                // RFC 6598 CGNAT / shared
+			"http://198.18.0.1/webhook",                // RFC 2544 benchmarking
 			"http://0.0.0.0:8080/webhook",              // unspecified
 		}
 		sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true})

--- a/a2asrv/push/sender_test.go
+++ b/a2asrv/push/sender_test.go
@@ -206,7 +206,7 @@ func TestHTTPPushSender_SendPushError(t *testing.T) {
 			name:    "invalid request URL",
 			event:   events,
 			config:  &a2a.PushConfig{URL: "::"},
-			wantErr: "failed to create HTTP request",
+			wantErr: "failed to parse push notification URL",
 		},
 		{
 			name:    "http client fails",
@@ -273,6 +273,23 @@ func TestHTTPPushSender_SendPushError(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestHTTPPushSender_SendPushIgnoresNonHTTP(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	event := &a2a.Task{ID: "test-task", ContextID: "test-context"}
+	sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true})
+
+	for _, raw := range []string{"topic://name", "file:///etc/passwd"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			err := sender.SendPush(ctx, &a2a.PushConfig{URL: raw}, event)
+			if err != nil {
+				t.Fatalf("SendPush() error = %v, want %v", err, nil)
+			}
+		})
+	}
 }
 
 func TestHTTPPushSender_SSRFProtection(t *testing.T) {

--- a/a2asrv/push/store.go
+++ b/a2asrv/push/store.go
@@ -83,18 +83,17 @@ func validateConfig(config *a2a.PushConfig, allowPrivateNetworks bool) error {
 	return nil
 }
 
-// validatePushEndpointURL enforces http(s) and rejects obvious private/loopback
-// targets at write time (create + SendMessage embed). Dial-time checks in the
-// sender still cover DNS rebinding; this is fail-fast parity with a2a-python /
-// a2a-js create-time guards.
+// validatePushEndpointURL parses the endpoint. Non-http(s) schemes are stored
+// so other senders (for example topic:// MQ) can use the same config.
+// For http(s), reject private/loopback literal hosts at write time.
+// Dial-time checks in HTTPPushSender still cover DNS rebinding.
 func validatePushEndpointURL(raw string, allowPrivateNetworks bool) error {
 	u, err := url.ParseRequestURI(raw)
 	if err != nil {
 		return err
 	}
-	scheme := strings.ToLower(u.Scheme)
-	if scheme != "http" && scheme != "https" {
-		return fmt.Errorf("scheme must be http or https, got %q", u.Scheme)
+	if !isHTTPPushScheme(u.Scheme) {
+		return nil
 	}
 	host := u.Hostname()
 	if host == "" {

--- a/a2asrv/push/store.go
+++ b/a2asrv/push/store.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -33,14 +35,33 @@ var ErrPushConfigNotFound = errors.New("push config not found")
 // Authorization (cross-tenant isolation) is enforced at the handler level
 // via taskStore.Get; this store is a plain in-memory CRUD store.
 type InMemoryPushConfigStore struct {
-	mu      sync.RWMutex
-	configs map[a2a.TaskID]map[string]*a2a.PushConfig
+	mu                   sync.RWMutex
+	configs              map[a2a.TaskID]map[string]*a2a.PushConfig
+	allowPrivateNetworks bool
 }
 
-// NewInMemoryStore creates an empty store.
+// StoreConfig configures [InMemoryPushConfigStore].
+type StoreConfig struct {
+	// AllowPrivateNetworks relaxes create-time URL SSRF checks so loopback
+	// and private literal targets can be stored. Defaults to false. Pair with
+	// [HTTPSenderConfig.AllowPrivateNetworks] for trusted internal deployments.
+	AllowPrivateNetworks bool
+}
+
+// NewInMemoryStore creates an empty store with create-time push URL SSRF checks enabled.
 func NewInMemoryStore() *InMemoryPushConfigStore {
+	return NewInMemoryStoreWithConfig(nil)
+}
+
+// NewInMemoryStoreWithConfig creates an empty store using the given config.
+func NewInMemoryStoreWithConfig(config *StoreConfig) *InMemoryPushConfigStore {
+	allowPrivate := false
+	if config != nil {
+		allowPrivate = config.AllowPrivateNetworks
+	}
 	return &InMemoryPushConfigStore{
-		configs: make(map[a2a.TaskID]map[string]*a2a.PushConfig),
+		configs:              make(map[a2a.TaskID]map[string]*a2a.PushConfig),
+		allowPrivateNetworks: allowPrivate,
 	}
 }
 
@@ -49,22 +70,51 @@ func newID() string {
 	return uuid.Must(uuid.NewV7()).String()
 }
 
-func validateConfig(config *a2a.PushConfig) error {
+func validateConfig(config *a2a.PushConfig, allowPrivateNetworks bool) error {
 	if config == nil {
 		return errors.New("push config cannot be nil")
 	}
 	if config.URL == "" {
 		return errors.New("push config endpoint cannot be empty")
 	}
-	if _, err := url.ParseRequestURI(config.URL); err != nil {
+	if err := validatePushEndpointURL(config.URL, allowPrivateNetworks); err != nil {
 		return fmt.Errorf("invalid push config endpoint URL: %w", err)
+	}
+	return nil
+}
+
+// validatePushEndpointURL enforces http(s) and rejects obvious private/loopback
+// targets at write time (create + SendMessage embed). Dial-time checks in the
+// sender still cover DNS rebinding; this is fail-fast parity with a2a-python /
+// a2a-js create-time guards.
+func validatePushEndpointURL(raw string, allowPrivateNetworks bool) error {
+	u, err := url.ParseRequestURI(raw)
+	if err != nil {
+		return err
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("scheme must be http or https, got %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("host is required")
+	}
+	if allowPrivateNetworks {
+		return nil
+	}
+	if host == "localhost" || strings.HasSuffix(strings.ToLower(host), ".localhost") {
+		return fmt.Errorf("%w: %s", errBlockedPushTarget, host)
+	}
+	if ip := net.ParseIP(host); ip != nil && isBlockedIP(ip) {
+		return fmt.Errorf("%w: %s", errBlockedPushTarget, ip)
 	}
 	return nil
 }
 
 // Save adds a copy of push config to the store.
 func (s *InMemoryPushConfigStore) Save(ctx context.Context, taskID a2a.TaskID, config *a2a.PushConfig) (*a2a.PushConfig, error) {
-	if err := validateConfig(config); err != nil {
+	if err := validateConfig(config, s.allowPrivateNetworks); err != nil {
 		return nil, fmt.Errorf("%w: %w", a2a.ErrInvalidParams, err)
 	}
 

--- a/a2asrv/push/store_test.go
+++ b/a2asrv/push/store_test.go
@@ -75,14 +75,20 @@ func TestInMemoryPushConfigStore_Save(t *testing.T) {
 			wantErr: fmt.Errorf("%w: invalid push config endpoint URL: parse \"not a url\": invalid URI for request", a2a.ErrInvalidParams),
 		},
 		{
-			name:    "file scheme",
-			config:  &a2a.PushConfig{URL: "file:///etc/passwd"},
-			wantErr: fmt.Errorf("%w: invalid push config endpoint URL: scheme must be http or https, got %q", a2a.ErrInvalidParams, "file"),
+			name:   "topic scheme stored for non-http senders",
+			config: &a2a.PushConfig{URL: "topic://name"},
+			want: &a2a.PushConfig{
+				TaskID: taskID,
+				URL:    "topic://name",
+			},
 		},
 		{
-			name:    "javascript scheme",
-			config:  &a2a.PushConfig{URL: "javascript:alert(1)"},
-			wantErr: fmt.Errorf("%w: invalid push config endpoint URL: scheme must be http or https, got %q", a2a.ErrInvalidParams, "javascript"),
+			name:   "file scheme stored",
+			config: &a2a.PushConfig{URL: "file:///etc/passwd"},
+			want: &a2a.PushConfig{
+				TaskID: taskID,
+				URL:    "file:///etc/passwd",
+			},
 		},
 		{
 			name:    "loopback literal",

--- a/a2asrv/push/store_test.go
+++ b/a2asrv/push/store_test.go
@@ -74,6 +74,26 @@ func TestInMemoryPushConfigStore_Save(t *testing.T) {
 			config:  &a2a.PushConfig{URL: "not a url"},
 			wantErr: fmt.Errorf("%w: invalid push config endpoint URL: parse \"not a url\": invalid URI for request", a2a.ErrInvalidParams),
 		},
+		{
+			name:    "file scheme",
+			config:  &a2a.PushConfig{URL: "file:///etc/passwd"},
+			wantErr: fmt.Errorf("%w: invalid push config endpoint URL: scheme must be http or https, got %q", a2a.ErrInvalidParams, "file"),
+		},
+		{
+			name:    "javascript scheme",
+			config:  &a2a.PushConfig{URL: "javascript:alert(1)"},
+			wantErr: fmt.Errorf("%w: invalid push config endpoint URL: scheme must be http or https, got %q", a2a.ErrInvalidParams, "javascript"),
+		},
+		{
+			name:    "loopback literal",
+			config:  &a2a.PushConfig{URL: "http://127.0.0.1/webhook"},
+			wantErr: fmt.Errorf("%w: invalid push config endpoint URL: %w: 127.0.0.1", a2a.ErrInvalidParams, errBlockedPushTarget),
+		},
+		{
+			name:    "localhost hostname",
+			config:  &a2a.PushConfig{URL: "http://localhost:1/webhook"},
+			wantErr: fmt.Errorf("%w: invalid push config endpoint URL: %w: localhost", a2a.ErrInvalidParams, errBlockedPushTarget),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -100,6 +120,17 @@ func TestInMemoryPushConfigStore_Save(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("AllowPrivateNetworks opts out of create-time guard", func(t *testing.T) {
+		store := NewInMemoryStoreWithConfig(&StoreConfig{AllowPrivateNetworks: true})
+		saved, err := store.Save(ctx, taskID, &a2a.PushConfig{URL: "http://127.0.0.1/webhook"})
+		if err != nil {
+			t.Fatalf("Save() with AllowPrivateNetworks failed: %v", err)
+		}
+		if saved.URL != "http://127.0.0.1/webhook" {
+			t.Fatalf("Save() URL = %q", saved.URL)
+		}
+	})
 }
 
 func TestInMemoryPushConfigStore_ModifiedConfig(t *testing.T) {

--- a/itk/main.go
+++ b/itk/main.go
@@ -494,9 +494,9 @@ func run() error {
 		},
 	}
 
-	pushStore := push.NewInMemoryStore()
 	// The ITK harness delivers to loopback notification servers, so it opts out
 	// of the default SSRF guard that rejects loopback and private targets.
+	pushStore := push.NewInMemoryStoreWithConfig(&push.StoreConfig{AllowPrivateNetworks: true})
 	pushSender := push.NewHTTPPushSender(&push.HTTPSenderConfig{AllowPrivateNetworks: true})
 
 	executor := &V10AgentExecutor{}


### PR DESCRIPTION
## Summary
- Dial-time: block RFC 6598 CGNAT and RFC 2544 benchmarking ranges in `isBlockedIP` (parity with Python `ipaddress.is_private`).
- Create/save-time: reject non-http(s) and private/loopback literal hosts when storing push configs (`CreateTaskPushConfig` and SendMessage embed). Dial-time guard remains for DNS rebinding.
- `push.StoreConfig.AllowPrivateNetworks` opts out for trusted internal deployments (paired with sender `AllowPrivateNetworks`).

Threat model: a caller who can create/embed push configs can already choose the webhook URL; dial-time already blocks private POSTs. This is fail-fast write-path + scheme reject (parity with a2a-python create-time / a2a-js#645), not a new authority class.

## Test plan
- [x] `go test ./a2asrv/push/ ./a2asrv/ -count=1`
- [x] Revert-tested: disabling private reject makes loopback/localhost Save cases fail their want-err assertions
- [x] ITK + FailOnPush tests opt into `AllowPrivateNetworks` on the store