### PR TITLE
fix(push): harden push sender config validation (scheme whitelist, auth scheme, CRLF)

### DIFF
--- a/a2asrv/push/sender.go
+++ b/a2asrv/push/sender.go
@@ -172,11 +172,22 @@ func (s *HTTPPushSender) SendPush(ctx context.Context, config *a2a.PushConfig, e
 		req.Header.Set(tokenHeader, config.Token)
 	}
 	if config.Auth != nil && config.Auth.Credentials != "" {
+		// Reject credentials containing CR/LF up front: net/http would refuse to
+		// write such a header value, but failing here produces a clear error
+		// instead of a transport-level failure (and guards against header
+		// injection through the Authorization value).
+		if strings.ContainsAny(config.Auth.Credentials, "\r\n") {
+			return s.handleError(ctx, fmt.Errorf("push notification auth credentials must not contain CR or LF characters"))
+		}
 		switch strings.ToLower(config.Auth.Scheme) {
 		case "bearer":
 			req.Header.Set("Authorization", "Bearer "+config.Auth.Credentials)
 		case "basic":
 			req.Header.Set("Authorization", "Basic "+config.Auth.Credentials)
+		default:
+			// Unknown scheme: fail loudly instead of silently dropping the
+			// configured authentication on the floor.
+			return s.handleError(ctx, fmt.Errorf("unsupported push notification auth scheme: %q", config.Auth.Scheme))
 		}
 	}
 

--- a/a2asrv/push/sender_test.go
+++ b/a2asrv/push/sender_test.go
@@ -168,6 +168,56 @@ func TestHTTPPushSender_SendPushSuccess(t *testing.T) {
 	}
 }
 
+func TestHTTPPushSender_AuthSchemeAndCredentialsValidation(t *testing.T) {
+	ctx := context.Background()
+	event := &a2a.Task{ID: "test-task", ContextID: "test-context"}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Run("unknown auth scheme returns error when FailOnError is set", func(t *testing.T) {
+		sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true, AllowPrivateNetworks: true})
+		config := &a2a.PushConfig{URL: server.URL, Auth: &a2a.PushAuthInfo{Scheme: "Digest", Credentials: "secret"}}
+		err := sender.SendPush(ctx, config, event)
+		if err == nil || !strings.Contains(err.Error(), "unsupported push notification auth scheme") {
+			t.Errorf("SendPush() error = %v, want an unsupported auth scheme error", err)
+		}
+	})
+
+	t.Run("unknown auth scheme is only logged when FailOnError is false", func(t *testing.T) {
+		sender := NewHTTPPushSender(&HTTPSenderConfig{AllowPrivateNetworks: true})
+		config := &a2a.PushConfig{URL: server.URL, Auth: &a2a.PushAuthInfo{Scheme: "Digest", Credentials: "secret"}}
+		if err := sender.SendPush(ctx, config, event); err != nil {
+			t.Errorf("SendPush() error = %v, want nil when FailOnError is false", err)
+		}
+	})
+
+	t.Run("credentials with CR or LF are rejected", func(t *testing.T) {
+		sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true, AllowPrivateNetworks: true})
+		for _, creds := range []string{"abc\r\nX-Injected: 1", "abc\nX-Injected: 1"} {
+			config := &a2a.PushConfig{URL: server.URL, Auth: &a2a.PushAuthInfo{Scheme: "Bearer", Credentials: creds}}
+			err := sender.SendPush(ctx, config, event)
+			if err == nil || !strings.Contains(err.Error(), "must not contain CR or LF") {
+				t.Errorf("SendPush() with CRLF credentials error = %v, want a CR/LF rejection error", err)
+			}
+		}
+	})
+
+	t.Run("bearer and basic credentials without CRLF still succeed", func(t *testing.T) {
+		sender := NewHTTPPushSender(&HTTPSenderConfig{FailOnError: true, AllowPrivateNetworks: true})
+		for _, auth := range []*a2a.PushAuthInfo{
+			{Scheme: "Bearer", Credentials: "token-123"},
+			{Scheme: "Basic", Credentials: "dXNlcjpwYXNz"},
+		} {
+			config := &a2a.PushConfig{URL: server.URL, Auth: auth}
+			if err := sender.SendPush(ctx, config, event); err != nil {
+				t.Errorf("SendPush() with %s auth failed: %v", auth.Scheme, err)
+			}
+		}
+	})
+}
+
 func TestHTTPPushSender_SendPushError(t *testing.T) {
 	ctx := context.Background()
 	task := &a2a.Task{ID: "test-task", ContextID: "test-context"}

--- a/a2asrv/push/store.go
+++ b/a2asrv/push/store.go
@@ -56,8 +56,15 @@ func validateConfig(config *a2a.PushConfig) error {
 	if config.URL == "" {
 		return errors.New("push config endpoint cannot be empty")
 	}
-	if _, err := url.ParseRequestURI(config.URL); err != nil {
+	parsedURL, err := url.ParseRequestURI(config.URL)
+	if err != nil {
 		return fmt.Errorf("invalid push config endpoint URL: %w", err)
+	}
+	// Only http/https are acceptable push endpoints; allowing arbitrary
+	// schemes (file://, ftp://, ...) would let a client direct the server's
+	// outbound HTTP client at non-HTTP sinks.
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("push config endpoint URL must use http or https scheme, got %q", parsedURL.Scheme)
 	}
 	return nil
 }

--- a/a2asrv/push/store_test.go
+++ b/a2asrv/push/store_test.go
@@ -74,6 +74,16 @@ func TestInMemoryPushConfigStore_Save(t *testing.T) {
 			config:  &a2a.PushConfig{URL: "not a url"},
 			wantErr: fmt.Errorf("%w: invalid push config endpoint URL: parse \"not a url\": invalid URI for request", a2a.ErrInvalidParams),
 		},
+		{
+			name:    "non-http scheme",
+			config:  &a2a.PushConfig{URL: "file:///etc/passwd"},
+			wantErr: fmt.Errorf("%w: push config endpoint URL must use http or https scheme, got \"file\"", a2a.ErrInvalidParams),
+		},
+		{
+			name:    "ftp scheme",
+			config:  &a2a.PushConfig{URL: "ftp://example.com/file"},
+			wantErr: fmt.Errorf("%w: push config endpoint URL must use http or https scheme, got \"ftp\"", a2a.ErrInvalidParams),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## What changed

### 1. Restrict push config endpoint URLs to http/https

**Problem:**

`validateConfig` only checked URL syntax, so arbitrary schemes (`file://`, `ftp://`, ...) were accepted and would direct the server's outbound HTTP client at non-HTTP sinks.

**Fix (a2asrv/push/store.go):**
- After `url.ParseRequestURI`, reject any scheme other than `http` or `https` with a clear error message.

### 2. Reject CR/LF in push auth credentials

**Problem:**

Credentials containing carriage return or line feed were passed straight into the `Authorization` header value; `net/http` would refuse to write such a header, producing an opaque transport-level failure and opening a header-injection vector.

**Fix (a2asrv/push/sender.go):**
- Reject credentials containing `\r` or `\n` up front with a clear error (`push notification auth credentials must not contain CR or LF characters`).

### 3. Fail loudly on unknown push auth schemes

**Problem:**

An unknown auth scheme (anything other than `bearer`/`basic`) was silently ignored, dropping the configured authentication on the floor.

**Fix (a2asrv/push/sender.go):**
- Return an `unsupported push notification auth scheme` error when `FailOnError` is set; otherwise the failure is only logged (existing behavior preserved).
- Added tests covering the scheme whitelist, unknown auth scheme, and CR/LF credentials in `a2asrv/push/store_test.go` and `a2asrv/push/sender_test.go`.

## Testing

- `go test ./a2asrv/push/` — all pass, including the new scheme whitelist, unknown auth scheme, and CR/LF credential cases.

Behavior change: push configs with non-http(s) URLs are now rejected on save; an unknown auth scheme returns an error when `FailOnError` is enabled (previously silently dropped).
