### PR TITLE
fix(eventqueue): make inMemoryQueue closed flag atomic

### DIFF
--- a/a2asrv/eventqueue/queue_in_memory_impl.go
+++ b/a2asrv/eventqueue/queue_in_memory_impl.go
@@ -17,6 +17,7 @@ package eventqueue
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 )
 
 type broadcast struct {
@@ -116,14 +117,14 @@ type inMemoryQueue struct {
 	broker     *inMemoryEventBroker
 	closedChan chan struct{}
 	eventsChan chan *Message
-	closed     bool
+	closed     atomic.Bool
 }
 
 var _ Reader = (*inMemoryQueue)(nil)
 var _ Writer = (*inMemoryQueue)(nil)
 
 func (q *inMemoryQueue) Write(ctx context.Context, message *Message) error {
-	if q.closed {
+	if q.closed.Load() {
 		return ErrQueueClosed
 	}
 
@@ -175,7 +176,10 @@ func (q *inMemoryQueue) Close() error {
 }
 
 func (q *inMemoryQueue) destroy() {
-	q.closed = true
-	close(q.eventsChan)
-	close(q.closedChan)
+	// CompareAndSwap makes destroy idempotent and synchronizes with
+	// concurrent Write calls that read the closed flag (data-race free).
+	if q.closed.CompareAndSwap(false, true) {
+		close(q.eventsChan)
+		close(q.closedChan)
+	}
 }

--- a/a2asrv/eventqueue/queue_in_memory_impl_test.go
+++ b/a2asrv/eventqueue/queue_in_memory_impl_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -278,4 +279,47 @@ func TestInMemoryQueue_BlockedWriteOnFullQueueThenDestroy(t *testing.T) {
 		}
 	}
 	<-completed
+}
+
+// TestInMemoryQueue_ConcurrentWriteAndDestroy is a regression test for BUG-20:
+// the `closed` flag was a plain bool written by the broker goroutine during
+// destroy and read by Write without synchronization, which is a data race
+// (caught by `go test -race`). It exercises concurrent Write and Destroy to
+// shake out races; run with -race to verify.
+func TestInMemoryQueue_ConcurrentWriteAndDestroy(t *testing.T) {
+	t.Parallel()
+	qm := newTestManager(t, WithQueueBufferSize(16))
+
+	tid := a2a.NewTaskID()
+	_, writeQueue := mustCreateReadWriter(t, qm, tid)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					// Errors are expected once the queue is destroyed
+					// (ErrQueueClosed); anything else must not happen.
+					if err := writeQueue.Write(t.Context(), &Message{Event: &a2a.Message{ID: "test"}}); err != nil && !errors.Is(err, ErrQueueClosed) {
+						t.Errorf("Write() error = %v, want ErrQueueClosed or nil", err)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	// Let the writers overlap with the destroy, then destroy the queue.
+	time.Sleep(5 * time.Millisecond)
+	if err := qm.Destroy(t.Context(), tid); err != nil {
+		t.Fatalf("qm.Destroy() error = %v", err)
+	}
+	close(stop)
+	wg.Wait()
 }

--- a/a2asrv/eventqueue/queue_in_memory_impl_test.go
+++ b/a2asrv/eventqueue/queue_in_memory_impl_test.go
@@ -296,9 +296,7 @@ func TestInMemoryQueue_ConcurrentWriteAndDestroy(t *testing.T) {
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
 	for range 8 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-stop:
@@ -312,7 +310,7 @@ func TestInMemoryQueue_ConcurrentWriteAndDestroy(t *testing.T) {
 					}
 				}
 			}
-		}()
+		})
 	}
 
 	// Let the writers overlap with the destroy, then destroy the queue.

--- a/a2asrv/eventqueue/queue_in_memory_impl_test.go
+++ b/a2asrv/eventqueue/queue_in_memory_impl_test.go
@@ -281,7 +281,7 @@ func TestInMemoryQueue_BlockedWriteOnFullQueueThenDestroy(t *testing.T) {
 	<-completed
 }
 
-// TestInMemoryQueue_ConcurrentWriteAndDestroy is a regression test for BUG-20:
+// TestInMemoryQueue_ConcurrentWriteAndDestroy is a regression test for the closed-flag race:
 // the `closed` flag was a plain bool written by the broker goroutine during
 // destroy and read by Write without synchronization, which is a data race
 // (caught by `go test -race`). It exercises concurrent Write and Destroy to


### PR DESCRIPTION
## What changed

### 1. Make the in-memory queue `closed` flag atomic

**Problem:**

`inMemoryQueue.closed` was a plain `bool` written by the broker goroutine during `destroy` and read by concurrent `Write` calls without synchronization — a data race (caught by `go test -race`).

**Fix (a2asrv/eventqueue/queue_in_memory_impl.go, a2asrv/eventqueue/queue_in_memory_impl_test.go):**
- Replaced the plain `bool` with `atomic.Bool`; `Write` now reads it via `Load()`.
- `destroy` now uses `CompareAndSwap(false, true)` before closing the channels, making it idempotent and synchronizing with concurrent writes.
- Added regression test `TestInMemoryQueue_ConcurrentWriteAndDestroy`.

## Testing

- `go test ./a2asrv/eventqueue/` passes.
- Note: `-race` could not run locally (cgo disabled on this machine); the CI workflow runs the suite with `-race`.

Behavior change: none.
