### PR TITLE
fix(sse): use monotonic per-connection event IDs instead of random UUIDs

### DIFF
--- a/internal/sse/sse.go
+++ b/internal/sse/sse.go
@@ -23,8 +23,7 @@ import (
 	"io"
 	"iter"
 	"net/http"
-
-	"github.com/google/uuid"
+	"strconv"
 )
 
 const (
@@ -43,6 +42,10 @@ const (
 type SSEWriter struct {
 	writer  http.ResponseWriter
 	flusher http.Flusher
+	// eventID is a monotonically increasing per-connection counter used as the
+	// SSE event ID. Random IDs (previously UUIDs) break Last-Event-ID
+	// resumption: a client cannot tell where a reconnection should continue.
+	eventID uint64
 }
 
 // NewWriter creates a new [SSEWriter].
@@ -75,8 +78,9 @@ func (w *SSEWriter) WriteKeepAlive(ctx context.Context) error {
 
 // WriteData writes a data block to the SSE stream.
 func (w *SSEWriter) WriteData(ctx context.Context, data []byte) error {
-	eventID := uuid.NewString()
-	if _, err := fmt.Fprintf(w.writer, "%s %s\n", sseIDPrefix, []byte(eventID)); err != nil {
+	w.eventID++
+	eventID := strconv.FormatUint(w.eventID, 10)
+	if _, err := fmt.Fprintf(w.writer, "%s %s\n", sseIDPrefix, eventID); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprintf(w.writer, "%s %s\n\n", sseDataPrefix, data); err != nil {

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -15,7 +15,10 @@
 package sse
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -220,5 +223,62 @@ func TestSSE_NoSpaceCompatibility(t *testing.T) {
 	}
 	if eventCount != 1 {
 		t.Fatalf("ParseDataStream() emitted %d events, want 1", eventCount)
+	}
+}
+
+// TestSSE_EventIDsAreSequential is a regression test for BUG-22: event IDs
+// were random UUIDs, which made Last-Event-ID resumption impossible. IDs must
+// now be a monotonic per-connection counter (1, 2, 3, ...).
+func TestSSE_EventIDsAreSequential(t *testing.T) {
+	const wantEvents = 5
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		ctx := req.Context()
+		sse, err := NewWriter(rw)
+		if err != nil {
+			t.Fatalf("NewWriter() error = %v", err)
+		}
+		sse.WriteHeaders()
+		for i := range wantEvents {
+			if err := sse.WriteData(ctx, []byte("event-"+strconv.Itoa(i))); err != nil {
+				t.Fatalf("WriteData() error = %v", err)
+			}
+		}
+	}))
+	defer server.Close()
+
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, "POST", server.URL, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() error = %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+
+	var ids []string
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	for scanner.Scan() {
+		if rest, ok := strings.CutPrefix(scanner.Text(), sseIDPrefix+" "); ok {
+			ids = append(ids, rest)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner.Err() = %v", err)
+	}
+	if len(ids) != wantEvents {
+		t.Fatalf("got %d event ids %v, want %d", len(ids), ids, wantEvents)
+	}
+	for i, id := range ids {
+		want := strconv.Itoa(i + 1)
+		if id != want {
+			t.Fatalf("event id %d = %q, want %q (monotonic counter)", i, id, want)
+		}
 	}
 }

--- a/internal/sse/sse_test.go
+++ b/internal/sse/sse_test.go
@@ -226,7 +226,7 @@ func TestSSE_NoSpaceCompatibility(t *testing.T) {
 	}
 }
 
-// TestSSE_EventIDsAreSequential is a regression test for BUG-22: event IDs
+// TestSSE_EventIDsAreSequential is a regression test for sequential event IDs: event IDs
 // were random UUIDs, which made Last-Event-ID resumption impossible. IDs must
 // now be a monotonic per-connection counter (1, 2, 3, ...).
 func TestSSE_EventIDsAreSequential(t *testing.T) {


### PR DESCRIPTION
## What changed

### 1. Replace random SSE event IDs with a monotonic counter

**Problem:**

Every SSE event got a random UUID as its `id:`. Random IDs break `Last-Event-ID` resumption: after a reconnection a client cannot tell which event to continue from, since the IDs carry no ordering information.

**Fix (internal/sse/sse.go, internal/sse/sse_test.go):**
- Added a per-connection `eventID uint64` counter to `SSEWriter`; `WriteData` now emits sequential IDs (`1`, `2`, `3`, ...) via `strconv.FormatUint`.
- Removed the now-unused `github.com/google/uuid` dependency.
- Added regression test `TestSSE_EventIDsAreSequential`.

## Testing

- `go test ./a2aclient/... ./internal/... ./a2asrv/...` — all pass.
- New `TestSSE_EventIDsAreSequential` verifies IDs are 1..N on a connection.

Behavior change: SSE event IDs are now a monotonic per-connection counter instead of random UUIDs.
