### PR TITLE
fix(grpc): propagate push config list pagination and return next page token

### DIFF
--- a/a2agrpc/v0/handler.go
+++ b/a2agrpc/v0/handler.go
@@ -263,7 +263,7 @@ func (h *Handler) ListTaskPushNotificationConfig(ctx context.Context, pbReq *a2a
 
 	resp := &a2a.ListTaskPushConfigResponse{
 		Configs:       configs.Configs,
-		NextPageToken: "",
+		NextPageToken: configs.NextPageToken,
 	}
 
 	pbResp, err := pbconv.ToProtoListTaskPushConfigResponse(resp)

--- a/a2agrpc/v1/handler.go
+++ b/a2agrpc/v1/handler.go
@@ -250,7 +250,7 @@ func (h *Handler) ListTaskPushNotificationConfigs(ctx context.Context, pbReq *a2
 
 	resp := &a2a.ListTaskPushConfigResponse{
 		Configs:       configs.Configs,
-		NextPageToken: "",
+		NextPageToken: configs.NextPageToken,
 	}
 
 	pbResp, err := pbconv.ToProtoListTaskPushConfigResponse(resp)

--- a/a2asrv/agentexec.go
+++ b/a2asrv/agentexec.go
@@ -485,7 +485,7 @@ func (p *processor) sendPushNotifications(ctx context.Context, event a2a.Event) 
 	}
 	taskID := p.execCtx.TaskID
 
-	configs, err := p.pushConfigStore.List(ctx, taskID)
+	configs, _, err := p.pushConfigStore.List(ctx, taskID, 0, "")
 	if err != nil {
 		return err
 	}

--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -426,14 +426,14 @@ func (h *defaultRequestHandler) ListTaskPushConfigs(ctx context.Context, req *a2
 	if _, err := h.taskStore.Get(ctx, req.TaskID); err != nil {
 		return nil, fmt.Errorf("failed to list push configs: %w", err)
 	}
-	configs, err := h.pushConfigStore.List(ctx, req.TaskID)
+	configs, nextPageToken, err := h.pushConfigStore.List(ctx, req.TaskID, req.PageSize, req.PageToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list push configs: %w", err)
 	}
 	if configs == nil {
-		return &a2a.ListTaskPushConfigResponse{Configs: []*a2a.PushConfig{}}, nil
+		return &a2a.ListTaskPushConfigResponse{Configs: []*a2a.PushConfig{}, NextPageToken: nextPageToken}, nil
 	}
-	return &a2a.ListTaskPushConfigResponse{Configs: configs}, nil
+	return &a2a.ListTaskPushConfigResponse{Configs: configs, NextPageToken: nextPageToken}, nil
 }
 
 // CreateTaskPushConfig implements RequestHandler.

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -716,7 +716,7 @@ func TestRequestHandler_SendMessage_PushNotifications(t *testing.T) {
 	if diff := cmp.Diff(wantResult, result); diff != "" {
 		t.Fatalf("SendMessage() mismatch (-want +got):\n%s", diff)
 	}
-	saved, err := ps.List(ctx, taskSeed.ID)
+	saved, _, err := ps.List(ctx, taskSeed.ID, 0, "")
 	if err != nil || len(saved) != 1 {
 		t.Fatalf("expected push config to be saved, but got %v, %v", saved, err)
 	}

--- a/a2asrv/push/api.go
+++ b/a2asrv/push/api.go
@@ -37,8 +37,12 @@ type ConfigStore interface {
 	// Get retrieves a push configuration registered for a Task with the given configID.
 	Get(ctx context.Context, taskID a2a.TaskID, configID string) (*a2a.PushConfig, error)
 
-	// List retrieves all registered push configurations for a Task. Returning an error stops the execution.
-	List(ctx context.Context, taskID a2a.TaskID) ([]*a2a.PushConfig, error)
+	// List retrieves registered push configurations for a Task. pageSize > 0
+	// applies offset-based pagination: the returned next page token (empty when
+	// no further pages exist) can be passed back as pageToken to fetch the next
+	// page. pageSize <= 0 returns all configurations without a next page token.
+	// Returning an error stops the execution.
+	List(ctx context.Context, taskID a2a.TaskID, pageSize int, pageToken string) ([]*a2a.PushConfig, string, error)
 
 	// Delete removes a push configuration registered for a Task with the given configID.
 	Delete(ctx context.Context, taskID a2a.TaskID, configID string) error

--- a/a2asrv/push/store.go
+++ b/a2asrv/push/store.go
@@ -16,9 +16,12 @@ package push
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
+	"strconv"
 	"sync"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -108,25 +111,78 @@ func (s *InMemoryPushConfigStore) Get(ctx context.Context, taskID a2a.TaskID, co
 	return nil, ErrPushConfigNotFound
 }
 
-// List returns a copy of stored configs for a task.
-func (s *InMemoryPushConfigStore) List(ctx context.Context, taskID a2a.TaskID) ([]*a2a.PushConfig, error) {
+// List returns a copy of stored configs for a task, applying offset-based
+// pagination when pageSize > 0. Configs are ordered by ID so pages are
+// deterministic. The next page token is empty when no further pages exist.
+func (s *InMemoryPushConfigStore) List(ctx context.Context, taskID a2a.TaskID, pageSize int, pageToken string) ([]*a2a.PushConfig, string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	configs, ok := s.configs[taskID]
 	if !ok {
-		return []*a2a.PushConfig{}, nil
+		return []*a2a.PushConfig{}, "", nil
 	}
 
-	result := make([]*a2a.PushConfig, 0, len(configs))
-	for _, config := range configs {
-		cp, err := utils.DeepCopy(config)
+	// Sort IDs for a deterministic ordering across pages.
+	ids := make([]string, 0, len(configs))
+	for id := range configs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	offset := 0
+	if pageToken != "" {
+		decodedOffset, err := decodePushConfigPageToken(pageToken)
 		if err != nil {
-			return nil, err
+			return nil, "", err
+		}
+		offset = decodedOffset
+	}
+	if offset < 0 || offset >= len(ids) {
+		// Token is past the end: an empty page with no further pages.
+		return []*a2a.PushConfig{}, "", nil
+	}
+
+	end := len(ids)
+	if pageSize > 0 && offset+pageSize < end {
+		end = offset + pageSize
+	}
+
+	result := make([]*a2a.PushConfig, 0, end-offset)
+	for _, id := range ids[offset:end] {
+		cp, err := utils.DeepCopy(configs[id])
+		if err != nil {
+			return nil, "", err
 		}
 		result = append(result, cp)
 	}
-	return result, nil
+
+	nextPageToken := ""
+	if pageSize > 0 && end < len(ids) {
+		nextPageToken = encodePushConfigPageToken(end)
+	}
+	return result, nextPageToken, nil
+}
+
+// encodePushConfigPageToken encodes a page offset as an opaque, URL-safe token
+// (base64 of the decimal offset), matching the opaque-token style used by task
+// pagination.
+func encodePushConfigPageToken(offset int) string {
+	return base64.URLEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+// decodePushConfigPageToken decodes an offset-based page token. Invalid tokens
+// yield [a2a.ErrParseError].
+func decodePushConfigPageToken(token string) (int, error) {
+	decoded, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return 0, a2a.ErrParseError
+	}
+	offset, err := strconv.Atoi(string(decoded))
+	if err != nil {
+		return 0, a2a.ErrParseError
+	}
+	return offset, nil
 }
 
 // Delete removes a single config from a task.

--- a/a2asrv/push/store_test.go
+++ b/a2asrv/push/store_test.go
@@ -15,6 +15,7 @@
 package push
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -248,7 +249,7 @@ func TestInMemoryPushConfigStore_List(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			configs, err := store.List(ctx, tc.taskID)
+			configs, _, err := store.List(ctx, tc.taskID, 0, "")
 			if err != nil {
 				t.Fatalf("Get() failed: %v", err)
 			}
@@ -305,7 +306,7 @@ func TestInMemoryPushConfigStore_Delete(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Delete() failed: %v", err)
 			}
-			got, err := store.List(ctx, tc.taskID)
+			got, _, err := store.List(ctx, tc.taskID, 0, "")
 			if err != nil {
 				t.Fatalf("Get() failed: %v", err)
 			}
@@ -400,7 +401,7 @@ func TestInMemoryPushConfigStore_ConcurrenctCreation(t *testing.T) {
 	wg.Wait()
 	close(created)
 
-	configs, err := store.List(ctx, taskID)
+	configs, _, err := store.List(ctx, taskID, 0, "")
 	if err != nil {
 		t.Fatalf("Get() failed: %v", err)
 	}
@@ -437,4 +438,71 @@ func toConfigList(storeConfigs map[a2a.TaskID]map[string]*a2a.PushConfig) map[a2
 		result[taskID] = sortConfigList(configs)
 	}
 	return result
+}
+
+func TestInMemoryPushConfigStore_ListPagination(t *testing.T) {
+	ctx := t.Context()
+	taskID := a2a.TaskID("task")
+
+	store := NewInMemoryStore()
+	const total = 7
+	for i := range total {
+		if _, err := store.Save(ctx, taskID, &a2a.PushConfig{ID: fmt.Sprintf("config-%02d", i), URL: fmt.Sprintf("https://example.com/%d", i)}); err != nil {
+			t.Fatalf("Save() failed: %v", err)
+		}
+	}
+
+	// pageSize <= 0 returns everything and no next page token.
+	configs, next, err := store.List(ctx, taskID, 0, "")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(configs) != total || next != "" {
+		t.Fatalf("List(0) = %d configs, next %q; want %d configs and no token", len(configs), next, total)
+	}
+
+	// Paginate with pageSize 3: pages of 3, 3, 1, in deterministic ID order.
+	var seen []string
+	token := ""
+	pages := 0
+	for {
+		page, nextToken, err := store.List(ctx, taskID, 3, token)
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		for _, c := range page {
+			seen = append(seen, c.ID)
+		}
+		pages++
+		if nextToken == "" {
+			break
+		}
+		token = nextToken
+	}
+	if pages != 3 {
+		t.Fatalf("got %d pages, want 3", pages)
+	}
+	if len(seen) != total {
+		t.Fatalf("collected %d configs, want %d", len(seen), total)
+	}
+	for i, id := range seen {
+		if want := fmt.Sprintf("config-%02d", i); id != want {
+			t.Fatalf("config at position %d = %q, want %q (deterministic ID order)", i, id, want)
+		}
+	}
+
+	// Invalid token format yields an error.
+	if _, _, err := store.List(ctx, taskID, 3, "not-a-token"); !errors.Is(err, a2a.ErrParseError) {
+		t.Fatalf("List() with invalid token error = %v, want ErrParseError", err)
+	}
+
+	// A valid token past the end yields an empty page without a next token.
+	pastEnd := encodePushConfigPageToken(100)
+	page, nextToken, err := store.List(ctx, taskID, 3, pastEnd)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(page) != 0 || nextToken != "" {
+		t.Fatalf("List(past-end token) = %d configs, next %q; want empty page", len(page), nextToken)
+	}
 }

--- a/internal/testutil/push_config_store.go
+++ b/internal/testutil/push_config_store.go
@@ -28,7 +28,7 @@ type TestPushConfigStore struct {
 
 	SaveFunc      func(ctx context.Context, taskID a2a.TaskID, config *a2a.PushConfig) (*a2a.PushConfig, error)
 	GetFunc       func(ctx context.Context, taskID a2a.TaskID, configID string) (*a2a.PushConfig, error)
-	ListFunc      func(ctx context.Context, taskID a2a.TaskID) ([]*a2a.PushConfig, error)
+	ListFunc      func(ctx context.Context, taskID a2a.TaskID, pageSize int, pageToken string) ([]*a2a.PushConfig, string, error)
 	DeleteFunc    func(ctx context.Context, taskID a2a.TaskID, configID string) error
 	DeleteAllFunc func(ctx context.Context, taskID a2a.TaskID) error
 }
@@ -50,11 +50,11 @@ func (m *TestPushConfigStore) Get(ctx context.Context, taskID a2a.TaskID, config
 }
 
 // List implements [push.ConfigStore] interface.
-func (m *TestPushConfigStore) List(ctx context.Context, taskID a2a.TaskID) ([]*a2a.PushConfig, error) {
+func (m *TestPushConfigStore) List(ctx context.Context, taskID a2a.TaskID, pageSize int, pageToken string) ([]*a2a.PushConfig, string, error) {
 	if m.ListFunc != nil {
-		return m.ListFunc(ctx, taskID)
+		return m.ListFunc(ctx, taskID, pageSize, pageToken)
 	}
-	return m.InMemoryPushConfigStore.List(ctx, taskID)
+	return m.InMemoryPushConfigStore.List(ctx, taskID, pageSize, pageToken)
 }
 
 // Delete implements [push.ConfigStore] interface.
@@ -91,8 +91,8 @@ func (m *TestPushConfigStore) SetGetOverride(config *a2a.PushConfig, err error) 
 
 // SetListOverride overrides List execution
 func (m *TestPushConfigStore) SetListOverride(configs []*a2a.PushConfig, err error) *TestPushConfigStore {
-	m.ListFunc = func(ctx context.Context, taskID a2a.TaskID) ([]*a2a.PushConfig, error) {
-		return configs, err
+	m.ListFunc = func(ctx context.Context, taskID a2a.TaskID, pageSize int, pageToken string) ([]*a2a.PushConfig, string, error) {
+		return configs, "", err
 	}
 	return m
 }


### PR DESCRIPTION
## What changed

### 1. Propagate pagination through the push config list path

**Problem:**

`ListTaskPushConfigs` ignored `PageSize`/`PageToken`, and the gRPC v0/v1 handlers hardcoded `NextPageToken: ""`, so push config pagination was never exposed to clients.

**Fix (a2asrv/push/api.go, a2asrv/push/store.go, a2asrv/handler.go, a2agrpc/v0/handler.go, a2agrpc/v1/handler.go, a2asrv/agentexec.go, internal/testutil/push_config_store.go, a2asrv/push/store_test.go):**
- `a2asrv/push/api.go`: extended `ConfigStore.List` to `List(ctx, taskID, pageSize, pageToken) ([]*a2a.PushConfig, string, error)`, returning the next page token.
- `a2asrv/push/store.go`: `InMemoryPushConfigStore.List` now sorts config IDs deterministically and applies offset-based pagination when `pageSize > 0`; tokens are opaque base64url-encoded offsets; invalid tokens return `a2a.ErrParseError`.
- `a2asrv/handler.go`: `ListTaskPushConfigs` passes `req.PageSize`/`req.PageToken` through and returns `NextPageToken` in the response.
- `a2agrpc/v0/handler.go` and `a2agrpc/v1/handler.go`: propagate `configs.NextPageToken` instead of `""`.
- `a2asrv/agentexec.go` and `internal/testutil/push_config_store.go`: updated to the new `List` signature.
- `a2asrv/push/store_test.go`: added `TestInMemoryPushConfigStore_ListPagination` covering full listing, a 3-page walk, invalid tokens, and past-end tokens.

## Testing

- Full suite — 21 packages pass (`go test ./a2asrv/... ./internal/... ./a2agrpc/... ./a2apb/... ./a2acompat/... ./a2a/ ./a2aclient/...`).
- New `TestInMemoryPushConfigStore_ListPagination` passes.
- `go build ./...` passes.

Behavior change: gRPC `ListTaskPushNotificationConfig(s)` with `pageSize` set now returns paginated results plus a `nextPageToken`; previously the token was always empty.
