### PR TITLE
fix(grpcutil): resolve ambiguous code-only error mappings conservatively

### DIFF
--- a/internal/grpcutil/errors.go
+++ b/internal/grpcutil/errors.go
@@ -169,11 +169,19 @@ func FromGRPCError(err error) error {
 			}
 		}
 	} else {
+		// No ErrorInfo reason: matching by code alone is ambiguous because
+		// several a2a errors share a gRPC code (e.g. FailedPrecondition maps
+		// to ErrTaskNotCancelable, ErrUnsupportedOperation, ...). Use the
+		// single mapping when only one error exists for the code, otherwise
+		// fall back to the conservative generic error instead of guessing.
+		var matched []error
 		for _, mapping := range errorMappings {
 			if s.Code() == mapping.code {
-				baseErr = mapping.err
-				break
+				matched = append(matched, mapping.err)
 			}
+		}
+		if len(matched) == 1 {
+			baseErr = matched[0]
 		}
 	}
 

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc/codes"
@@ -435,5 +436,85 @@ func TestFromGRPCErrorEdgeCases(t *testing.T) {
 				t.Errorf("FromGRPCError() base error = %v, want %v", gotBaseErr, wantErr)
 			}
 		})
+	}
+}
+
+// TestFromGRPCErrorCodeOnlyFallback is a regression test for BUG-24: when a
+// gRPC status carries no ErrorInfo reason, matching by code alone is
+// ambiguous for codes shared by several a2a errors. A single mapping for the
+// code is used; ambiguous codes fall back to the conservative ErrInternalError.
+func TestFromGRPCErrorCodeOnlyFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "single-candidate NotFound maps to ErrTaskNotFound",
+			err:  status.Error(codes.NotFound, "not found"),
+			want: a2a.ErrTaskNotFound,
+		},
+		{
+			name: "single-candidate Unimplemented maps to ErrMethodNotFound",
+			err:  status.Error(codes.Unimplemented, "unimplemented"),
+			want: a2a.ErrMethodNotFound,
+		},
+		{
+			name: "single-candidate Canceled maps to context.Canceled",
+			err:  status.Error(codes.Canceled, "canceled"),
+			want: context.Canceled,
+		},
+		{
+			name: "ambiguous FailedPrecondition falls back to ErrInternalError",
+			err:  status.Error(codes.FailedPrecondition, "failed precondition"),
+			want: a2a.ErrInternalError,
+		},
+		{
+			name: "ambiguous InvalidArgument falls back to ErrInternalError",
+			err:  status.Error(codes.InvalidArgument, "invalid argument"),
+			want: a2a.ErrInternalError,
+		},
+		{
+			name: "ambiguous Internal falls back to ErrInternalError",
+			err:  status.Error(codes.Internal, "internal"),
+			want: a2a.ErrInternalError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := FromGRPCError(tc.err)
+			var a2aErr *a2a.Error
+			if !errors.As(got, &a2aErr) {
+				t.Fatalf("FromGRPCError() = %T, want *a2a.Error", got)
+			}
+			if !errors.Is(a2aErr.Err, tc.want) {
+				t.Errorf("FromGRPCError() base error = %v, want %v", a2aErr.Err, tc.want)
+			}
+		})
+	}
+}
+
+// TestFromGRPCErrorReasonPriority verifies that a matching ErrorInfo reason
+// takes priority over the code-only fallback, even for ambiguous codes.
+func TestFromGRPCErrorReasonPriority(t *testing.T) {
+	t.Parallel()
+
+	st := status.New(codes.FailedPrecondition, "unsupported operation")
+	st, err := st.WithDetails(&errdetails.ErrorInfo{Reason: a2a.ErrorReason(a2a.ErrUnsupportedOperation), Domain: a2a.ProtocolDomain})
+	if err != nil {
+		t.Fatalf("WithDetails() error = %v", err)
+	}
+
+	got := FromGRPCError(st.Err())
+	var a2aErr *a2a.Error
+	if !errors.As(got, &a2aErr) {
+		t.Fatalf("FromGRPCError() = %T, want *a2a.Error", got)
+	}
+	if !errors.Is(a2aErr.Err, a2a.ErrUnsupportedOperation) {
+		t.Errorf("FromGRPCError() base error = %v, want ErrUnsupportedOperation", a2aErr.Err)
 	}
 }

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -439,7 +439,7 @@ func TestFromGRPCErrorEdgeCases(t *testing.T) {
 	}
 }
 
-// TestFromGRPCErrorCodeOnlyFallback is a regression test for BUG-24: when a
+// TestFromGRPCErrorCodeOnlyFallback is a regression test for gRPC code-only fallback: when a
 // gRPC status carries no ErrorInfo reason, matching by code alone is
 // ambiguous for codes shared by several a2a errors. A single mapping for the
 // code is used; ambiguous codes fall back to the conservative ErrInternalError.

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )


### PR DESCRIPTION
## What changed

### 1. Resolve ambiguous code-only gRPC error mappings conservatively

**Problem:**

When a gRPC status carries no `ErrorInfo` reason, `FromGRPCError` matched by code alone and picked the first mapping for that code. Several a2a errors share a gRPC code (e.g. `FailedPrecondition` maps to `ErrTaskNotCancelable`, `ErrUnsupportedOperation`, ...), so the picked error could be the wrong one.

**Fix (internal/grpcutil/errors.go, internal/grpcutil/errors_test.go):**
- Collect every mapping whose code matches; use the single candidate when exactly one exists.
- When multiple a2a errors share the code, fall back to the conservative `a2a.ErrInternalError` instead of guessing.
- An explicit `ErrorInfo` reason still takes priority over the code-only fallback.
- Added `TestFromGRPCErrorCodeOnlyFallback` and `TestFromGRPCErrorReasonPriority`.

## Testing

- `go test ./internal/grpcutil/ ./a2agrpc/... ./a2aclient/...` — all pass.
- New tests cover single-candidate mapping (NotFound, Unimplemented, Canceled), ambiguous fallback (FailedPrecondition, InvalidArgument, Internal), and reason priority.

Behavior change: code-only errors for codes shared by several a2a errors now map to `ErrInternalError` instead of an arbitrary one; single-candidate and reason-based mappings are unchanged.
