### PR TITLE
fix(taskstore): make page tokens unambiguous for task IDs containing underscores

### DIFF
--- a/a2asrv/taskstore/inmemory.go
+++ b/a2asrv/taskstore/inmemory.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -319,7 +320,11 @@ func toListTasksResult(tasks []*storedTask, req *a2a.ListTasksRequest) ([]*a2a.T
 
 func encodePageToken(updatedTime time.Time, taskID a2a.TaskID) string {
 	timeStrNano := updatedTime.Format(time.RFC3339Nano)
-	return base64.URLEncoding.EncodeToString(fmt.Appendf(nil, "%s_%s", timeStrNano, taskID))
+	// The task ID is client-controlled and may itself contain "_", so a plain
+	// "_" separator would make the token ambiguous. Prefix the ID with its
+	// byte length so the fields can be split unambiguously. The whole token
+	// remains base64url-encoded as before.
+	return base64.URLEncoding.EncodeToString(fmt.Appendf(nil, "%s_%d_%s", timeStrNano, len(taskID), taskID))
 }
 
 func decodePageToken(nextPageToken string) (time.Time, a2a.TaskID, error) {
@@ -328,17 +333,28 @@ func decodePageToken(nextPageToken string) (time.Time, a2a.TaskID, error) {
 		return time.Time{}, "", a2a.ErrParseError
 	}
 
-	parts := strings.Split(string(decoded), "_")
-	if len(parts) != 2 {
+	// New tokens have the form "<time>_<length>_<taskID>". Legacy tokens
+	// (without the length prefix) have the form "<time>_<taskID>" and are
+	// still accepted for backward compatibility.
+	parts := strings.SplitN(string(decoded), "_", 3)
+	var taskID string
+	switch len(parts) {
+	case 2: // legacy format
+		taskID = parts[1]
+	case 3: // length-prefixed format
+		length, err := strconv.Atoi(parts[1])
+		if err != nil || length < 0 || length != len(parts[2]) {
+			return time.Time{}, "", a2a.ErrParseError
+		}
+		taskID = parts[2]
+	default:
 		return time.Time{}, "", a2a.ErrParseError
 	}
-
-	taskID := a2a.TaskID(parts[1])
 
 	updatedTime, err := time.Parse(time.RFC3339Nano, parts[0])
 	if err != nil {
 		return time.Time{}, "", a2a.ErrParseError
 	}
 
-	return updatedTime, taskID, nil
+	return updatedTime, a2a.TaskID(taskID), nil
 }

--- a/a2asrv/taskstore/store_test.go
+++ b/a2asrv/taskstore/store_test.go
@@ -578,3 +578,85 @@ func TestInMemoryTaskStore_CrossTenantIsolation(t *testing.T) {
 		t.Fatalf("alice task ID mismatch")
 	}
 }
+
+// TestInMemoryTaskStore_List_PageTokenWithUnderscoreIDs is a regression test
+// for BUG-25: page tokens are encoded as "<time>_<taskID>", so a task ID
+// containing "_" made the token undecodable (Split("_") produced more than
+// two parts) and pagination broke for such tasks.
+func TestInMemoryTaskStore_List_PageTokenWithUnderscoreIDs(t *testing.T) {
+	store := NewInMemory(&InMemoryStoreConfig{Authenticator: getAuthInfo, TimeProvider: newIncreasingTimeProvider(startTime)})
+	// IDs containing underscores, exactly the case the old "_" separator broke.
+	tasks := []*a2a.Task{
+		{ID: "task_a", ContextID: "ctx"},
+		{ID: "task_b_1", ContextID: "ctx"},
+		{ID: "task_c__double", ContextID: "ctx"},
+	}
+	mustCreate(t, store, tasks...)
+
+	// Walk every page (pageSize 1) and collect all task IDs.
+	var collected []string
+	pageToken := ""
+	for {
+		resp, err := store.List(t.Context(), &a2a.ListTasksRequest{PageSize: 1, PageToken: pageToken, ContextID: "ctx"})
+		if err != nil {
+			t.Fatalf("store.List() error = %v", err)
+		}
+		for _, task := range resp.Tasks {
+			collected = append(collected, string(task.ID))
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+		if len(collected) > len(tasks) {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	want := []string{"task_c__double", "task_b_1", "task_a"} // newest first, as List orders by lastUpdated desc
+	if !reflect.DeepEqual(collected, want) {
+		t.Fatalf("collected task IDs = %v, want %v", collected, want)
+	}
+}
+
+func TestPageTokenRoundTrip(t *testing.T) {
+	updatedTime := time.Date(2026, 6, 20, 12, 0, 0, 123456789, time.UTC)
+
+	t.Run("task ID with underscores round-trips", func(t *testing.T) {
+		taskID := a2a.TaskID("task_a_b_c")
+		token := encodePageToken(updatedTime, taskID)
+		gotTime, gotID, err := decodePageToken(token)
+		if err != nil {
+			t.Fatalf("decodePageToken() error = %v", err)
+		}
+		if !gotTime.Equal(updatedTime) {
+			t.Errorf("decodePageToken() time = %v, want %v", gotTime, updatedTime)
+		}
+		if gotID != taskID {
+			t.Errorf("decodePageToken() taskID = %q, want %q", gotID, taskID)
+		}
+	})
+
+	t.Run("legacy token without length prefix still decodes", func(t *testing.T) {
+		taskID := a2a.TaskID("plain-id")
+		timeStrNano := updatedTime.Format(time.RFC3339Nano)
+		legacyToken := base64.URLEncoding.EncodeToString(fmt.Appendf(nil, "%s_%s", timeStrNano, taskID))
+		gotTime, gotID, err := decodePageToken(legacyToken)
+		if err != nil {
+			t.Fatalf("decodePageToken() legacy token error = %v", err)
+		}
+		if !gotTime.Equal(updatedTime) {
+			t.Errorf("decodePageToken() time = %v, want %v", gotTime, updatedTime)
+		}
+		if gotID != taskID {
+			t.Errorf("decodePageToken() taskID = %q, want %q", gotID, taskID)
+		}
+	})
+
+	t.Run("corrupted length prefix is rejected", func(t *testing.T) {
+		badToken := base64.URLEncoding.EncodeToString([]byte("2026-06-20T12:00:00.123456789Z_99_short"))
+		if _, _, err := decodePageToken(badToken); !errors.Is(err, a2a.ErrParseError) {
+			t.Fatalf("decodePageToken() error = %v, want ErrParseError", err)
+		}
+	})
+}

--- a/a2asrv/taskstore/store_test.go
+++ b/a2asrv/taskstore/store_test.go
@@ -580,7 +580,7 @@ func TestInMemoryTaskStore_CrossTenantIsolation(t *testing.T) {
 }
 
 // TestInMemoryTaskStore_List_PageTokenWithUnderscoreIDs is a regression test
-// for BUG-25: page tokens are encoded as "<time>_<taskID>", so a task ID
+// for page token separator handling: page tokens are encoded as "<time>_<taskID>", so a task ID
 // containing "_" made the token undecodable (Split("_") produced more than
 // two parts) and pagination broke for such tasks.
 func TestInMemoryTaskStore_List_PageTokenWithUnderscoreIDs(t *testing.T) {


### PR DESCRIPTION
## What changed

### 1. Make task page tokens unambiguous for IDs containing underscores

**Problem:**

Page tokens were encoded as `<time>_<taskID>` and decoded with `strings.Split(decoded, "_")`. The task ID is client-controlled and may itself contain `_`, so such tokens produced more than two parts and pagination broke for those tasks.

**Fix (a2asrv/taskstore/inmemory.go, a2asrv/taskstore/store_test.go):**
- New token format `<time>_<length>_<taskID>`, where `<length>` is the byte length of the task ID; decoding uses `SplitN(_, 3)` plus a length check.
- Legacy `<time>_<taskID>` tokens are still accepted for backward compatibility.
- Corrupted length prefixes are rejected with `a2a.ErrParseError`.
- Added `TestInMemoryTaskStore_List_PageTokenWithUnderscoreIDs` and `TestPageTokenRoundTrip`.

## Testing

- `go test ./a2asrv/... ./internal/...` — all pass.
- New tests cover underscore IDs (single and double), legacy-token decoding, and corrupted length-prefix rejection.

Behavior change: the token format is now `<time>_<length>_<taskID>`; tokens produced by older versions still decode.
