### PR TITLE
fix(push): map missing push config to task-not-found class across transports

### DIFF
--- a/a2agrpc/v1/handler_test.go
+++ b/a2agrpc/v1/handler_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2apb/v1"
 	"github.com/a2aproject/a2a-go/v2/a2apb/v1/pbconv"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
+	"github.com/a2aproject/a2a-go/v2/internal/testutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -1277,5 +1279,50 @@ func TestGrpcHandler_GetExtendedAgentCard(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// minimalExecutor is a no-op AgentExecutor used to build a real
+// a2asrv.defaultRequestHandler for transport-level tests.
+type minimalExecutor struct{}
+
+func (minimalExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {}
+}
+
+func (minimalExecutor) Cancel(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {}
+}
+
+// TestGrpcHandler_GetTaskPushNotificationConfig_NotFound is a regression test
+// for BUG-36: a missing push config must surface as gRPC NotFound, not a
+// generic internal error.
+func TestGrpcHandler_GetTaskPushNotificationConfig_NotFound(t *testing.T) {
+	ctx := t.Context()
+	taskID := a2a.TaskID("test-task")
+	ts := testutil.NewTestTaskStoreWithConfig(&taskstore.InMemoryStoreConfig{
+		Authenticator: func(ctx context.Context) (string, error) { return "test", nil },
+	}).WithTasks(t, &a2a.Task{ID: taskID, ContextID: "test-context"})
+	ps := testutil.NewTestPushConfigStore()
+	pn := testutil.NewTestPushSender(t)
+	reqHandler := a2asrv.NewHandler(minimalExecutor{},
+		a2asrv.WithTaskStore(ts),
+		a2asrv.WithPushNotifications(ps, pn),
+	)
+	client := startTestServer(t, reqHandler)
+
+	_, err := client.GetTaskPushNotificationConfig(ctx, &a2apb.GetTaskPushNotificationConfigRequest{
+		TaskId: string(taskID),
+		Id:     "non-existent",
+	})
+	if err == nil {
+		t.Fatal("GetTaskPushNotificationConfig() expected error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("GetTaskPushNotificationConfig() error is not a gRPC status error: %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("GetTaskPushNotificationConfig() got error code %v, want NotFound", st.Code())
 	}
 }

--- a/a2agrpc/v1/handler_test.go
+++ b/a2agrpc/v1/handler_test.go
@@ -1295,7 +1295,7 @@ func (minimalExecutor) Cancel(ctx context.Context, execCtx *a2asrv.ExecutorConte
 }
 
 // TestGrpcHandler_GetTaskPushNotificationConfig_NotFound is a regression test
-// for BUG-36: a missing push config must surface as gRPC NotFound, not a
+// for missing push config handling: a missing push config must surface as gRPC NotFound, not a
 // generic internal error.
 func TestGrpcHandler_GetTaskPushNotificationConfig_NotFound(t *testing.T) {
 	ctx := t.Context()

--- a/a2asrv/handler.go
+++ b/a2asrv/handler.go
@@ -16,6 +16,7 @@ package a2asrv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
@@ -409,10 +410,16 @@ func (h *defaultRequestHandler) GetTaskPushConfig(ctx context.Context, req *a2a.
 	}
 	config, err := h.pushConfigStore.Get(ctx, req.TaskID, req.ID)
 	if err != nil {
+		if errors.Is(err, push.ErrPushConfigNotFound) {
+			// Map a missing push config to the task-not-found class so every
+			// transport reports it as not found (REST 404, JSON-RPC -32001,
+			// gRPC NotFound) instead of an unmapped internal error.
+			return nil, fmt.Errorf("push config %q not found: %w", req.ID, a2a.ErrTaskNotFound)
+		}
 		return nil, fmt.Errorf("failed to get push config: %w", err)
 	}
 	if config == nil {
-		return nil, push.ErrPushConfigNotFound
+		return nil, fmt.Errorf("push config %q not found: %w", req.ID, a2a.ErrTaskNotFound)
 	}
 	return config, nil
 }

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -1963,7 +1963,7 @@ func TestRequestHandler_GetTaskPushConfig(t *testing.T) {
 		{
 			name:    "non-existent config",
 			req:     &a2a.GetTaskPushConfigRequest{TaskID: taskID, ID: "non-existent"},
-			wantErr: push.ErrPushConfigNotFound,
+			wantErr: a2a.ErrTaskNotFound, // mapped from ErrPushConfigNotFound (BUG-36)
 			options: []RequestHandlerOption{
 				WithPushNotifications(ps, pn),
 				withTestTask(t, taskID),

--- a/a2asrv/handler_test.go
+++ b/a2asrv/handler_test.go
@@ -1963,7 +1963,7 @@ func TestRequestHandler_GetTaskPushConfig(t *testing.T) {
 		{
 			name:    "non-existent config",
 			req:     &a2a.GetTaskPushConfigRequest{TaskID: taskID, ID: "non-existent"},
-			wantErr: a2a.ErrTaskNotFound, // mapped from ErrPushConfigNotFound (BUG-36)
+			wantErr: a2a.ErrTaskNotFound, // mapped from ErrPushConfigNotFound
 			options: []RequestHandlerOption{
 				WithPushNotifications(ps, pn),
 				withTestTask(t, taskID),

--- a/a2asrv/jsonrpc_test.go
+++ b/a2asrv/jsonrpc_test.go
@@ -449,3 +449,43 @@ func mustUnmarshal(t *testing.T, data []byte) map[string]any {
 	}
 	return result
 }
+
+// TestJSONRPC_GetTaskPushConfig_NotFound is a regression test for BUG-36: a
+// missing push config must be reported as JSON-RPC -32001 (task-not-found
+// class) instead of a generic internal error.
+func TestJSONRPC_GetTaskPushConfig_NotFound(t *testing.T) {
+	ctx := t.Context()
+	taskID := a2a.NewTaskID()
+	ps := testutil.NewTestPushConfigStore()
+	pn := testutil.NewTestPushSender(t)
+	reqHandler := newTestHandler(
+		WithPushNotifications(ps, pn),
+		withTestTask(t, taskID),
+	)
+	server := httptest.NewServer(NewJSONRPCHandler(reqHandler))
+	t.Cleanup(server.Close)
+
+	params := json.RawMessage(fmt.Sprintf(`{"taskId": %q, "id": "non-existent"}`, taskID))
+	request := mustMarshal(t, jsonrpc.ServerRequest{JSONRPC: "2.0", Method: jsonrpc.MethodPushConfigGet, Params: params, ID: "123"})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL, bytes.NewBuffer(request))
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() error = %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var payload jsonrpc.ServerResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decoder.Decode() error = %v", err)
+	}
+	if payload.Error == nil {
+		t.Fatal("expected an error response, got nil")
+	}
+	if !errors.Is(jsonrpc.FromJSONRPCError(payload.Error), a2a.ErrTaskNotFound) {
+		t.Errorf("payload.Error = %v, want TaskNotFound (-32001)", payload.Error)
+	}
+}

--- a/a2asrv/jsonrpc_test.go
+++ b/a2asrv/jsonrpc_test.go
@@ -450,7 +450,7 @@ func mustUnmarshal(t *testing.T, data []byte) map[string]any {
 	return result
 }
 
-// TestJSONRPC_GetTaskPushConfig_NotFound is a regression test for BUG-36: a
+// TestJSONRPC_GetTaskPushConfig_NotFound is a regression test for missing push config handling: a
 // missing push config must be reported as JSON-RPC -32001 (task-not-found
 // class) instead of a generic internal error.
 func TestJSONRPC_GetTaskPushConfig_NotFound(t *testing.T) {

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -711,7 +711,7 @@ func TestREST_GetTask_Success(t *testing.T) {
 	}
 }
 
-// TestREST_GetTaskPushConfig_NotFound is a regression test for BUG-36: a
+// TestREST_GetTaskPushConfig_NotFound is a regression test for missing push config handling: a
 // missing push config must be reported as HTTP 404 (task-not-found class)
 // instead of a generic 500.
 func TestREST_GetTaskPushConfig_NotFound(t *testing.T) {

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -710,3 +710,35 @@ func TestREST_GetTask_Success(t *testing.T) {
 		})
 	}
 }
+
+// TestREST_GetTaskPushConfig_NotFound is a regression test for BUG-36: a
+// missing push config must be reported as HTTP 404 (task-not-found class)
+// instead of a generic 500.
+func TestREST_GetTaskPushConfig_NotFound(t *testing.T) {
+	ctx := t.Context()
+	taskID := a2a.NewTaskID()
+	ps := testutil.NewTestPushConfigStore()
+	pn := testutil.NewTestPushSender(t)
+	reqHandler := newTestHandler(
+		WithPushNotifications(ps, pn),
+		withTestTask(t, taskID),
+	)
+	server := httptest.NewServer(NewRESTHandler(reqHandler))
+	t.Cleanup(server.Close)
+
+	path := rest.MakeGetPushConfigPath(string(taskID), "non-existent")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+path, nil)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() error = %v", err)
+	}
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("server.Client().Do() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected HTTP 404, got %d: %s", resp.StatusCode, body)
+	}
+}


### PR DESCRIPTION
## What changed

### 1. Map a missing push config to the task-not-found error class

**Problem:**

`GetTaskPushConfig` surfaced a missing config as `push.ErrPushConfigNotFound`, an unmapped error that each transport reported as a generic internal error (HTTP 500 / JSON-RPC -32603 / gRPC Unknown) instead of a not-found response.

**Fix (a2asrv/handler.go, a2asrv/rest_test.go, a2asrv/jsonrpc_test.go, a2agrpc/v1/handler_test.go, a2asrv/handler_test.go):**
- Wrap a missing config (`push.ErrPushConfigNotFound` and the nil-config case) as `a2a.ErrTaskNotFound` so every transport reports the task-not-found class: REST 404, JSON-RPC -32001, gRPC NotFound.
- Added transport-level regression tests: `TestREST_GetTaskPushConfig_NotFound` (REST, `a2asrv/rest_test.go`), `TestJSONRPC_GetTaskPushConfig_NotFound` (JSON-RPC, `a2asrv/jsonrpc_test.go`), `TestGrpcHandler_GetTaskPushNotificationConfig_NotFound` (gRPC v1, `a2agrpc/v1/handler_test.go`), and updated the handler assertion in `a2asrv/handler_test.go`.

## Testing

- `go test ./a2asrv/... ./a2agrpc/... ./internal/...` — all pass, including the three new transport-level 404/-32001/NotFound tests.

Behavior change: `GetTaskPushConfig` on a non-existent config now returns a task-not-found class error (404/-32001/NotFound) instead of a generic internal error.
