### PR TITLE
fix(taskstate): reject unknown task state values on unmarshal and REST status param

### DIFF
--- a/a2a/core.go
+++ b/a2a/core.go
@@ -319,12 +319,20 @@ func (ts *TaskState) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	if s == "TASK_STATE_UNSPECIFIED" {
+	switch s {
+	case "TASK_STATE_UNSPECIFIED":
 		*ts = TaskStateUnspecified
 		return nil
+	case string(TaskStateAuthRequired), string(TaskStateCanceled), string(TaskStateCompleted),
+		string(TaskStateFailed), string(TaskStateInputRequired), string(TaskStateRejected),
+		string(TaskStateSubmitted), string(TaskStateWorking):
+		*ts = TaskState(s)
+		return nil
+	default:
+		// Reject unknown values instead of silently accepting them; an
+		// invalid enum token must not pass as a valid task state.
+		return fmt.Errorf("invalid task state %q", s)
 	}
-	*ts = TaskState(s)
-	return nil
 }
 
 // Terminal returns true for states in which a Task becomes immutable, i.e. no further

--- a/a2a/json_test.go
+++ b/a2a/json_test.go
@@ -367,3 +367,41 @@ func TestMessageRole_Codec(t *testing.T) {
 		}
 	}
 }
+
+// TestTaskStateUnmarshalJSON is a regression test for BUG-37: unknown task
+// state values must be rejected during JSON unmarshaling instead of being
+// silently accepted as an opaque enum value.
+func TestTaskStateUnmarshalJSON(t *testing.T) {
+	valid := []struct {
+		json string
+		want TaskState
+	}{
+		{`"TASK_STATE_UNSPECIFIED"`, TaskStateUnspecified},
+		{`"TASK_STATE_AUTH_REQUIRED"`, TaskStateAuthRequired},
+		{`"TASK_STATE_CANCELED"`, TaskStateCanceled},
+		{`"TASK_STATE_COMPLETED"`, TaskStateCompleted},
+		{`"TASK_STATE_FAILED"`, TaskStateFailed},
+		{`"TASK_STATE_INPUT_REQUIRED"`, TaskStateInputRequired},
+		{`"TASK_STATE_REJECTED"`, TaskStateRejected},
+		{`"TASK_STATE_SUBMITTED"`, TaskStateSubmitted},
+		{`"TASK_STATE_WORKING"`, TaskStateWorking},
+	}
+	for _, tc := range valid {
+		var state TaskState
+		if err := json.Unmarshal([]byte(tc.json), &state); err != nil {
+			t.Errorf("UnmarshalJSON(%s) error = %v", tc.json, err)
+			continue
+		}
+		if state != tc.want {
+			t.Errorf("UnmarshalJSON(%s) = %q, want %q", tc.json, state, tc.want)
+		}
+	}
+
+	invalid := []string{`""`, `"BOGUS_STATE"`, `"task_state_completed"`, `"TASK_STATE_"`}
+	for _, tc := range invalid {
+		var state TaskState
+		if err := json.Unmarshal([]byte(tc), &state); err == nil {
+			t.Errorf("UnmarshalJSON(%s) = %q, want an error", tc, state)
+		}
+	}
+}

--- a/a2a/json_test.go
+++ b/a2a/json_test.go
@@ -368,7 +368,7 @@ func TestMessageRole_Codec(t *testing.T) {
 	}
 }
 
-// TestTaskStateUnmarshalJSON is a regression test for BUG-37: unknown task
+// TestTaskStateUnmarshalJSON is a regression test for task state validation: unknown task
 // state values must be rejected during JSON unmarshaling instead of being
 // silently accepted as an opaque enum value.
 func TestTaskStateUnmarshalJSON(t *testing.T) {

--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -181,6 +181,12 @@ func (h *restHandler) handleListTasks(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
+	status, err := parseTaskStateOpt(query, "status")
+	if err != nil {
+		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
+		return
+	}
+
 	statusTimestampAfter, err := parseTimeOpt(query, "statusTimestampAfter")
 	if err != nil {
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
@@ -189,7 +195,7 @@ func (h *restHandler) handleListTasks(rw http.ResponseWriter, req *http.Request)
 
 	request := &a2a.ListTasksRequest{
 		ContextID:            query.Get("contextId"),
-		Status:               a2a.TaskState(query.Get("status")),
+		Status:               status,
 		PageSize:             pageSize,
 		PageToken:            query.Get("pageToken"),
 		HistoryLength:        historyLength,
@@ -564,4 +570,18 @@ func parseBool(query url.Values, key string) (bool, error) {
 		return false, fmt.Errorf("invalid %s: %w", key, err)
 	}
 	return v, nil
+}
+
+func parseTaskStateOpt(query url.Values, key string) (a2a.TaskState, error) {
+	val := query.Get(key)
+	if val == "" {
+		return a2a.TaskStateUnspecified, nil
+	}
+	// Reuse TaskState's own validation by unmarshaling the quoted value;
+	// unknown states are rejected here instead of silently reaching the handler.
+	var state a2a.TaskState
+	if err := json.Unmarshal([]byte(strconv.Quote(val)), &state); err != nil {
+		return a2a.TaskStateUnspecified, fmt.Errorf("invalid %s: %w", key, err)
+	}
+	return state, nil
 }

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -711,7 +711,7 @@ func TestREST_GetTask_Success(t *testing.T) {
 	}
 }
 
-// TestREST_ListTasks_InvalidStatus is a regression test for BUG-37: an
+// TestREST_ListTasks_InvalidStatus is a regression test for task state validation: an
 // invalid status query parameter must be rejected with HTTP 400 instead of
 // being silently passed through as an opaque TaskState.
 func TestREST_ListTasks_InvalidStatus(t *testing.T) {

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -605,7 +605,7 @@ func TestREST_ListTasks_Success(t *testing.T) {
 
 	query := url.Values{}
 	query.Set("contextId", "ctx-999")
-	query.Set("status", "running")
+	query.Set("status", "TASK_STATE_WORKING")
 	query.Set("pageSize", "50")
 	query.Set("pageToken", "next-page-token")
 	query.Set("historyLength", "100")
@@ -629,7 +629,7 @@ func TestREST_ListTasks_Success(t *testing.T) {
 	intPtr := func(i int) *int { return &i }
 	want := &a2a.ListTasksRequest{
 		ContextID:            "ctx-999",
-		Status:               a2a.TaskState("running"),
+		Status:               a2a.TaskStateWorking,
 		PageSize:             50,
 		PageToken:            "next-page-token",
 		IncludeArtifacts:     true,
@@ -708,5 +708,21 @@ func TestREST_GetTask_Success(t *testing.T) {
 				t.Fatalf("getTask request mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestREST_ListTasks_InvalidStatus is a regression test for BUG-37: an
+// invalid status query parameter must be rejected with HTTP 400 instead of
+// being silently passed through as an opaque TaskState.
+func TestREST_ListTasks_InvalidStatus(t *testing.T) {
+	mock := &mockRequestHandler{}
+	handler := NewRESTHandler(mock)
+
+	req := httptest.NewRequest(http.MethodGet, rest.MakeListTasksPath()+"?status=BOGUS_STATE", nil)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusBadRequest {
+		t.Fatalf("expected HTTP 400, got %d. body: %s", rw.Code, rw.Body.String())
 	}
 }


### PR DESCRIPTION
## What changed

### 1. Reject unknown TaskState values on unmarshal

**Problem:**

`TaskState.UnmarshalJSON` accepted any string as an opaque enum value, so malformed or unknown states (e.g. `"BOGUS_STATE"`, lowercase values) passed validation silently.

**Fix (a2a/core.go, a2a/json_test.go):**
- Restrict unmarshal to the known enum values (plus `TASK_STATE_UNSPECIFIED`); anything else returns `invalid task state %q`.
- Added `TestTaskStateUnmarshalJSON` covering all valid states and invalid inputs.

### 2. Validate the REST ListTasks `status` query parameter

**Problem:**

`handleListTasks` built the request from `a2a.TaskState(query.Get("status"))` with no validation, so an invalid status reached the handler instead of producing a client error.

**Fix (a2asrv/rest.go, a2asrv/rest_test.go):**
- Added `parseTaskStateOpt`, which reuses `TaskState`'s own validation (quoted unmarshal) and rejects unknown values with HTTP 400.
- Added `TestREST_ListTasks_InvalidStatus`; updated `TestREST_ListTasks_Success` to use `TASK_STATE_WORKING` instead of the previously silently-accepted `running`.

## Testing

- Full suite passes (`go test ./a2asrv/... ./internal/... ./a2agrpc/... ./a2apb/... ./a2acompat/... ./a2a/ ./a2aclient/...`).
- New `TestTaskStateUnmarshalJSON` and `TestREST_ListTasks_InvalidStatus` pass.

Behavior change: unknown task state values are now rejected during JSON unmarshaling and in the REST `status` query parameter.
