### PR TITLE
fix(push): cap push notification configs per task

### DIFF
--- a/a2asrv/push/store.go
+++ b/a2asrv/push/store.go
@@ -64,7 +64,7 @@ func validateConfig(config *a2a.PushConfig) error {
 
 // maxPushConfigsPerTask caps the number of push notification configs a single
 // task may register. Without a limit a client could grow the store without
-// bound (BUG-42).
+// bound.
 const maxPushConfigsPerTask = 50
 
 // Save adds a copy of push config to the store.

--- a/a2asrv/push/store.go
+++ b/a2asrv/push/store.go
@@ -62,6 +62,11 @@ func validateConfig(config *a2a.PushConfig) error {
 	return nil
 }
 
+// maxPushConfigsPerTask caps the number of push notification configs a single
+// task may register. Without a limit a client could grow the store without
+// bound (BUG-42).
+const maxPushConfigsPerTask = 50
+
 // Save adds a copy of push config to the store.
 func (s *InMemoryPushConfigStore) Save(ctx context.Context, taskID a2a.TaskID, config *a2a.PushConfig) (*a2a.PushConfig, error) {
 	if err := validateConfig(config); err != nil {
@@ -81,10 +86,17 @@ func (s *InMemoryPushConfigStore) Save(ctx context.Context, taskID a2a.TaskID, c
 	}
 	toSave.TaskID = taskID
 
-	if _, ok := s.configs[taskID]; !ok {
-		s.configs[taskID] = make(map[string]*a2a.PushConfig)
+	configs, ok := s.configs[taskID]
+	if !ok {
+		configs = make(map[string]*a2a.PushConfig)
+		s.configs[taskID] = configs
 	}
-	s.configs[taskID][toSave.ID] = toSave
+	// Updating an existing config is always allowed; only new insertions are
+	// subject to the per-task limit.
+	if _, exists := configs[toSave.ID]; !exists && len(configs) >= maxPushConfigsPerTask {
+		return nil, fmt.Errorf("%w: task %s already has the maximum number of push notification configs (%d)", a2a.ErrInvalidParams, taskID, maxPushConfigsPerTask)
+	}
+	configs[toSave.ID] = toSave
 
 	savedCopy, err := utils.DeepCopy(toSave)
 	if err != nil {

--- a/a2asrv/push/store_test.go
+++ b/a2asrv/push/store_test.go
@@ -381,7 +381,8 @@ func TestInMemoryPushConfigStore_ConcurrenctCreation(t *testing.T) {
 	var wg sync.WaitGroup
 	store := NewInMemoryStore()
 	taskID := a2a.TaskID("concurrent-task")
-	numGoroutines := 100
+	// Stay within the per-task config limit so every concurrent save succeeds.
+	numGoroutines := maxPushConfigsPerTask
 	created := make(chan *a2a.PushConfig, numGoroutines)
 
 	for i := range numGoroutines {
@@ -437,4 +438,45 @@ func toConfigList(storeConfigs map[a2a.TaskID]map[string]*a2a.PushConfig) map[a2
 		result[taskID] = sortConfigList(configs)
 	}
 	return result
+}
+
+// TestInMemoryPushConfigStore_MaxConfigsPerTask is a regression test for
+// BUG-42: a task must not be able to register more than maxPushConfigsPerTask
+// push configs; exceeding the limit returns an error, while updating an
+// existing config at the limit is still allowed.
+func TestInMemoryPushConfigStore_MaxConfigsPerTask(t *testing.T) {
+	ctx := t.Context()
+	taskID := a2a.TaskID("task")
+
+	store := NewInMemoryStore()
+	for i := range maxPushConfigsPerTask {
+		_, err := store.Save(ctx, taskID, &a2a.PushConfig{ID: fmt.Sprintf("config-%03d", i), URL: "https://example.com/push"})
+		if err != nil {
+			t.Fatalf("Save() %d failed: %v", i, err)
+		}
+	}
+
+	// A new config beyond the limit is rejected.
+	if _, err := store.Save(ctx, taskID, &a2a.PushConfig{URL: "https://example.com/overflow"}); err == nil {
+		t.Fatal("Save() beyond the limit succeeded, want an error")
+	}
+
+	// Updating an existing config at the limit is still allowed.
+	if _, err := store.Save(ctx, taskID, &a2a.PushConfig{ID: "config-000", URL: "https://example.com/updated"}); err != nil {
+		t.Fatalf("Save() update at limit failed: %v", err)
+	}
+
+	// Replacing the config keeps the count at the limit, so a new insert is
+	// still rejected.
+	if _, err := store.Save(ctx, taskID, &a2a.PushConfig{URL: "https://example.com/overflow-2"}); err == nil {
+		t.Fatal("Save() beyond the limit succeeded after update, want an error")
+	}
+
+	configs, err := store.List(ctx, taskID)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(configs) != maxPushConfigsPerTask {
+		t.Fatalf("stored %d configs, want %d", len(configs), maxPushConfigsPerTask)
+	}
 }

--- a/a2asrv/push/store_test.go
+++ b/a2asrv/push/store_test.go
@@ -441,7 +441,7 @@ func toConfigList(storeConfigs map[a2a.TaskID]map[string]*a2a.PushConfig) map[a2
 }
 
 // TestInMemoryPushConfigStore_MaxConfigsPerTask is a regression test for
-// BUG-42: a task must not be able to register more than maxPushConfigsPerTask
+// the per-task push config limit: a task must not be able to register more than maxPushConfigsPerTask
 // push configs; exceeding the limit returns an error, while updating an
 // existing config at the limit is still allowed.
 func TestInMemoryPushConfigStore_MaxConfigsPerTask(t *testing.T) {


### PR DESCRIPTION
## What changed

### 1. Cap push notification configs per task

**Problem:**

`InMemoryPushConfigStore.Save` accepted an unlimited number of push configs per task, letting a client grow the store without bound.

**Fix (a2asrv/push/store.go, a2asrv/push/store_test.go):**
- Added `maxPushConfigsPerTask = 50`; new insertions beyond the limit are rejected with `a2a.ErrInvalidParams` (`task %s already has the maximum number of push notification configs (50)`).
- Updating an existing config at the limit is still allowed; the limit applies to new insertions only.
- Added `TestInMemoryPushConfigStore_MaxConfigsPerTask` and reduced the concurrency test to 50 goroutines so every concurrent save still succeeds.

## Testing

- `go test ./a2asrv/push/ ./a2asrv/... ./a2agrpc/...` — all pass.
- New `TestInMemoryPushConfigStore_MaxConfigsPerTask` covers rejection beyond the limit, update-at-limit, and count stability.

Behavior change: the 51st distinct push config for a task is rejected with an invalid-params error.
