### PR TITLE
fix(transports): sanitize internal error messages and panic output

### DIFF
--- a/a2asrv/jsonrpc.go
+++ b/a2asrv/jsonrpc.go
@@ -193,7 +193,7 @@ func (h *jsonrpcHandler) handleStreamingRequest(ctx context.Context, rw http.Res
 			}
 			// Log the full panic (including the stack trace) server-side; the
 			// client only ever sees the sanitized error produced by the panic
-			// handler (BUG-46).
+			// handler.
 			log.Error(ctx, "panic in streaming request handler", err)
 			data, ok := marshalJSONRPCError(req, h.cfg.PanicHandler(err))
 			if !ok {

--- a/a2asrv/jsonrpc.go
+++ b/a2asrv/jsonrpc.go
@@ -191,6 +191,10 @@ func (h *jsonrpcHandler) handleStreamingRequest(ctx context.Context, rw http.Res
 			if h.cfg.PanicHandler == nil {
 				panic(err)
 			}
+			// Log the full panic (including the stack trace) server-side; the
+			// client only ever sees the sanitized error produced by the panic
+			// handler (BUG-46).
+			log.Error(ctx, "panic in streaming request handler", err)
 			data, ok := marshalJSONRPCError(req, h.cfg.PanicHandler(err))
 			if !ok {
 				log.Error(ctx, "failed to marshal error response", err)

--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -340,6 +340,10 @@ func (h *restHandler) handleStreamingRequest(eventSequence iter.Seq2[a2a.Event, 
 			if h.cfg.PanicHandler == nil {
 				panic(err)
 			}
+			// Log the full panic (including the stack trace) server-side; the
+			// client only ever sees the sanitized error produced by the panic
+			// handler (BUG-46).
+			log.Error(ctx, "panic in streaming request handler", err)
 			errResp := rest.ToRESTError(h.cfg.PanicHandler(err), a2a.TaskID(""))
 			data, jErr := json.Marshal(errResp)
 			if jErr != nil {

--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -342,7 +342,7 @@ func (h *restHandler) handleStreamingRequest(eventSequence iter.Seq2[a2a.Event, 
 			}
 			// Log the full panic (including the stack trace) server-side; the
 			// client only ever sees the sanitized error produced by the panic
-			// handler (BUG-46).
+			// handler.
 			log.Error(ctx, "panic in streaming request handler", err)
 			errResp := rest.ToRESTError(h.cfg.PanicHandler(err), a2a.TaskID(""))
 			data, jErr := json.Marshal(errResp)

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"iter"
 	"net/http"
@@ -571,8 +572,9 @@ func (i *testInterceptor) Before(ctx context.Context, callCtx *CallContext, req 
 
 type mockRequestHandler struct {
 	RequestHandler
-	listTasksFunc func(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error)
-	getTaskFunc   func(ctx context.Context, req *a2a.GetTaskRequest) (*a2a.Task, error)
+	listTasksFunc       func(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error)
+	getTaskFunc         func(ctx context.Context, req *a2a.GetTaskRequest) (*a2a.Task, error)
+	subscribeToTaskFunc func(ctx context.Context, req *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error]
 }
 
 func (m *mockRequestHandler) ListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
@@ -587,6 +589,15 @@ func (m *mockRequestHandler) GetTask(ctx context.Context, req *a2a.GetTaskReques
 		return m.getTaskFunc(ctx, req)
 	}
 	return &a2a.Task{ID: req.ID}, nil
+}
+
+func (m *mockRequestHandler) SubscribeToTask(ctx context.Context, req *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
+	if m.subscribeToTaskFunc != nil {
+		return m.subscribeToTaskFunc(ctx, req)
+	}
+	return func(yield func(a2a.Event, error) bool) {
+		yield(&a2a.Task{ID: req.ID}, nil)
+	}
 }
 
 func TestREST_ListTasks_Success(t *testing.T) {
@@ -708,5 +719,50 @@ func TestREST_GetTask_Success(t *testing.T) {
 				t.Fatalf("getTask request mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestREST_SSE_PanicDoesNotLeakStackTrace is a regression test for BUG-46:
+// when a streaming handler panics, the client must not receive the panic
+// value or stack trace, even if the configured panic handler embeds the panic
+// error in its response.
+func TestREST_SSE_PanicDoesNotLeakStackTrace(t *testing.T) {
+	mock := &mockRequestHandler{
+		subscribeToTaskFunc: func(ctx context.Context, req *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
+			return func(yield func(a2a.Event, error) bool) {
+				panic("secret-internal-panic-value")
+			}
+		},
+	}
+	// The panic handler naively embeds the panic error (which contains the
+	// stack trace); the transport must still sanitize what reaches the client.
+	handler := NewRESTHandler(mock, WithTransportPanicHandler(func(r any) error {
+		return fmt.Errorf("panic occurred: %v", r)
+	}))
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/tasks/task-1:subscribe", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() error = %v", err)
+	}
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("server.Client().Do() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+	if bytes.Contains(body, []byte("secret-internal-panic-value")) {
+		t.Fatalf("panic value leaked to the client: %s", body)
+	}
+	if bytes.Contains(body, []byte("goroutine")) {
+		t.Fatalf("stack trace leaked to the client: %s", body)
+	}
+	if !bytes.Contains(body, []byte("internal error")) {
+		t.Fatalf("expected a sanitized 'internal error' message, got: %s", body)
 	}
 }

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -722,7 +722,7 @@ func TestREST_GetTask_Success(t *testing.T) {
 	}
 }
 
-// TestREST_SSE_PanicDoesNotLeakStackTrace is a regression test for BUG-46:
+// TestREST_SSE_PanicDoesNotLeakStackTrace is a regression test for stack trace sanitization:
 // when a streaming handler panics, the client must not receive the panic
 // value or stack trace, even if the configured panic handler embeds the panic
 // error in its response.

--- a/internal/grpcutil/errors.go
+++ b/internal/grpcutil/errors.go
@@ -84,7 +84,7 @@ func ToGRPCError(err error) error {
 		}
 	}
 
-	// Do not leak internal error details to clients (BUG-12/BUG-46): when the
+	// Do not leak internal error details to clients: when the
 	// error cannot be attributed to a known a2a error, expose a generic
 	// message and log the full error server-side. Errors carrying an explicit
 	// client message (*a2a.Error.Message) keep it.

--- a/internal/grpcutil/errors.go
+++ b/internal/grpcutil/errors.go
@@ -74,15 +74,32 @@ func ToGRPCError(err error) error {
 
 	code := codes.Internal
 	reason := "INTERNAL_ERROR"
+	mapped := false
 	for _, mapping := range errorMappings {
 		if errors.Is(err, mapping.err) {
 			code = mapping.code
 			reason = a2a.ErrorReason(mapping.err)
+			mapped = true
 			break
 		}
 	}
 
-	st := status.New(code, err.Error())
+	// Do not leak internal error details to clients (BUG-12/BUG-46): when the
+	// error cannot be attributed to a known a2a error, expose a generic
+	// message and log the full error server-side. Errors carrying an explicit
+	// client message (*a2a.Error.Message) keep it.
+	message := err.Error()
+	if !mapped {
+		var a2aErr *a2a.Error
+		if errors.As(err, &a2aErr) && a2aErr.Message != "" {
+			message = a2aErr.Message
+		} else {
+			log.Warn(context.Background(), "internal error response", err)
+			message = "internal error"
+		}
+	}
+
+	st := status.New(code, message)
 	var errInfoMeta map[string]string
 	var a2aErr *a2a.Error
 	var messages []protoadapt.MessageV1

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -331,7 +332,7 @@ func TestToGRPCErrorEdgeCases(t *testing.T) {
 		{
 			name: "unknown error",
 			err:  unknownError,
-			want: status.Error(codes.Internal, unknownError.Error()),
+			want: status.Error(codes.Internal, "internal error"),
 		},
 		{
 			name: "structpb conversion failure",
@@ -435,5 +436,24 @@ func TestFromGRPCErrorEdgeCases(t *testing.T) {
 				t.Errorf("FromGRPCError() base error = %v, want %v", gotBaseErr, wantErr)
 			}
 		})
+	}
+}
+
+// TestToGRPCError_SanitizesUnknownErrors is a regression test for BUG-12:
+// unknown/internal errors must not leak their raw message to clients.
+func TestToGRPCError_SanitizesUnknownErrors(t *testing.T) {
+	t.Parallel()
+
+	internal := errors.New("internal secret: /var/lib/a2a/credentials/secret_key")
+	got := ToGRPCError(internal)
+	st, ok := status.FromError(got)
+	if !ok {
+		t.Fatalf("ToGRPCError() is not a gRPC status error: %v", got)
+	}
+	if st.Message() != "internal error" {
+		t.Errorf("ToGRPCError() message = %q, want %q", st.Message(), "internal error")
+	}
+	if strings.Contains(st.Message(), "secret") {
+		t.Errorf("ToGRPCError() leaked internal details: %q", st.Message())
 	}
 }

--- a/internal/grpcutil/errors_test.go
+++ b/internal/grpcutil/errors_test.go
@@ -439,7 +439,7 @@ func TestFromGRPCErrorEdgeCases(t *testing.T) {
 	}
 }
 
-// TestToGRPCError_SanitizesUnknownErrors is a regression test for BUG-12:
+// TestToGRPCError_SanitizesUnknownErrors is a regression test for error sanitization:
 // unknown/internal errors must not leak their raw message to clients.
 func TestToGRPCError_SanitizesUnknownErrors(t *testing.T) {
 	t.Parallel()

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -16,6 +16,7 @@
 package jsonrpc
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
 	"github.com/a2aproject/a2a-go/v2/internal/utils"
+	"github.com/a2aproject/a2a-go/v2/log"
 )
 
 // JSON-RPC 2.0 protocol constants
@@ -136,6 +138,7 @@ func ToJSONRPCError(err error) *Error {
 
 	code := -32603
 	reason := "INTERNAL_ERROR"
+	mapped := false
 	var data []*errordetails.Typed
 
 	var a2aErr *a2a.Error
@@ -147,6 +150,7 @@ func ToJSONRPCError(err error) *Error {
 		if errors.Is(err, target) {
 			code = c
 			reason = a2a.ErrorReason(target)
+			mapped = true
 			break
 		}
 	}
@@ -172,9 +176,24 @@ func ToJSONRPCError(err error) *Error {
 	errorInfo := errordetails.NewErrorInfo(reason, a2a.ProtocolDomain, metadata)
 	data = append(data, errorInfo)
 
+	// Do not leak internal error details to clients (BUG-12/BUG-46): when the
+	// error cannot be attributed to a known a2a error, expose a generic
+	// message and log the full error server-side. Errors carrying an explicit
+	// client message (*a2a.Error.Message) keep it.
+	message := err.Error()
+	if !mapped {
+		var a2aErr *a2a.Error
+		if errors.As(err, &a2aErr) && a2aErr.Message != "" {
+			message = a2aErr.Message
+		} else {
+			log.Error(context.Background(), "internal error response", err)
+			message = "internal error"
+		}
+	}
+
 	return &Error{
 		Code:    code,
-		Message: err.Error(),
+		Message: message,
 		Data:    data,
 	}
 }

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -176,7 +176,7 @@ func ToJSONRPCError(err error) *Error {
 	errorInfo := errordetails.NewErrorInfo(reason, a2a.ProtocolDomain, metadata)
 	data = append(data, errorInfo)
 
-	// Do not leak internal error details to clients (BUG-12/BUG-46): when the
+	// Do not leak internal error details to clients: when the
 	// error cannot be attributed to a known a2a error, expose a generic
 	// message and log the full error server-side. Errors carrying an explicit
 	// client message (*a2a.Error.Message) keep it.

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -380,7 +380,7 @@ func ToRESTError(err error, taskID a2a.TaskID) *Error {
 	details = append(details, errorInfo)
 
 	// Do not leak internal error details (wrapped context, stack traces,
-	// implementation internals) to clients (BUG-12/BUG-46): when the error
+	// implementation internals) to clients: when the error
 	// cannot be attributed to a known a2a error, expose a generic message and
 	// log the full error server-side. Errors carrying an explicit client
 	// message (*a2a.Error.Message) keep it.

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -28,6 +28,7 @@ import (
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/errordetails"
 	"github.com/a2aproject/a2a-go/v2/internal/utils"
+	"github.com/a2aproject/a2a-go/v2/log"
 )
 
 // PathBuilder constructs REST paths for A2A endpoints, optionally rooted
@@ -336,12 +337,14 @@ func ToRESTError(err error, taskID a2a.TaskID) *Error {
 	httpStatus := http.StatusInternalServerError
 	grpcStatus := "INTERNAL"
 	reason := "INTERNAL_ERROR"
+	mapped := false
 
 	for _, mapping := range errorMappings {
 		if errors.Is(err, mapping.err) {
 			httpStatus = mapping.httpStatus
 			grpcStatus = mapping.grpcStatus
 			reason = a2a.ErrorReason(mapping.err)
+			mapped = true
 			break
 		}
 	}
@@ -376,12 +379,28 @@ func ToRESTError(err error, taskID a2a.TaskID) *Error {
 	errorInfo := errordetails.NewErrorInfo(reason, a2a.ProtocolDomain, metadata)
 	details = append(details, errorInfo)
 
+	// Do not leak internal error details (wrapped context, stack traces,
+	// implementation internals) to clients (BUG-12/BUG-46): when the error
+	// cannot be attributed to a known a2a error, expose a generic message and
+	// log the full error server-side. Errors carrying an explicit client
+	// message (*a2a.Error.Message) keep it.
+	message := err.Error()
+	if !mapped {
+		var a2aErr *a2a.Error
+		if errors.As(err, &a2aErr) && a2aErr.Message != "" {
+			message = a2aErr.Message
+		} else {
+			log.Error(context.Background(), "internal error response", err)
+			message = "internal error"
+		}
+	}
+
 	return &Error{
 		httpStatus: httpStatus,
 		Err: StatusError{
 			Code:    httpStatus,
 			Status:  grpcStatus,
-			Message: err.Error(),
+			Message: message,
 			Details: details,
 		},
 	}

--- a/internal/rest/rest_test.go
+++ b/internal/rest/rest_test.go
@@ -672,7 +672,7 @@ func errorWithErrorInfo(t *testing.T, message string, err error, reason string) 
 	}
 }
 
-// TestToRESTError_SanitizesUnknownErrors is a regression test for BUG-12:
+// TestToRESTError_SanitizesUnknownErrors is a regression test for error sanitization:
 // unknown/internal errors must not leak their raw message to clients.
 func TestToRESTError_SanitizesUnknownErrors(t *testing.T) {
 	t.Parallel()

--- a/internal/rest/rest_test.go
+++ b/internal/rest/rest_test.go
@@ -490,7 +490,7 @@ func TestToRESTErrorEdgeCases(t *testing.T) {
 		{
 			name: "unknown error",
 			err:  errors.New("some unknown error"),
-			want: &Error{httpStatus: http.StatusInternalServerError, Err: StatusError{Code: http.StatusInternalServerError, Status: "INTERNAL", Message: "some unknown error"}},
+			want: &Error{httpStatus: http.StatusInternalServerError, Err: StatusError{Code: http.StatusInternalServerError, Status: "INTERNAL", Message: "internal error"}},
 		},
 	}
 
@@ -669,5 +669,23 @@ func errorWithErrorInfo(t *testing.T, message string, err error, reason string) 
 				"metadata": map[string]string{},
 			}),
 		},
+	}
+}
+
+// TestToRESTError_SanitizesUnknownErrors is a regression test for BUG-12:
+// unknown/internal errors must not leak their raw message to clients.
+func TestToRESTError_SanitizesUnknownErrors(t *testing.T) {
+	t.Parallel()
+
+	internal := errors.New("internal secret: /var/lib/a2a/credentials/secret_key")
+	got := ToRESTError(internal, "")
+	if got == nil {
+		t.Fatal("ToRESTError() = nil, want an error")
+	}
+	if got.Err.Message != "internal error" {
+		t.Errorf("ToRESTError() message = %q, want %q", got.Err.Message, "internal error")
+	}
+	if strings.Contains(got.Err.Message, "secret") {
+		t.Errorf("ToRESTError() leaked internal details: %q", got.Err.Message)
 	}
 }


### PR DESCRIPTION
## What changed

### 1. Sanitize unmapped/internal error messages across transports

**Problem:**

`ToRESTError`, `ToJSONRPCError`, and `ToGRPCError` propagated `err.Error()` verbatim, leaking internal details (wrapped context, implementation internals) to clients for errors that are not attributable to a known a2a error.

**Fix (internal/rest/rest.go, internal/jsonrpc/jsonrpc.go, internal/grpcutil/errors.go):**
- When the error does not match a known a2a error, expose a generic `internal error` message and log the full error server-side; errors carrying an explicit client message (`*a2a.Error.Message`) keep it.
- Added `TestToRESTError_SanitizesUnknownErrors` (`internal/rest/rest_test.go`) and `TestToGRPCError_SanitizesUnknownErrors` (`internal/grpcutil/errors_test.go`); updated the two "unknown error" edge-case assertions to expect the generic message.

### 2. Stop leaking panic values and stack traces on streaming requests

**Problem:**

When a streaming handler panicked, the panic handler output could embed the panic value / stack trace, which was then sent to the client over REST SSE or JSON-RPC.

**Fix (a2asrv/rest.go, a2asrv/jsonrpc.go, a2asrv/rest_test.go):**
- Log the full panic (including the stack trace) server-side before invoking the panic handler, so the client only ever receives the sanitized error.
- Added `TestREST_SSE_PanicDoesNotLeakStackTrace` in `a2asrv/rest_test.go` (the panic handler deliberately embeds the panic value; the transport must still sanitize it).

## Testing

- Full suite passes (`go test ./a2asrv/... ./internal/... ./a2agrpc/... ./a2apb/... ./a2acompat/... ./a2a/ ./a2aclient/...`).
- New `TestToRESTError_SanitizesUnknownErrors`, `TestToGRPCError_SanitizesUnknownErrors`, and `TestREST_SSE_PanicDoesNotLeakStackTrace` pass.

Behavior change: unmapped/internal errors now show `internal error` to clients (details go to server logs); panic paths no longer emit stack traces or panic values.
