### PR TITLE
fix(transport): enable SSE keep-alive by default and cap request body size

### DIFF
--- a/a2asrv/jsonrpc.go
+++ b/a2asrv/jsonrpc.go
@@ -37,7 +37,7 @@ type jsonrpcHandler struct {
 
 // NewJSONRPCHandler creates an [http.Handler] which implements JSONRPC A2A protocol binding.
 func NewJSONRPCHandler(handler RequestHandler, options ...TransportOption) http.Handler {
-	h := &jsonrpcHandler{handler: handler, cfg: &TransportConfig{}}
+	h := &jsonrpcHandler{handler: handler, cfg: &TransportConfig{KeepAliveInterval: defaultKeepAliveInterval}}
 	for _, option := range options {
 		option(h.cfg)
 	}
@@ -53,6 +53,8 @@ func (h *jsonrpcHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		h.writeJSONRPCError(ctx, rw, a2a.ErrInvalidRequest, nil)
 		return
 	}
+
+	limitRequestBody(rw, req)
 
 	defer func() {
 		if err := req.Body.Close(); err != nil {

--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -40,7 +40,7 @@ type restHandler struct {
 
 // NewRESTHandler creates an [http.Handler] which implements the HTTP+JSON A2A protocol binding.
 func NewRESTHandler(handler RequestHandler, opts ...TransportOption) http.Handler {
-	h := &restHandler{handler: handler, cfg: &TransportConfig{}}
+	h := &restHandler{handler: handler, cfg: &TransportConfig{KeepAliveInterval: defaultKeepAliveInterval}}
 	for _, option := range opts {
 		option(h.cfg)
 	}
@@ -99,6 +99,7 @@ func NewTenantRESTHandler(tenantTemplate string, handler RequestHandler, opts ..
 
 func (h *restHandler) handleSendMessage(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+	limitRequestBody(rw, req)
 	var message a2a.SendMessageRequest
 	if err := json.NewDecoder(req.Body).Decode(&message); err != nil {
 		writeRESTError(ctx, rw, a2a.ErrParseError, a2a.TaskID(""))
@@ -120,6 +121,7 @@ func (h *restHandler) handleSendMessage(rw http.ResponseWriter, req *http.Reques
 
 func (h *restHandler) handleStreamMessage(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+	limitRequestBody(rw, req)
 	var message a2a.SendMessageRequest
 	if err := json.NewDecoder(req.Body).Decode(&message); err != nil {
 		writeRESTError(ctx, rw, a2a.ErrParseError, a2a.TaskID(""))
@@ -375,6 +377,8 @@ func (h *restHandler) handleCreateTaskPushConfig(rw http.ResponseWriter, req *ht
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(taskID))
 		return
 	}
+
+	limitRequestBody(rw, req)
 
 	request := &a2a.PushConfig{}
 	if err := json.NewDecoder(req.Body).Decode(request); err != nil {

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -765,7 +765,7 @@ func TestREST_SSE_KeepAliveHeartbeats(t *testing.T) {
 
 	br := bufio.NewReader(resp.Body)
 	// Consume the first event (id:/data:/blank line).
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		if _, err := br.ReadString('\n'); err != nil {
 			t.Fatalf("reading first SSE event: %v", err)
 		}

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -723,7 +723,7 @@ func TestREST_GetTask_Success(t *testing.T) {
 	}
 }
 
-// TestJSONRPCHandler_DefaultKeepAliveEnabled is a regression test for BUG-09:
+// TestJSONRPCHandler_DefaultKeepAliveEnabled is a regression test for SSE keep-alive:
 // SSE keep-alive must be enabled by default (non-zero interval) and
 // WithTransportKeepAlive(0) must still disable it.
 func TestJSONRPCHandler_DefaultKeepAliveEnabled(t *testing.T) {
@@ -739,7 +739,7 @@ func TestJSONRPCHandler_DefaultKeepAliveEnabled(t *testing.T) {
 }
 
 // TestREST_SSE_KeepAliveHeartbeats verifies that keep-alive comments are
-// emitted on an idle SSE stream (BUG-09).
+// emitted on an idle SSE stream.
 func TestREST_SSE_KeepAliveHeartbeats(t *testing.T) {
 	firstEvent := make(chan struct{})
 	mock := &mockRequestHandler{
@@ -786,7 +786,7 @@ func TestREST_SSE_KeepAliveHeartbeats(t *testing.T) {
 	t.Fatal("no keep-alive comment received on an idle SSE stream")
 }
 
-// TestREST_RequestBodyTooLarge is a regression test for BUG-10: request bodies
+// TestREST_RequestBodyTooLarge is a regression test for request body limits: request bodies
 // larger than maxRequestBodySize must be rejected instead of buffered.
 func TestREST_RequestBodyTooLarge(t *testing.T) {
 	mock := &mockRequestHandler{}
@@ -812,7 +812,7 @@ func TestREST_RequestBodyTooLarge(t *testing.T) {
 	}
 }
 
-// TestJSONRPC_RequestBodyTooLarge is a regression test for BUG-10 on the
+// TestJSONRPC_RequestBodyTooLarge is a regression test for request body limits on the
 // JSON-RPC transport. JSON-RPC responses are always HTTP 200, so the error
 // must be detected in the response body.
 func TestJSONRPC_RequestBodyTooLarge(t *testing.T) {

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -15,6 +15,7 @@
 package a2asrv
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -25,6 +26,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -571,8 +573,9 @@ func (i *testInterceptor) Before(ctx context.Context, callCtx *CallContext, req 
 
 type mockRequestHandler struct {
 	RequestHandler
-	listTasksFunc func(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error)
-	getTaskFunc   func(ctx context.Context, req *a2a.GetTaskRequest) (*a2a.Task, error)
+	listTasksFunc       func(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error)
+	getTaskFunc         func(ctx context.Context, req *a2a.GetTaskRequest) (*a2a.Task, error)
+	subscribeToTaskFunc func(ctx context.Context, req *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error]
 }
 
 func (m *mockRequestHandler) ListTasks(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
@@ -587,6 +590,15 @@ func (m *mockRequestHandler) GetTask(ctx context.Context, req *a2a.GetTaskReques
 		return m.getTaskFunc(ctx, req)
 	}
 	return &a2a.Task{ID: req.ID}, nil
+}
+
+func (m *mockRequestHandler) SubscribeToTask(ctx context.Context, req *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
+	if m.subscribeToTaskFunc != nil {
+		return m.subscribeToTaskFunc(ctx, req)
+	}
+	return func(yield func(a2a.Event, error) bool) {
+		yield(&a2a.Task{ID: req.ID}, nil)
+	}
 }
 
 func TestREST_ListTasks_Success(t *testing.T) {
@@ -708,5 +720,127 @@ func TestREST_GetTask_Success(t *testing.T) {
 				t.Fatalf("getTask request mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestJSONRPCHandler_DefaultKeepAliveEnabled is a regression test for BUG-09:
+// SSE keep-alive must be enabled by default (non-zero interval) and
+// WithTransportKeepAlive(0) must still disable it.
+func TestJSONRPCHandler_DefaultKeepAliveEnabled(t *testing.T) {
+	h := NewJSONRPCHandler(&mockRequestHandler{}).(*jsonrpcHandler)
+	if h.cfg.KeepAliveInterval <= 0 {
+		t.Fatalf("default KeepAliveInterval = %v, want > 0", h.cfg.KeepAliveInterval)
+	}
+
+	h2 := NewJSONRPCHandler(&mockRequestHandler{}, WithTransportKeepAlive(0)).(*jsonrpcHandler)
+	if h2.cfg.KeepAliveInterval != 0 {
+		t.Fatalf("KeepAliveInterval with WithTransportKeepAlive(0) = %v, want 0", h2.cfg.KeepAliveInterval)
+	}
+}
+
+// TestREST_SSE_KeepAliveHeartbeats verifies that keep-alive comments are
+// emitted on an idle SSE stream (BUG-09).
+func TestREST_SSE_KeepAliveHeartbeats(t *testing.T) {
+	firstEvent := make(chan struct{})
+	mock := &mockRequestHandler{
+		subscribeToTaskFunc: func(ctx context.Context, req *a2a.SubscribeToTaskRequest) iter.Seq2[a2a.Event, error] {
+			return func(yield func(a2a.Event, error) bool) {
+				if !yield(&a2a.Task{ID: req.ID}, nil) {
+					return
+				}
+				close(firstEvent)
+				<-ctx.Done()
+			}
+		},
+	}
+	handler := NewRESTHandler(mock, WithTransportKeepAlive(50*time.Millisecond))
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	resp, err := server.Client().Get(server.URL + "/tasks/task-1:subscribe")
+	if err != nil {
+		t.Fatalf("server.Client().Get() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	br := bufio.NewReader(resp.Body)
+	// Consume the first event (id:/data:/blank line).
+	for i := 0; i < 3; i++ {
+		if _, err := br.ReadString('\n'); err != nil {
+			t.Fatalf("reading first SSE event: %v", err)
+		}
+	}
+	<-firstEvent
+
+	// An idle stream must emit keep-alive comments.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("reading keep-alive: %v", err)
+		}
+		if strings.Contains(line, "keep-alive") {
+			return
+		}
+	}
+	t.Fatal("no keep-alive comment received on an idle SSE stream")
+}
+
+// TestREST_RequestBodyTooLarge is a regression test for BUG-10: request bodies
+// larger than maxRequestBodySize must be rejected instead of buffered.
+func TestREST_RequestBodyTooLarge(t *testing.T) {
+	mock := &mockRequestHandler{}
+	handler := NewRESTHandler(mock)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	oversized := strings.Repeat("a", maxRequestBodySize+1)
+	body := `{"jsonrpc":"2.0","method":"tasks/send","params":{"message":{"role":"user","parts":[{"text":"` + oversized + `"}]}},"id":"1"}`
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL+rest.MakeSendMessagePath(), bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() error = %v", err)
+	}
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("server.Client().Do() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("expected oversized body to be rejected, got HTTP 200")
+	}
+}
+
+// TestJSONRPC_RequestBodyTooLarge is a regression test for BUG-10 on the
+// JSON-RPC transport. JSON-RPC responses are always HTTP 200, so the error
+// must be detected in the response body.
+func TestJSONRPC_RequestBodyTooLarge(t *testing.T) {
+	mock := &mockRequestHandler{}
+	handler := NewJSONRPCHandler(mock)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	oversized := strings.Repeat("a", maxRequestBodySize+1)
+	body := `{"jsonrpc":"2.0","method":"tasks/send","params":{"message":{"role":"user","parts":[{"text":"` + oversized + `"}]}},"id":"1"}`
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("http.NewRequestWithContext() error = %v", err)
+	}
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("server.Client().Do() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var payload struct {
+		Error json.RawMessage `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if len(payload.Error) == 0 || string(payload.Error) == "null" {
+		t.Fatalf("expected an oversized-body rejection error, got %q", payload.Error)
 	}
 }

--- a/a2asrv/transport.go
+++ b/a2asrv/transport.go
@@ -14,11 +14,32 @@
 
 package a2asrv
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
+
+// defaultKeepAliveInterval is the SSE keep-alive interval used when the caller
+// does not configure one. Heartbeats prevent proxies and load balancers from
+// dropping idle SSE connections (BUG-09). Use WithTransportKeepAlive(0) to
+// disable them.
+const defaultKeepAliveInterval = 15 * time.Second
+
+// maxRequestBodySize caps the size of request bodies accepted by the
+// transports, preventing memory exhaustion from oversized payloads (BUG-10).
+const maxRequestBodySize = 10 * 1024 * 1024 // 10 MB
+
+// limitRequestBody wraps the request body with an [http.MaxBytesReader] so
+// that oversized payloads are rejected instead of being buffered in memory.
+func limitRequestBody(rw http.ResponseWriter, req *http.Request) {
+	req.Body = http.MaxBytesReader(rw, req.Body, maxRequestBodySize)
+}
 
 // WithTransportKeepAlive enables SSE keep-alive messages at the specified interval.
 // Keep-alive messages prevent API gateways from dropping idle connections.
-// If interval is 0 or negative, keep-alive is disabled (default behavior).
+// If interval is 0 or negative, keep-alive is disabled.
+// Keep-alive is enabled by default at [defaultKeepAliveInterval]; pass
+// WithTransportKeepAlive(0) to turn it off.
 func WithTransportKeepAlive(interval time.Duration) TransportOption {
 	return func(c *TransportConfig) {
 		c.KeepAliveInterval = interval

--- a/a2asrv/transport.go
+++ b/a2asrv/transport.go
@@ -21,12 +21,12 @@ import (
 
 // defaultKeepAliveInterval is the SSE keep-alive interval used when the caller
 // does not configure one. Heartbeats prevent proxies and load balancers from
-// dropping idle SSE connections (BUG-09). Use WithTransportKeepAlive(0) to
+// dropping idle SSE connections. Use WithTransportKeepAlive(0) to
 // disable them.
 const defaultKeepAliveInterval = 15 * time.Second
 
 // maxRequestBodySize caps the size of request bodies accepted by the
-// transports, preventing memory exhaustion from oversized payloads (BUG-10).
+// transports, preventing memory exhaustion from oversized payloads.
 const maxRequestBodySize = 10 * 1024 * 1024 // 10 MB
 
 // limitRequestBody wraps the request body with an [http.MaxBytesReader] so


### PR DESCRIPTION
## What changed

### 1. Enable SSE keep-alive by default

**Problem:**

SSE keep-alive was disabled by default, so idle streaming connections could be dropped by proxies and load balancers.

**Fix (a2asrv/transport.go, a2asrv/rest.go, a2asrv/jsonrpc.go, a2asrv/rest_test.go):**
- `a2asrv/transport.go`: added `defaultKeepAliveInterval = 15s`; `WithTransportKeepAlive` documentation now states keep-alive is enabled by default and `WithTransportKeepAlive(0)` disables it.
- `a2asrv/rest.go` and `a2asrv/jsonrpc.go`: both handlers initialize `TransportConfig` with the default interval instead of zero.
- Added `TestJSONRPCHandler_DefaultKeepAliveEnabled` and `TestREST_SSE_KeepAliveHeartbeats` in `a2asrv/rest_test.go`.

### 2. Cap request body size at 10 MB

**Problem:**

Request bodies were buffered without a size limit, allowing memory exhaustion from oversized payloads.

**Fix (a2asrv/transport.go, a2asrv/rest.go, a2asrv/jsonrpc.go):**
- Added `maxRequestBodySize = 10 MB` and `limitRequestBody`, which wraps the body with `http.MaxBytesReader`; oversized bodies are rejected instead of buffered.
- Applied on the REST send/stream and create-push-config paths (`a2asrv/rest.go`) and on the JSON-RPC handler (`a2asrv/jsonrpc.go`).
- Added `TestREST_RequestBodyTooLarge` and `TestJSONRPC_RequestBodyTooLarge` in `a2asrv/rest_test.go`.

## Testing

- Full suite passes (`go test ./a2asrv/... ./internal/... ./a2agrpc/... ./a2apb/... ./a2acompat/... ./a2a/ ./a2aclient/...`).
- New `TestJSONRPCHandler_DefaultKeepAliveEnabled`, `TestREST_SSE_KeepAliveHeartbeats`, `TestREST_RequestBodyTooLarge`, and `TestJSONRPC_RequestBodyTooLarge` pass.

Behavior change: SSE streams now emit a keep-alive heartbeat every 15 s by default (disable with `WithTransportKeepAlive(0)`); request bodies larger than 10 MB are rejected.
