### PR TITLE
fix(taskexec): close event-queue reader on cancel early exits

### DIFF
--- a/internal/taskexec/distributed_manager.go
+++ b/internal/taskexec/distributed_manager.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -54,6 +55,11 @@ type distributedManager struct {
 	queueManager eventqueue.Manager
 	taskStore    taskstore.Store
 	ctxCodec     ContextCodec
+
+	// mu serializes the cancel check-then-act: the terminal-state check followed
+	// by the cancelation submission, so concurrent Cancel calls for the same task
+	// cannot both observe a non-terminal state and submit overlapping cancelations.
+	mu sync.Mutex
 }
 
 var _ Manager = (*distributedManager)(nil)
@@ -179,12 +185,31 @@ func (m *distributedManager) Cancel(ctx context.Context, req *a2a.CancelTaskRequ
 		return nil, err
 	}
 
+	// Close the check-then-act window: re-check the task state under the lock
+	// immediately before submitting, so a task that completed/failed while the
+	// queue and context were being prepared is not submitted for cancelation.
+	m.mu.Lock()
+	storedTask, err = m.taskStore.Get(ctx, req.ID)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("failed to re-load a task: %w", err)
+	}
+	if storedTask.Task.Status.State == a2a.TaskStateCanceled {
+		m.mu.Unlock()
+		return storedTask.Task, nil
+	}
+	if storedTask.Task.Status.State.Terminal() {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("task in non-cancelable state %q: %w",
+			storedTask.Task.Status.State, a2a.ErrTaskNotCancelable)
+	}
 	taskID, err := m.workQueue.Write(ctx, &workqueue.Payload{
 		Type:          workqueue.PayloadTypeCancel,
 		TaskID:        req.ID,
 		CancelRequest: req,
 		CallContext:   encodedCtx,
 	})
+	m.mu.Unlock()
 	if err != nil {
 		// if cancelation lease is already taken we can tap into the running cancellation events
 		if !errors.Is(err, workqueue.ErrLeaseAlreadyTaken) {

--- a/internal/taskexec/distributed_manager.go
+++ b/internal/taskexec/distributed_manager.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -55,11 +54,6 @@ type distributedManager struct {
 	queueManager eventqueue.Manager
 	taskStore    taskstore.Store
 	ctxCodec     ContextCodec
-
-	// mu serializes the cancel check-then-act: the terminal-state check followed
-	// by the cancelation submission, so concurrent Cancel calls for the same task
-	// cannot both observe a non-terminal state and submit overlapping cancelations.
-	mu sync.Mutex
 }
 
 var _ Manager = (*distributedManager)(nil)
@@ -182,34 +176,16 @@ func (m *distributedManager) Cancel(ctx context.Context, req *a2a.CancelTaskRequ
 
 	encodedCtx, err := m.encodeContext(ctx)
 	if err != nil {
+		safeCloseReader(ctx, queue)
 		return nil, err
 	}
 
-	// Close the check-then-act window: re-check the task state under the lock
-	// immediately before submitting, so a task that completed/failed while the
-	// queue and context were being prepared is not submitted for cancelation.
-	m.mu.Lock()
-	storedTask, err = m.taskStore.Get(ctx, req.ID)
-	if err != nil {
-		m.mu.Unlock()
-		return nil, fmt.Errorf("failed to re-load a task: %w", err)
-	}
-	if storedTask.Task.Status.State == a2a.TaskStateCanceled {
-		m.mu.Unlock()
-		return storedTask.Task, nil
-	}
-	if storedTask.Task.Status.State.Terminal() {
-		m.mu.Unlock()
-		return nil, fmt.Errorf("task in non-cancelable state %q: %w",
-			storedTask.Task.Status.State, a2a.ErrTaskNotCancelable)
-	}
 	taskID, err := m.workQueue.Write(ctx, &workqueue.Payload{
 		Type:          workqueue.PayloadTypeCancel,
 		TaskID:        req.ID,
 		CancelRequest: req,
 		CallContext:   encodedCtx,
 	})
-	m.mu.Unlock()
 	if err != nil {
 		// if cancelation lease is already taken we can tap into the running cancellation events
 		if !errors.Is(err, workqueue.ErrLeaseAlreadyTaken) {

--- a/internal/taskexec/distributed_manager_test.go
+++ b/internal/taskexec/distributed_manager_test.go
@@ -280,6 +280,40 @@ func TestClusterFrontend_EncodeContextError(t *testing.T) {
 	})
 }
 
+func TestClusterFrontend_Cancel_EncodeContextErrorClosesQueue(t *testing.T) {
+	t.Parallel()
+
+	tid := a2a.NewTaskID()
+	store := testutil.NewTestTaskStore()
+	store.GetFunc = func(ctx context.Context, taskID a2a.TaskID) (*taskstore.StoredTask, error) {
+		return &taskstore.StoredTask{Task: &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}}, nil
+	}
+
+	queue := testutil.NewTestEventQueue()
+	queueClosed := false
+	queue.CloseFunc = func() error {
+		queueClosed = true
+		return nil
+	}
+	qm := testutil.NewTestQueueManager()
+	qm.SetQueue(queue)
+
+	frontend := NewDistributedManager(DistributedManagerConfig{
+		TaskStore:    store,
+		QueueManager: qm,
+		WorkQueue:    testutil.NewTestWorkQueue(),
+		ContextCodec: &testContextCodec{encodeErr: fmt.Errorf("encode failed")},
+	})
+
+	_, err := frontend.Cancel(t.Context(), &a2a.CancelTaskRequest{ID: tid})
+	if err == nil || !strings.Contains(err.Error(), "encode failed") {
+		t.Fatalf("Cancel() error = %v, want to contain %q", err, "encode failed")
+	}
+	if !queueClosed {
+		t.Fatal("Cancel() must close the event-queue reader when context encoding fails")
+	}
+}
+
 type testContextCodec struct {
 	encodeErr error
 	decodeErr error
@@ -309,7 +343,6 @@ func TestClusterFrontend_Cancel(t *testing.T) {
 			name: "cancel running task",
 			getTaskResults: []*a2a.Task{
 				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
-				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
 				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCanceled}},
 			},
 			wantQueueWrite: &workqueue.Payload{
@@ -320,13 +353,16 @@ func TestClusterFrontend_Cancel(t *testing.T) {
 			wantResult: &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCanceled}},
 		},
 		{
-			name: "task completes before cancelation submission",
+			name: "failed to cancel task",
 			getTaskResults: []*a2a.Task{
 				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
 				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
 			},
-			// The re-check under the lock observes the terminal state, so no
-			// cancelation is submitted (TOCTOU window closed).
+			wantQueueWrite: &workqueue.Payload{
+				Type:          workqueue.PayloadTypeCancel,
+				TaskID:        tid,
+				CancelRequest: &a2a.CancelTaskRequest{ID: tid},
+			},
 			wantErrContain: a2a.ErrTaskNotCancelable.Error(),
 		},
 		{
@@ -351,7 +387,7 @@ func TestClusterFrontend_Cancel(t *testing.T) {
 		},
 		{
 			name:           "work queue write error",
-			getTaskResults: []*a2a.Task{{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}, {ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}},
+			getTaskResults: []*a2a.Task{{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}},
 			writeQueueErr:  fmt.Errorf("write failed"),
 			wantErrContain: "write failed",
 		},

--- a/internal/taskexec/distributed_manager_test.go
+++ b/internal/taskexec/distributed_manager_test.go
@@ -309,6 +309,7 @@ func TestClusterFrontend_Cancel(t *testing.T) {
 			name: "cancel running task",
 			getTaskResults: []*a2a.Task{
 				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
+				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
 				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCanceled}},
 			},
 			wantQueueWrite: &workqueue.Payload{
@@ -319,16 +320,13 @@ func TestClusterFrontend_Cancel(t *testing.T) {
 			wantResult: &a2a.Task{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCanceled}},
 		},
 		{
-			name: "failed to cancel task",
+			name: "task completes before cancelation submission",
 			getTaskResults: []*a2a.Task{
 				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
 				{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
 			},
-			wantQueueWrite: &workqueue.Payload{
-				Type:          workqueue.PayloadTypeCancel,
-				TaskID:        tid,
-				CancelRequest: &a2a.CancelTaskRequest{ID: tid},
-			},
+			// The re-check under the lock observes the terminal state, so no
+			// cancelation is submitted (TOCTOU window closed).
 			wantErrContain: a2a.ErrTaskNotCancelable.Error(),
 		},
 		{
@@ -353,7 +351,7 @@ func TestClusterFrontend_Cancel(t *testing.T) {
 		},
 		{
 			name:           "work queue write error",
-			getTaskResults: []*a2a.Task{{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}},
+			getTaskResults: []*a2a.Task{{ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}, {ID: tid, Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}},
 			writeQueueErr:  fmt.Errorf("write failed"),
 			wantErrContain: "write failed",
 		},


### PR DESCRIPTION
## What changed

### 1. Close the event-queue reader when Cancel exits early

**Problem:** In `distributedManager.Cancel`, once the event-queue reader is created via `CreateReader`, every early exit (context-encoding failure, task-store reload error, already-canceled/terminal states) returned without closing the reader, leaking the reader/registration.

**Fix (internal/taskexec/distributed_manager.go):**
- All early-return paths after `CreateReader` now call `safeCloseReader(ctx, queue)` (including the pre-existing context-encoding error path), so the reader is never left behind.
- Added a regression test asserting the reader is closed when context encoding fails.

The previously proposed frontend-local mutex + task-state re-check was withdrawn per review: the per-manager mutex cannot close the distributed task-state TOCTOU window (completion is persisted by the backend task-update path which does not take this lock, and different manager instances have independent locks), and holding a manager-wide lock across the potentially blocking `WorkQueue.Write` serializes cancels of unrelated task IDs. Distributed coordination continues to rely on the existing work-queue lease and task-store OCC semantics.

## Testing

- `go test ./internal/taskexec/...` — all tests pass, including the new `TestClusterFrontend_Cancel_EncodeContextErrorClosesQueue`.