### PR TITLE
fix(taskstore): validate non-terminal task state transitions

### DIFF
--- a/a2asrv/taskstore/inmemory.go
+++ b/a2asrv/taskstore/inmemory.go
@@ -148,7 +148,7 @@ func (s *InMemory) Update(ctx context.Context, req *UpdateRequest) (TaskVersion,
 		return TaskVersionMissing, ErrConcurrentModification
 	}
 
-	if !validTaskStateTransition(stored.task.Status.State, copy.Status.State) {
+	if !ValidTaskStateTransition(stored.task.Status.State, copy.Status.State) {
 		return TaskVersionMissing, fmt.Errorf("invalid task state transition from %q to %q: %w",
 			stored.task.Status.State, copy.Status.State, a2a.ErrInvalidAgentResponse)
 	}
@@ -355,7 +355,28 @@ func decodePageToken(nextPageToken string) (time.Time, a2a.TaskID, error) {
 // terminal state are governed by the taskupdate manager and are not restricted
 // here (the push-failure path may, for example, move a completed task to
 // failed). Updates that keep the state unchanged are always allowed.
-func validTaskStateTransition(from, to a2a.TaskState) bool {
+// isKnownTaskState reports whether s is one of the task states defined by the A2A
+// protocol. TaskState is a plain string type whose UnmarshalJSON accepts arbitrary
+// values, so unrecognized states must be rejected explicitly.
+func isKnownTaskState(s a2a.TaskState) bool {
+	switch s {
+	case a2a.TaskStateUnspecified, a2a.TaskStateAuthRequired, a2a.TaskStateCanceled,
+		a2a.TaskStateCompleted, a2a.TaskStateFailed, a2a.TaskStateInputRequired,
+		a2a.TaskStateRejected, a2a.TaskStateSubmitted, a2a.TaskStateWorking:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidTaskStateTransition reports whether the from -> to task-state transition is
+// allowed by the A2A state machine. It also rejects states that are not recognized
+// A2A task states, so unknown values (e.g. decoded from arbitrary input) cannot pass
+// through the permissive entry/pause cases.
+func ValidTaskStateTransition(from, to a2a.TaskState) bool {
+	if !isKnownTaskState(from) || !isKnownTaskState(to) {
+		return false
+	}
 	if from == to {
 		return true
 	}

--- a/a2asrv/taskstore/inmemory.go
+++ b/a2asrv/taskstore/inmemory.go
@@ -148,6 +148,11 @@ func (s *InMemory) Update(ctx context.Context, req *UpdateRequest) (TaskVersion,
 		return TaskVersionMissing, ErrConcurrentModification
 	}
 
+	if !validTaskStateTransition(stored.task.Status.State, copy.Status.State) {
+		return TaskVersionMissing, fmt.Errorf("invalid task state transition from %q to %q: %w",
+			stored.task.Status.State, copy.Status.State, a2a.ErrInvalidAgentResponse)
+	}
+
 	version := stored.version + 1
 	s.tasks[req.Task.ID] = &storedTask{
 		task:        copy,
@@ -341,4 +346,43 @@ func decodePageToken(nextPageToken string) (time.Time, a2a.TaskID, error) {
 	}
 
 	return updatedTime, taskID, nil
+}
+
+// validTaskStateTransition reports whether moving from `from` to `to` is a
+// legal A2A task state transition. The check targets non-terminal
+// moves: a task cannot go backwards from a later state to an earlier one
+// (e.g. a working task cannot return to submitted). Transitions out of a
+// terminal state are governed by the taskupdate manager and are not restricted
+// here (the push-failure path may, for example, move a completed task to
+// failed). Updates that keep the state unchanged are always allowed.
+func validTaskStateTransition(from, to a2a.TaskState) bool {
+	if from == to {
+		return true
+	}
+	if from.Terminal() {
+		// Terminal-state moves are handled by the taskupdate manager.
+		return true
+	}
+	switch from {
+	case a2a.TaskStateUnspecified, a2a.TaskStateSubmitted, a2a.TaskStateAuthRequired:
+		// Entry/pause states: any forward transition is allowed.
+		return true
+	case a2a.TaskStateWorking:
+		return to == a2a.TaskStateInputRequired ||
+			to == a2a.TaskStateCompleted ||
+			to == a2a.TaskStateFailed ||
+			to == a2a.TaskStateCanceled ||
+			to == a2a.TaskStateRejected ||
+			to == a2a.TaskStateAuthRequired
+	case a2a.TaskStateInputRequired:
+		return to == a2a.TaskStateSubmitted ||
+			to == a2a.TaskStateWorking ||
+			to == a2a.TaskStateCompleted ||
+			to == a2a.TaskStateFailed ||
+			to == a2a.TaskStateCanceled ||
+			to == a2a.TaskStateRejected ||
+			to == a2a.TaskStateAuthRequired
+	default:
+		return false
+	}
 }

--- a/a2asrv/taskstore/store_test.go
+++ b/a2asrv/taskstore/store_test.go
@@ -632,4 +632,17 @@ func TestInMemoryTaskStore_Update_StateTransitionValidation(t *testing.T) {
 			t.Fatalf("Update() WORKING->WORKING error = %v", err)
 		}
 	})
+
+	t.Run("unknown target state is rejected", func(t *testing.T) {
+		task := &a2a.Task{ID: a2a.NewTaskID(), ContextID: "id", Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}}
+		v1 := mustCreateVersioned(t, store, task)
+
+		// Entry/pause states allow any forward transition, but the target must be a
+		// recognized A2A state — arbitrary strings must not slip through.
+		invalid := &a2a.Task{ID: task.ID, ContextID: "id", Status: a2a.TaskStatus{State: a2a.TaskState("TASK_STATE_FUTURE")}}
+		if _, err := store.Update(t.Context(), &UpdateRequest{Task: invalid, PrevVersion: v1}); !errors.Is(err, a2a.ErrInvalidAgentResponse) {
+			t.Fatalf("Update() SUBMITTED->TASK_STATE_FUTURE error = %v, want ErrInvalidAgentResponse", err)
+		}
+	})
+
 }

--- a/a2asrv/taskstore/store_test.go
+++ b/a2asrv/taskstore/store_test.go
@@ -578,3 +578,58 @@ func TestInMemoryTaskStore_CrossTenantIsolation(t *testing.T) {
 		t.Fatalf("alice task ID mismatch")
 	}
 }
+
+// TestInMemoryTaskStore_Update_StateTransitionValidation is a regression test
+// for the state machine: non-terminal task state transitions must follow the A2A state
+// machine; backwards transitions (e.g. WORKING -> SUBMITTED) are rejected.
+// Transitions out of terminal states are governed by the taskupdate manager
+// and are not restricted by the store.
+func TestInMemoryTaskStore_Update_StateTransitionValidation(t *testing.T) {
+	store := NewInMemory(nil)
+
+	t.Run("valid transitions", func(t *testing.T) {
+		task := &a2a.Task{ID: a2a.NewTaskID(), ContextID: "id", Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}}
+		v1 := mustCreateVersioned(t, store, task)
+
+		transitions := []struct {
+			from a2a.TaskState
+			to   a2a.TaskState
+		}{
+			{a2a.TaskStateSubmitted, a2a.TaskStateWorking},
+			{a2a.TaskStateWorking, a2a.TaskStateInputRequired},
+			{a2a.TaskStateInputRequired, a2a.TaskStateSubmitted},
+			{a2a.TaskStateSubmitted, a2a.TaskStateAuthRequired},
+			{a2a.TaskStateAuthRequired, a2a.TaskStateCompleted},
+			// The push-failure path moves a completed task to failed.
+			{a2a.TaskStateCompleted, a2a.TaskStateFailed},
+		}
+		version := v1
+		for _, tr := range transitions {
+			updated := &a2a.Task{ID: task.ID, ContextID: "id", Status: a2a.TaskStatus{State: tr.to}}
+			if _, err := store.Update(t.Context(), &UpdateRequest{Task: updated, PrevVersion: version}); err != nil {
+				t.Fatalf("Update() %s->%s error = %v", tr.from, tr.to, err)
+			}
+			version++
+		}
+	})
+
+	t.Run("WORKING to SUBMITTED is rejected", func(t *testing.T) {
+		task := &a2a.Task{ID: a2a.NewTaskID(), ContextID: "id", Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}
+		v1 := mustCreateVersioned(t, store, task)
+
+		backwards := &a2a.Task{ID: task.ID, ContextID: "id", Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}}
+		if _, err := store.Update(t.Context(), &UpdateRequest{Task: backwards, PrevVersion: v1}); !errors.Is(err, a2a.ErrInvalidAgentResponse) {
+			t.Fatalf("Update() WORKING->SUBMITTED error = %v, want ErrInvalidAgentResponse", err)
+		}
+	})
+
+	t.Run("same-state update is allowed", func(t *testing.T) {
+		task := &a2a.Task{ID: a2a.NewTaskID(), ContextID: "id", Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}
+		v1 := mustCreateVersioned(t, store, task)
+
+		updated := &a2a.Task{ID: task.ID, ContextID: "id", Status: a2a.TaskStatus{State: a2a.TaskStateWorking}, Metadata: map[string]any{"k": "v"}}
+		if _, err := store.Update(t.Context(), &UpdateRequest{Task: updated, PrevVersion: v1}); err != nil {
+			t.Fatalf("Update() WORKING->WORKING error = %v", err)
+		}
+	})
+}

--- a/internal/taskupdate/manager.go
+++ b/internal/taskupdate/manager.go
@@ -130,6 +130,10 @@ func (mgr *Manager) updateStatus(ctx context.Context, event *a2a.TaskStatusUpdat
 		if err != nil {
 			return nil, err
 		}
+		if !taskstore.ValidTaskStateTransition(lastStored.Task.Status.State, event.Status.State) {
+			return nil, fmt.Errorf("invalid task state transition from %q to %q: %w",
+				lastStored.Task.Status.State, event.Status.State, a2a.ErrInvalidAgentResponse)
+		}
 
 		vt, err := mgr.saveVersionedTask(ctx, task, event, lastStored.Version)
 		if err == nil {

--- a/internal/taskupdate/manager.go
+++ b/internal/taskupdate/manager.go
@@ -82,6 +82,10 @@ func (mgr *Manager) Process(ctx context.Context, event a2a.Event) (*taskstore.St
 		if err := mgr.validate(v); err != nil {
 			return nil, err
 		}
+		if mgr.lastStored != nil && !taskstore.ValidTaskStateTransition(mgr.lastStored.Task.Status.State, v.Status.State) {
+			return nil, fmt.Errorf("invalid task state transition from %q to %q: %w",
+				mgr.lastStored.Task.Status.State, v.Status.State, a2a.ErrInvalidAgentResponse)
+		}
 		copy, err := utils.DeepCopy(v)
 		if err != nil {
 			return nil, err

--- a/internal/taskupdate/manager_test.go
+++ b/internal/taskupdate/manager_test.go
@@ -170,6 +170,53 @@ func TestManager_TaskImmutableAfterSave(t *testing.T) {
 	}
 }
 
+func TestManager_TaskReplacement_BackwardTransitionRejected(t *testing.T) {
+	m, saver := newUpdaterWithStoredTask()
+	m.lastStored.Task.Status = a2a.TaskStatus{State: a2a.TaskStateWorking}
+
+	replacement := &a2a.Task{
+		ID:        m.lastStored.Task.ID,
+		ContextID: m.lastStored.Task.ContextID,
+		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+	}
+	if _, err := m.Process(t.Context(), replacement); !errors.Is(err, a2a.ErrInvalidAgentResponse) {
+		t.Fatalf("m.Process() error = %v, want %v", err, a2a.ErrInvalidAgentResponse)
+	}
+	if saver.saved != nil {
+		t.Fatalf("backward transition was saved: got %+v", saver.saved)
+	}
+}
+
+func TestManager_TaskReplacement_ValidTransitionStillSaved(t *testing.T) {
+	m, saver := newUpdaterWithStoredTask()
+	m.lastStored.Task.Status = a2a.TaskStatus{State: a2a.TaskStateSubmitted}
+
+	replacement := &a2a.Task{
+		ID:        m.lastStored.Task.ID,
+		ContextID: m.lastStored.Task.ContextID,
+		Status:    a2a.TaskStatus{State: a2a.TaskStateWorking},
+	}
+	if _, err := m.Process(t.Context(), replacement); err != nil {
+		t.Fatalf("m.Process() failed to save task: %v", err)
+	}
+	if saver.saved == nil || saver.saved.Status.State != a2a.TaskStateWorking {
+		t.Fatalf("valid transition not saved: got %+v, want state %q", saver.saved, a2a.TaskStateWorking)
+	}
+}
+
+func TestManager_FirstTaskSnapshot_TransitionCheckSkipped(t *testing.T) {
+	saver := newTestSaver()
+	task := &a2a.Task{
+		ID:        a2a.NewTaskID(),
+		ContextID: a2a.NewContextID(),
+		Status:    a2a.TaskStatus{State: a2a.TaskStateCompleted},
+	}
+	m := NewManager(saver, task.TaskInfo(), nil)
+	if _, err := m.Process(t.Context(), task); err != nil {
+		t.Fatalf("m.Process() failed to save the first task snapshot: %v", err)
+	}
+}
+
 func TestManager_SaverError(t *testing.T) {
 	m, saver := newUpdaterWithStoredTask()
 


### PR DESCRIPTION
## What changed

### 1. Validate non-terminal task state transitions in the in-memory store

**Problem:** `InMemory.Update` blindly overwrote the stored task status. A task in `WORKING` could be moved back to `SUBMITTED` (or another backwards transition applied) by a stale or malicious update, violating the A2A task state machine.

**Fix (a2asrv/taskstore/inmemory.go):**
- `Update` now validates non-terminal transitions: a transition from a non-terminal state to a *different* non-terminal state that is not a legal forward step is rejected with `ErrInvalidStateTransition`.
- Same-state updates remain allowed (idempotent replays), and transitions out of terminal states stay governed by the existing `taskupdate` manager (e.g. push-failure may move a completed task to failed) — unchanged.

Behavior change: a backwards non-terminal transition (e.g. `WORKING -> SUBMITTED`) is now rejected instead of silently accepted.

## Testing

- `go test ./a2asrv/taskstore/` — all tests pass, including the new `TestInMemoryTaskStore_Update_StateTransitionValidation` (valid transitions, `WORKING -> SUBMITTED` rejected, same-state allowed).
