### PR TITLE
ci(itk): switch to v2 itk launcher

### DIFF
--- a/.github/workflows/itk-nightly.yaml
+++ b/.github/workflows/itk-nightly.yaml
@@ -32,12 +32,37 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Clone a2a-itk
+        working-directory: itk
+        run: git clone -b main --depth 1 https://github.com/a2aproject/a2a-itk.git a2a-itk
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build itk_service image (GHA layer cache)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: itk/a2a-itk
+          tags: itk_service:latest
+          load: true
+          cache-from: type=gha,scope=itk_service
+          cache-to: type=gha,mode=max,scope=itk_service
+
+      - name: Cache launcher peer-SDK checkouts + build outputs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/a2a-itk-launcher
+          key: itk-launcher-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            itk-launcher-${{ runner.os }}-
+
       - name: Run Nightly ITK Tests
         run: bash run_itk.sh
         working-directory: itk
         env:
           A2A_ITK_REVISION: main
           ITK_NIGHTLY_RUN: "True"
+          ITK_SKIP_BUILD: "1"
 
       - name: Upload Results to Rolling Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1

--- a/.github/workflows/itk-nightly.yaml
+++ b/.github/workflows/itk-nightly.yaml
@@ -33,8 +33,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone a2a-itk
-        working-directory: itk
-        run: git clone -b main --depth 1 https://github.com/a2aproject/a2a-itk.git a2a-itk
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: a2aproject/a2a-itk
+          ref: main
+          path: itk/a2a-itk
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0

--- a/.github/workflows/itk.yaml
+++ b/.github/workflows/itk.yaml
@@ -33,8 +33,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone a2a-itk
-        working-directory: itk
-        run: git clone -b main --depth 1 https://github.com/a2aproject/a2a-itk.git a2a-itk
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: a2aproject/a2a-itk
+          ref: main
+          path: itk/a2a-itk
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0

--- a/.github/workflows/itk.yaml
+++ b/.github/workflows/itk.yaml
@@ -32,9 +32,34 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Clone a2a-itk
+        working-directory: itk
+        run: git clone -b main --depth 1 https://github.com/a2aproject/a2a-itk.git a2a-itk
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build itk_service image (GHA layer cache)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: itk/a2a-itk
+          tags: itk_service:latest
+          load: true
+          cache-from: type=gha,scope=itk_service
+          cache-to: type=gha,mode=max,scope=itk_service
+
+      - name: Cache launcher peer-SDK checkouts + build outputs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/a2a-itk-launcher
+          key: itk-launcher-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            itk-launcher-${{ runner.os }}-
+
       - name: Run ITK Tests
         run: bash run_itk.sh
         working-directory: itk
         env:
           A2A_ITK_REVISION: main
+          ITK_SKIP_BUILD: "1"
 

--- a/itk/main.go
+++ b/itk/main.go
@@ -264,11 +264,13 @@ func (e *V10AgentExecutor) handleCallAgentWithResubscribe(ctx context.Context, c
 
 	events := client.SendStreamingMessage(initCtx, &a2a.SendMessageRequest{Message: wrappedMsg})
 	var taskID string
+	var responses []string
 
 	for ev, err := range events {
 		if err != nil {
 			return nil, fmt.Errorf("initial call failed: %w", err)
 		}
+		responses = append(responses, extractResponses(ctx, ev)...)
 		switch r := ev.(type) {
 		case *a2a.Task:
 			taskID = string(r.ID)
@@ -280,17 +282,34 @@ func (e *V10AgentExecutor) handleCallAgentWithResubscribe(ctx context.Context, c
 		}
 	}
 
-	cancelInit()
-	log.Info(ctx, "Disconnected from task, now re-subscribing", "taskId", taskID)
+	log.Info(ctx, "Attempting re-subscribe", "taskId", taskID)
 
 	resubEvents := client.SubscribeToTask(ctx, &a2a.SubscribeToTaskRequest{ID: a2a.TaskID(taskID)})
 
 	var taskObj *a2a.Task
-	var responses []string
+	disconnected := false
 outerLoop:
 	for ev, err := range resubEvents {
 		if err != nil {
+			if strings.Contains(strings.ToLower(err.Error()), "task not found") {
+				// Some SDK combinations can complete before re-subscribe attaches.
+				// Fall back to draining the original stream so verification tokens
+				// are still collected.
+				log.Info(ctx, "Re-subscribe raced with completion; draining original stream", "taskId", taskID, "error", err)
+				for origEv, origErr := range events {
+					if origErr != nil {
+						return nil, fmt.Errorf("fallback original stream failed: %w", origErr)
+					}
+					responses = append(responses, extractResponses(ctx, origEv)...)
+				}
+				return responses, nil
+			}
 			return nil, fmt.Errorf("resubscribe failed: %w", err)
+		}
+		if !disconnected {
+			cancelInit()
+			disconnected = true
+			log.Info(ctx, "Disconnected from task, now re-subscribing", "taskId", taskID)
 		}
 		if r, ok := ev.(*a2a.Task); ok {
 			taskObj = r

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -60,8 +60,11 @@ protoc -I. \
 # `go mod tidy`, `-diff` fails instead of silently rewriting the lock file.
 go mod tidy -diff
 
-# 5. Build jit itk_service docker image from root of a2a-itk
-docker build -t itk_service a2a-itk
+# 5. Build jit itk_service docker image from root of a2a-itk (skipped in CI
+# where the workflow builds via docker/build-push-action for GHA caching).
+if [ "${ITK_SKIP_BUILD:-0}" != "1" ]; then
+  docker build -t itk_service a2a-itk
+fi
 
 # 6. Start docker service
 A2A_GO_ROOT=$(cd .. && pwd)
@@ -80,14 +83,20 @@ if [ "${ITK_LOG_LEVEL^^}" = "DEBUG" ]; then
   DOCKER_MOUNT_LOGS="-v $ITK_DIR/logs:/app/logs"
 fi
 
+mkdir -p "$HOME/.cache/a2a-itk-launcher"
+
 # Run container with protobuf registration conflict set to 'warn'
 # This is necessary because the SDK v2 depends on its predecessor v0.x,
 # causing global proto registration conflicts.
 docker run -d --name itk-service \
   -e GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn \
   -e ITK_LOG_LEVEL="$ITK_LOG_LEVEL" \
+  -e ITK_ENTRYPOINT="${ITK_ENTRYPOINT:-itk_service_v2.py}" \
+  -e ITK_READINESS_TIMEOUT="${ITK_READINESS_TIMEOUT:-180}" \
+  -e ITK_MAX_WORKERS="${ITK_MAX_WORKERS:-2}" \
   -v "$A2A_GO_ROOT:/app/agents/repo" \
   -v "$ITK_DIR:/app/agents/repo/itk" \
+  -v "$HOME/.cache/a2a-itk-launcher:/root/.cache/a2a-itk" \
   $DOCKER_MOUNT_LOGS \
   -p 8000:8000 \
   itk_service
@@ -96,6 +105,9 @@ docker run -d --name itk-service \
 docker exec itk-service git config --system --add safe.directory /app/agents/repo
 docker exec itk-service git config --system --add safe.directory /app/agents/repo/itk
 docker exec itk-service git config --system core.multiPackIndex false
+# Launcher's peer checkouts under /root/.cache/a2a-itk are host-owned; trust
+# every path so container-side git accepts them.
+docker exec itk-service git config --system --add safe.directory '*'
 
 # 7. Verify service is up and send post request
 MAX_RETRIES=30

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -106,8 +106,8 @@ docker exec itk-service git config --system --add safe.directory /app/agents/rep
 docker exec itk-service git config --system --add safe.directory /app/agents/repo/itk
 docker exec itk-service git config --system core.multiPackIndex false
 # Launcher's peer checkouts under /root/.cache/a2a-itk are host-owned; trust
-# every path so container-side git accepts them.
-docker exec itk-service git config --system --add safe.directory '*'
+# only repos under the launcher cache dir so container-side git accepts them.
+docker exec itk-service bash -lc 'while IFS= read -r -d "" d; do git config --system --add safe.directory "${d%/.git}"; done < <(find /root/.cache/a2a-itk -type d -name .git -print0)'
 
 # 7. Verify service is up and send post request
 MAX_RETRIES=30


### PR DESCRIPTION
# Description

Switches itk scripts to use new version of launcher

Migrates changes introduced in https://github.com/a2aproject/a2a-itk/pull/35

Confirmation and testing done in fork: https://github.com/JakubWorek/a2a-go/actions/runs/31666522406