### PR TITLE
fix: cli not parsing compat agent cards

### DIFF
--- a/a2acompat/a2av0/agentcard.go
+++ b/a2acompat/a2av0/agentcard.go
@@ -88,19 +88,11 @@ func (p *compatProducer) CardJSON(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	compatCard, err := toCompatCard(card)
-	if err != nil {
-		return nil, err
-	}
-	return json.MarshalIndent(compatCard, "", "  ")
+	return json.MarshalIndent(toCompatCard(card), "", "  ")
 }
 
-func toCompatCard(card *a2a.AgentCard) (*agentCardCompat, error) {
-	preferredInterface, additionalInterfaces, err := mapToCompatInterfaces(card)
-	if err != nil {
-		return nil, err
-	}
-	return &agentCardCompat{
+func toCompatCard(card *a2a.AgentCard) *agentCardCompat {
+	cardCompat := &agentCardCompat{
 		DefaultInputModes:    card.DefaultInputModes,
 		DefaultOutputModes:   card.DefaultOutputModes,
 		Description:          card.Description,
@@ -115,14 +107,17 @@ func toCompatCard(card *a2a.AgentCard) (*agentCardCompat, error) {
 		SecurityRequirements: card.SecurityRequirements,
 
 		ProtocolVersion:                   Version,
-		URL:                               preferredInterface.URL,
-		PreferredTransport:                preferredInterface.ProtocolBinding,
-		AdditionalInterfaces:              additionalInterfaces,
 		Skills:                            mapToCompatSkills(card.Skills),
 		Security:                          mapToCompatSecurity(card.SecurityRequirements),
 		SecuritySchemes:                   mapToCompatSecuritySchemes(card.SecuritySchemes),
 		SupportsAuthenticatedExtendedCard: card.Capabilities.ExtendedAgentCard,
-	}, nil
+	}
+	if preferredInterface, additionalInterfaces, ok := mapToCompatInterfaces(card); ok {
+		cardCompat.URL = preferredInterface.URL
+		cardCompat.PreferredTransport = preferredInterface.ProtocolBinding
+		cardCompat.AdditionalInterfaces = additionalInterfaces
+	}
+	return cardCompat
 }
 
 func mapFromCompatSecuritySchemes(schemes namedSecuritySchemes) a2a.NamedSecuritySchemes {
@@ -275,12 +270,12 @@ func mapFromCompatInterfaces(card agentCardCompat) []*a2a.AgentInterface {
 	return out
 }
 
-func mapToCompatInterfaces(card *a2a.AgentCard) (*a2a.AgentInterface, []agentInterface, error) {
+func mapToCompatInterfaces(card *a2a.AgentCard) (*a2a.AgentInterface, []agentInterface, bool) {
 	agentInterfaceIdx := slices.IndexFunc(card.SupportedInterfaces, func(i *a2a.AgentInterface) bool {
 		return i.ProtocolVersion == Version
 	})
 	if agentInterfaceIdx == -1 {
-		return nil, nil, fmt.Errorf("at least 1 interface supporting %s must be listed", Version)
+		return nil, nil, false
 	}
 	var additionalInterfaces []agentInterface
 	for i, iface := range card.SupportedInterfaces {
@@ -289,7 +284,7 @@ func mapToCompatInterfaces(card *a2a.AgentCard) (*a2a.AgentInterface, []agentInt
 		}
 		additionalInterfaces = append(additionalInterfaces, agentInterface{URL: iface.URL, Transport: iface.ProtocolBinding})
 	}
-	return card.SupportedInterfaces[agentInterfaceIdx], additionalInterfaces, nil
+	return card.SupportedInterfaces[agentInterfaceIdx], additionalInterfaces, true
 }
 
 func mapFromCompatSkills(skills []agentSkill) []a2a.AgentSkill {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -39,33 +39,44 @@ import (
 func TestDiscover(t *testing.T) {
 	t.Parallel()
 	url := startTestServer(t)
+	legacyURL := startLegacyTestServer(t)
 
-	t.Run("returns agent card", func(t *testing.T) {
-		t.Parallel()
-		out := mustRunCMD(t, "discover", url, "-o", "json")
-		var card a2a.AgentCard
-		if err := json.Unmarshal([]byte(out), &card); err != nil {
-			t.Fatalf("json.Unmarshal(discover output) error = %v", err)
-		}
-		if card.Name != "Test Echo" {
-			t.Fatalf("a2a discover card.Name = %q, want %q", card.Name, "Test Echo")
-		}
-		if !card.Capabilities.Streaming {
-			t.Fatal("a2a discover card.Capabilities.Streaming = false, want true")
-		}
-	})
+	modes := []struct {
+		suffix string
+		url    string
+	}{{suffix: " v1", url: url}, {suffix: " v0", url: legacyURL}}
 
-	t.Run("returns agent card with complete card url", func(t *testing.T) {
-		t.Parallel()
-		out := mustRunCMD(t, "discover", url+"/.well-known/agent-card.json", "-o", "json")
-		var card a2a.AgentCard
-		if err := json.Unmarshal([]byte(out), &card); err != nil {
-			t.Fatalf("json.Unmarshal(discover output) error = %v", err)
-		}
-		if card.Name != "Test Echo" {
-			t.Fatalf("a2a discover card.Name = %q, want %q", card.Name, "Test Echo")
-		}
-	})
+	for _, mode := range modes {
+		t.Run("returns agent card"+mode.suffix, func(t *testing.T) {
+			t.Parallel()
+			out := mustRunCMD(t, "discover", mode.url, "-o", "json")
+			var card a2a.AgentCard
+			if err := json.Unmarshal([]byte(out), &card); err != nil {
+				t.Fatalf("json.Unmarshal(discover output) error = %v", err)
+			}
+			if card.Name != "Test Echo" {
+				t.Errorf("a2a discover card.Name = %q, want %q", card.Name, "Test Echo")
+			}
+			if !card.Capabilities.Streaming {
+				t.Errorf("a2a discover card.Capabilities.Streaming = false, want true")
+			}
+			if len(card.SupportedInterfaces) == 0 {
+				t.Errorf("a2a discover supported interfaces is empty")
+			}
+		})
+
+		t.Run("returns agent card with complete card url"+mode.suffix, func(t *testing.T) {
+			t.Parallel()
+			out := mustRunCMD(t, "discover", mode.url+"/.well-known/agent-card.json", "-o", "json")
+			var card a2a.AgentCard
+			if err := json.Unmarshal([]byte(out), &card); err != nil {
+				t.Fatalf("json.Unmarshal(discover output) error = %v", err)
+			}
+			if card.Name != "Test Echo" {
+				t.Fatalf("a2a discover card.Name = %q, want %q", card.Name, "Test Echo")
+			}
+		})
+	}
 
 	t.Run("missing url fails", func(t *testing.T) {
 		t.Parallel()
@@ -92,7 +103,7 @@ func TestGetCard(t *testing.T) {
 func TestSend(t *testing.T) {
 	t.Parallel()
 	url := startTestServer(t)
-	legacyUrl := startLegacyTestServer(t)
+	legacyURL := startLegacyTestServer(t)
 
 	msgText := "hello hello!"
 	msgJSON := fmt.Sprintf(`{"role":"ROLE_USER","parts":[{"text":"%s"}]}`, msgText)
@@ -161,7 +172,7 @@ func TestSend(t *testing.T) {
 	modes := []struct {
 		suffix string
 		url    string
-	}{{suffix: "_v1", url: url}, {suffix: "_v0", url: legacyUrl}}
+	}{{suffix: "_v1", url: url}, {suffix: "_v0", url: legacyURL}}
 
 	for _, mode := range modes {
 		for _, tt := range sendTests {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -25,8 +26,13 @@ import (
 	"strings"
 	"testing"
 
+	a2acorev0 "github.com/a2aproject/a2a-go/a2a"
+	a2asrvv0 "github.com/a2aproject/a2a-go/a2asrv"
+	"github.com/a2aproject/a2a-go/a2asrv/eventqueue"
+
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2acompat/a2av0"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
 )
 
@@ -86,6 +92,7 @@ func TestGetCard(t *testing.T) {
 func TestSend(t *testing.T) {
 	t.Parallel()
 	url := startTestServer(t)
+	legacyUrl := startLegacyTestServer(t)
 
 	msgText := "hello hello!"
 	msgJSON := fmt.Sprintf(`{"role":"ROLE_USER","parts":[{"text":"%s"}]}`, msgText)
@@ -96,64 +103,86 @@ func TestSend(t *testing.T) {
 
 	sendTests := []struct {
 		name     string
-		args     []string
+		args     func(url string) []string
 		wantText string
 		wantErr  bool
 	}{
 		{
-			name:     "text",
-			args:     []string{"send", url, "-o", "json", msgText},
+			name: "text",
+			args: func(url string) []string {
+				return []string{"send", url, "-o", "json", msgText}
+			},
 			wantText: msgText,
 		},
 		{
-			name:     "parts",
-			args:     []string{"send", url, "-o", "json", "--parts", `[{"text":"part one"},{"text":"part two"}]`},
+			name: "parts",
+			args: func(url string) []string {
+				return []string{"send", url, "-o", "json", "--parts", `[{"text":"part one"},{"text":"part two"}]`}
+			},
 			wantText: "part one part two",
 		},
 		{
-			name:     "message json",
-			args:     []string{"send", url, "-o", "json", "--json", msgJSON},
+			name: "message json",
+			args: func(url string) []string {
+				return []string{"send", url, "-o", "json", "--json", msgJSON}
+			},
 			wantText: msgText,
 		},
 		{
-			name:     "message from file",
-			args:     []string{"send", url, "-o", "json", "-f", path},
+			name: "message from file",
+			args: func(url string) []string {
+				return []string{"send", url, "-o", "json", "-f", path}
+			},
 			wantText: msgText,
 		},
 		{
-			name:    "fails when no message",
-			args:    []string{"send", url},
+			name: "fails when no message",
+			args: func(url string) []string {
+				return []string{"send", url}
+			},
 			wantErr: true,
 		},
 		{
-			name:    "fails when no url",
-			args:    []string{"send"},
+			name: "fails when no url",
+			args: func(url string) []string {
+				return []string{"send"}
+			},
 			wantErr: true,
 		},
 		{
-			name:    "fails on bad --json",
-			args:    []string{"send", url, "--json", "{bad"},
+			name: "fails on bad --json",
+			args: func(url string) []string {
+				return []string{"send", url, "--json", "{bad"}
+			},
 			wantErr: true,
 		},
 	}
-	for _, tt := range sendTests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			out, err := runCMD(t, tt.args...)
-			if err != nil && tt.wantErr {
-				return
-			}
-			if err != nil {
-				t.Fatalf("runCMD(%q) error = %v", strings.Join(tt.args, " "), err)
-			}
-			var task a2a.Task
-			if err := json.Unmarshal([]byte(out), &task); err != nil {
-				t.Fatalf("json.Unmarshal() error = %v", err)
-			}
-			if text := allArtifactText(&task); text != tt.wantText {
-				t.Fatalf("allArtifactText() = %q, want %q", text, tt.wantText)
-			}
-		})
+
+	modes := []struct {
+		suffix string
+		url    string
+	}{{suffix: "_v1", url: url}, {suffix: "_v0", url: legacyUrl}}
+
+	for _, mode := range modes {
+		for _, tt := range sendTests {
+			t.Run(tt.name+mode.suffix, func(t *testing.T) {
+				t.Parallel()
+				out, err := runCMD(t, tt.args(mode.url)...)
+				if err != nil && tt.wantErr {
+					return
+				}
+				if err != nil {
+					t.Fatalf("runCMD(%q) error = %v", strings.Join(tt.args(mode.url), " "), err)
+				}
+				var task a2a.Task
+				if err := json.Unmarshal([]byte(out), &task); err != nil {
+					t.Fatalf("json.Unmarshal() error = %v", err)
+				}
+				if text := allArtifactText(&task); text != tt.wantText {
+					t.Fatalf("allArtifactText() = %q, want %q", text, tt.wantText)
+				}
+			})
+		}
 	}
 }
 
@@ -245,6 +274,28 @@ func startTestServer(t *testing.T) string {
 	return server.URL
 }
 
+func startLegacyTestServer(t *testing.T) string {
+	t.Helper()
+
+	handler := a2asrvv0.NewHandler(&legacyExecutor{})
+
+	mux := http.NewServeMux()
+	mux.Handle("/", a2asrvv0.NewJSONRPCHandler(handler))
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrvv0.NewStaticAgentCardHandler(&a2acorev0.AgentCard{
+		Name:               "Test Echo",
+		Version:            "1.0.0",
+		URL:                server.URL,
+		PreferredTransport: a2acorev0.TransportProtocol(a2a.TransportProtocolJSONRPC),
+		Capabilities:       a2acorev0.AgentCapabilities{Streaming: true},
+	}))
+
+	return server.URL
+}
+
 func sendTestMessage(t *testing.T, url, text string) a2a.TaskID {
 	t.Helper()
 	ctx := t.Context()
@@ -286,4 +337,27 @@ func runCMD(t *testing.T, args ...string) (string, error) {
 	root.SetArgs(args)
 	err := root.Execute()
 	return buf.String(), err
+}
+
+type legacyExecutor struct{}
+
+func (e *legacyExecutor) Execute(ctx context.Context, reqCtx *a2asrvv0.RequestContext, queue eventqueue.Queue) error {
+	if err := queue.Write(ctx, a2acorev0.NewStatusUpdateEvent(reqCtx, a2acorev0.TaskState(a2a.TaskStateSubmitted), nil)); err != nil {
+		return err
+	}
+	msg, err := a2av0.ToV1Message(reqCtx.Message)
+	if err != nil {
+		return err
+	}
+	echo := a2acorev0.TextPart{Text: messageText(msg)}
+	if err := queue.Write(ctx, a2acorev0.NewArtifactEvent(reqCtx, echo)); err != nil {
+		return err
+	}
+	finalEvent := a2acorev0.NewStatusUpdateEvent(reqCtx, a2acorev0.TaskState(a2a.TaskStateCompleted), nil)
+	finalEvent.Final = true
+	return queue.Write(ctx, finalEvent)
+}
+
+func (e *legacyExecutor) Cancel(ctx context.Context, reqCtx *a2asrvv0.RequestContext, queue eventqueue.Queue) error {
+	return fmt.Errorf("not implemented")
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -33,7 +33,7 @@ import (
 	a2agrpc "github.com/a2aproject/a2a-go/v2/a2agrpc/v1"
 )
 
-var cardResolver = func() *agentcard.Resolver {
+var compatCardResolver = func() *agentcard.Resolver {
 	resolver := agentcard.NewResolver(&http.Client{Timeout: 30 * time.Second})
 	resolver.CardParser = a2av0.NewAgentCardParser()
 	return resolver
@@ -62,7 +62,7 @@ func newClient(ctx context.Context, cfg *globalConfig, agentURL string, extraOpt
 	if cfg.auth != "" {
 		resolveOpts = append(resolveOpts, agentcard.WithRequestHeader("Authorization", cfg.auth))
 	}
-	card, err := cardResolver.Resolve(ctx, agentURL, resolveOpts...)
+	card, err := compatCardResolver.Resolve(ctx, agentURL, resolveOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("resolving agent card: %w", err)
 	}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -17,8 +17,10 @@ package cli
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -30,6 +32,12 @@ import (
 	a2agrpcv0 "github.com/a2aproject/a2a-go/v2/a2agrpc/v0"
 	a2agrpc "github.com/a2aproject/a2a-go/v2/a2agrpc/v1"
 )
+
+var cardResolver = func() *agentcard.Resolver {
+	resolver := agentcard.NewResolver(&http.Client{Timeout: 30 * time.Second})
+	resolver.CardParser = a2av0.NewAgentCardParser()
+	return resolver
+}()
 
 func newClient(ctx context.Context, cfg *globalConfig, agentURL string, extraOpts ...a2aclient.FactoryOption) (*a2aclient.Client, error) {
 	factoryOpts := append(clientFactoryOpts(cfg), extraOpts...)
@@ -54,7 +62,7 @@ func newClient(ctx context.Context, cfg *globalConfig, agentURL string, extraOpt
 	if cfg.auth != "" {
 		resolveOpts = append(resolveOpts, agentcard.WithRequestHeader("Authorization", cfg.auth))
 	}
-	card, err := agentcard.DefaultResolver.Resolve(ctx, agentURL, resolveOpts...)
+	card, err := cardResolver.Resolve(ctx, agentURL, resolveOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("resolving agent card: %w", err)
 	}

--- a/internal/cli/discover.go
+++ b/internal/cli/discover.go
@@ -72,7 +72,7 @@ func runDiscover(ctx context.Context, cfg *globalConfig, agentURL string, extend
 		cfg.logf("fetching agent card from %s", agentURL)
 
 		var err error
-		card, err = agentcard.DefaultResolver.Resolve(ctx, agentURL, resolveOpts...)
+		card, err = compatCardResolver.Resolve(ctx, agentURL, resolveOpts...)
 		if err != nil {
 			return fmt.Errorf("failed to resolve agent card: %w", err)
 		}


### PR DESCRIPTION
Use `a2av0.NewAgentCardParser()` so that a2a cli can be used with v0.3 servers when no `--transport` flag is passed.