### PR TITLE
chore: setup goreleaser for cli binary releases

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -12,8 +12,36 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
         with:
           token: ${{ secrets.A2A_BOT_PAT }}
-          release-type: python
+          release-type: go
+
+  goreleaser:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
+        with:
+          distribution: goreleaser
+          version: "v2.17.1"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# GoReleaser build output
+dist/
+
 # Go workspace file
 go.work
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,67 @@
+# GoReleaser configuration for the `a2a` CLI.
+# Docs: https://goreleaser.com
+#
+# Releases are cut by release-please, which creates the git tag and the GitHub
+# Release (with the changelog). This config only cross-compiles the `a2a` binary
+# and uploads the archives + checksums to that existing release.
+version: 2
+
+project_name: a2a
+
+before:
+  hooks:
+    - go mod tidy
+    - go mod download
+
+builds:
+  - id: a2a
+    main: ./cmd/a2a
+    binary: a2a
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/a2aproject/a2a-go/v2/internal/cli.version={{ .Version }}
+      - -X github.com/a2aproject/a2a-go/v2/internal/cli.commit={{ .FullCommit }}
+      - -X github.com/a2aproject/a2a-go/v2/internal/cli.date={{ .Date }}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: a2a
+    ids:
+      - a2a
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+      - README.md
+      - src: cmd/README.md
+        dst: CLI_README.md
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+# release-please owns the release notes
+changelog:
+  disable: true
+
+release:
+  # only attach binaries to the existing release 
+  mode: keep-existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 
 ### Test Writing
 
+* Do not leave comments in tests unless they explain a non-trivial implementation detail. Test name and test case setup should be self-explanatory.
 * ALWAYS use existing test files as a reference when generating new tests. Prioritize files in the same package if they exist.
 * Write "table-driven tests" when logic can be shared across multiple test cases.
 * Prioritize testing observable behavior of exported methods, not the internal state.

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -2,6 +2,16 @@
 
 A command-line interface for the Agent-to-Agent protocol. Link netcat for agents.
 
+## Install
+
+### Prebuilt binaries
+
+Download an archive for your platform from the [latest release](https://github.com/a2aproject/a2a-go/releases/latest), extract
+it, and put the `a2a` binary on your `PATH`. Verify the download against the
+`checksums.txt` published with the release.
+
+### From source
+
 ```bash
 go install github.com/a2aproject/a2a-go/v2/cmd/a2a@latest
 ```

--- a/docs/ai/RELEASE.md
+++ b/docs/ai/RELEASE.md
@@ -1,0 +1,69 @@
+# Release Flow
+
+> **Staleness warning**: if anything described here contradicts observed behavior, re-read
+> the source code / workflow files. This document may be out of date.
+
+This document describes how versioned releases and downloadable CLI binaries are produced.
+
+## Overview
+
+Two tools cooperate, both driven from `.github/workflows/release-please.yaml`:
+
+```
+push to main
+  -> release-please job (googleapis/release-please-action)
+       - maintains a "release PR" that bumps the version + CHANGELOG
+       - when that PR merges: creates the git tag (vX.Y.Z) and the GitHub Release
+         (release notes come from CHANGELOG.md)
+       - emits outputs: release_created, tag_name
+  -> goreleaser job (runs only if release_created == 'true')
+       - checks out the tag_name ref (fetch-depth: 0 so the tag is visible)
+       - runs `goreleaser release --clean` (config: .goreleaser.yaml)
+       - cross-compiles cmd/a2a, builds archives + checksums.txt
+       - uploads the artifacts to the EXISTING GitHub Release
+```
+
+Key point: release-please owns the tag, the release, and the release notes.
+GoReleaser only attaches binaries. This is why `.goreleaser.yaml` sets
+`release.mode: keep-existing` (do not touch the release body) and
+`changelog.disable: true` (do not generate its own changelog).
+
+## Version injection
+
+`internal/cli/version.go` declares build-metadata vars (`version`, `commit`,
+`date`), defaulting to dev values. GoReleaser overwrites them at link time via
+`-ldflags -X github.com/a2aproject/a2a-go/v2/internal/cli.<var>=...`. Because the
+`main` package (`cmd/a2a`) just delegates to `internal/cli`, the ldflags target
+the `internal/cli` package path, NOT `main`.
+
+For `go install <module>@<version>` builds (no ldflags), `buildVersionInfo()`
+falls back to `runtime/debug.ReadBuildInfo()` for the module version.
+
+Surfaced via `a2a version` (text/`-o json`) and the cobra-provided `--version`.
+
+## Build matrix
+
+goos: linux, darwin, windows × goarch: amd64, arm64 (6 archives).
+Unix archives are `tar.gz`; Windows is `zip` (`archives.format_overrides`).
+
+## Local validation
+
+- `goreleaser check` — validate `.goreleaser.yaml`.
+- `goreleaser release --snapshot --clean --skip=publish` — full dry-run build into `dist/`.
+- `actionlint .github/workflows/release-please.yaml` — lint the workflow.
+
+`dist/` is gitignored.
+
+## Gotchas
+
+- The `goreleaser` job uses the default `GITHUB_TOKEN` (needs `contents: write`)
+  to upload assets. The Release itself is created by release-please using
+  `secrets.A2A_BOT_PAT`.
+- Tags are `vX.Y.Z`; GoReleaser strips the `v` for `.Version` (e.g. `2.5.0`).
+- Pin action SHAs (repo convention); the version comment must match the SHA.
+- The GoReleaser *CLI* cannot be pinned to a commit SHA (the action installs
+  released binaries); it is pinned to an exact release tag via the action's
+  `version:` input (e.g. `v2.17.1`). Bump it in lockstep with the config schema.
+- `release-type: go` only updates `CHANGELOG.md` + `.release-please-manifest.json`
+  — Go has no version file to bump, and we don't need one (the version flows from
+  the git tag into the binary via ldflags, and from build info for `go install`).

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -83,6 +83,33 @@ func TestGetCard(t *testing.T) {
 	}
 }
 
+func TestVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("text output", func(t *testing.T) {
+		t.Parallel()
+		out := mustRunCMD(t, "version")
+		if !strings.HasPrefix(out, "a2a ") {
+			t.Fatalf("a2a version output = %q, want it to start with %q", out, "a2a ")
+		}
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		t.Parallel()
+		out := mustRunCMD(t, "version", "-o", "json")
+		var info versionInfo
+		if err := json.Unmarshal([]byte(out), &info); err != nil {
+			t.Fatalf("json.Unmarshal(version output) error = %v", err)
+		}
+		if info.Version == "" {
+			t.Fatalf("a2a version info.Version = %q, want non-empty", info.Version)
+		}
+		if info.GoVersion == "" {
+			t.Fatalf("a2a version info.GoVersion = %q, want non-empty", info.GoVersion)
+		}
+	})
+}
+
 func TestSend(t *testing.T) {
 	t.Parallel()
 	url := startTestServer(t)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,6 +59,7 @@ func newRootCmd(cfg *globalConfig, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "a2a",
 		Short:         "CLI for the Agent-to-Agent protocol",
+		Version:       buildVersionInfo().Version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -81,6 +82,7 @@ func newRootCmd(cfg *globalConfig, out io.Writer) *cobra.Command {
 		newCancelCmd(cfg),
 		newSubscribeCmd(cfg),
 		newServeCmd(cfg),
+		newVersionCmd(cfg),
 	)
 
 	return cmd

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+// Build metadata. These defaults are overwritten at release time using
+// ldflags specified in .goreleaser.yaml.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+type versionInfo struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	Date      string `json:"date"`
+	GoVersion string `json:"goVersion"`
+	Platform  string `json:"platform"`
+}
+
+func buildVersionInfo() versionInfo {
+	v := version
+	if v == "dev" { // go install produces binaries without ldflags
+		if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+			v = bi.Main.Version
+		}
+	}
+	return versionInfo{
+		Version:   v,
+		Commit:    commit,
+		Date:      date,
+		GoVersion: runtime.Version(),
+		Platform:  runtime.GOOS + "/" + runtime.GOARCH,
+	}
+}
+
+func newVersionCmd(cfg *globalConfig) *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			info := buildVersionInfo()
+			if cfg.output == "json" {
+				return printJSON(cfg.out, info)
+			}
+			_, err := fmt.Fprintf(cfg.out,
+				"a2a %s\ncommit:  %s\nbuilt:   %s\ngo:      %s\nos/arch: %s\n",
+				info.Version, info.Commit, info.Date, info.GoVersion, info.Platform)
+			return err
+		},
+	}
+}


### PR DESCRIPTION
Enable goreleaser on CI so that GitHub releases contain prebuilt CLI binaries