### PR TITLE
feat(cli): polling fallback for servers which don't support streaming

### DIFF
--- a/a2aclient/client.go
+++ b/a2aclient/client.go
@@ -229,6 +229,12 @@ func (c *Client) UpdateCard(card *a2a.AgentCard) error {
 	return nil
 }
 
+// Card returns the last AgentCard set on this client or nil if it was created from an [a2a.AgentInterface] handle
+// and was not updated using [Client.UpdateCard].
+func (c *Client) Card() *a2a.AgentCard {
+	return c.card.Load()
+}
+
 // Destroy cleans up resources associated with the client.
 func (c *Client) Destroy() error {
 	return c.transport.Destroy()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -19,12 +19,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	a2acorev0 "github.com/a2aproject/a2a-go/a2a"
 	a2asrvv0 "github.com/a2aproject/a2a-go/a2asrv"
@@ -200,21 +202,63 @@ func TestSend(t *testing.T) {
 func TestSendStreaming(t *testing.T) {
 	t.Parallel()
 	url := startTestServer(t)
-	out := mustRunCMD(t, "send", url, "-o", "json", "--stream", "stream me")
-	dec := json.NewDecoder(strings.NewReader(out))
-	var events []a2a.StreamResponse
-	for dec.More() {
-		var sr a2a.StreamResponse
-		if err := dec.Decode(&sr); err != nil {
-			t.Fatalf("json.Decode(event %d) error = %v", len(events), err)
-		}
-		if sr.Event == nil {
-			t.Fatalf("json.Decode(event %d) produced nil Event", len(events))
-		}
-		events = append(events, sr)
+	nonStreamingServerURL := startTestServerWith(t, a2a.AgentCapabilities{Streaming: false})
+
+	testCases := []struct {
+		name               string
+		command            []string
+		wantPollerFallback bool
+	}{
+		{
+			name:               "streaming supported",
+			command:            []string{"send", url, "-o", "json", "--stream", "stream me"},
+			wantPollerFallback: false,
+		},
+		{
+			name:               "poller fallback with create from card",
+			command:            []string{"send", nonStreamingServerURL, "-o", "json", "--stream", "stream me"},
+			wantPollerFallback: true,
+		},
+		{
+			name:               "poller fallback with create from interface",
+			command:            []string{"send", nonStreamingServerURL, "-o", "json", "--transport", "rest", "--stream", "stream me"},
+			wantPollerFallback: true,
+		},
 	}
-	if len(events) <= 1 {
-		t.Fatalf("a2a send --stream produced %d events, want > 1", len(events))
+	for _, tc := range testCases {
+		fallbackToPoller := false
+		poller := pollerFunc(func(ctx context.Context, client *a2aclient.Client, req *a2a.SendMessageRequest, interval time.Duration) iter.Seq2[a2a.Event, error] {
+			return func(yield func(a2a.Event, error) bool) {
+				fallbackToPoller = true
+				task := &a2a.Task{ID: a2a.NewTaskID(), ContextID: a2a.NewContextID(), Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}}
+				if !yield(task, nil) {
+					return
+				}
+				yield(a2a.NewStatusUpdateEvent(task, a2a.TaskStateCompleted, nil), nil)
+			}
+		})
+		out, err := runCMDWithPoller(t, poller, tc.command...)
+		if err != nil {
+			t.Fatalf("runCMDWithPoller() error = %v", err)
+		}
+		dec := json.NewDecoder(strings.NewReader(out))
+		var events []a2a.StreamResponse
+		for dec.More() {
+			var sr a2a.StreamResponse
+			if err := dec.Decode(&sr); err != nil {
+				t.Fatalf("json.Decode(event %d) error = %v", len(events), err)
+			}
+			if sr.Event == nil {
+				t.Fatalf("json.Decode(event %d) produced nil Event", len(events))
+			}
+			events = append(events, sr)
+		}
+		if len(events) <= 1 {
+			t.Fatalf("a2a send --stream produced %d events, want > 1", len(events))
+		}
+		if fallbackToPoller != tc.wantPollerFallback {
+			t.Fatalf("fallback to poller = %v, want the opposite", fallbackToPoller)
+		}
 	}
 }
 
@@ -264,10 +308,13 @@ func TestGetTask(t *testing.T) {
 
 func startTestServer(t *testing.T) string {
 	t.Helper()
+	return startTestServerWith(t, a2a.AgentCapabilities{Streaming: true})
+}
 
-	handler := a2asrv.NewHandler(&echoExecutor{},
-		a2asrv.WithCapabilityChecks(&a2a.AgentCapabilities{Streaming: true}),
-	)
+func startTestServerWith(t *testing.T, capabilities a2a.AgentCapabilities) string {
+	t.Helper()
+
+	handler := a2asrv.NewHandler(&echoExecutor{}, a2asrv.WithCapabilityChecks(&capabilities))
 
 	mux := http.NewServeMux()
 	mux.Handle("/", a2asrv.NewRESTHandler(handler))
@@ -278,7 +325,7 @@ func startTestServer(t *testing.T) string {
 	mux.Handle(a2asrv.WellKnownAgentCardPath, a2asrv.NewStaticAgentCardHandler(&a2a.AgentCard{
 		Name:                "Test Echo",
 		Version:             "1.0.0",
-		Capabilities:        a2a.AgentCapabilities{Streaming: true},
+		Capabilities:        capabilities,
 		SupportedInterfaces: []*a2a.AgentInterface{a2a.NewAgentInterface(server.URL, a2a.TransportProtocolHTTPJSON)},
 	}))
 
@@ -342,9 +389,14 @@ func mustRunCMD(t *testing.T, args ...string) string {
 
 func runCMD(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	return runCMDWithPoller(t, handlePolling, args...)
+}
+
+func runCMDWithPoller(t *testing.T, poller pollerFunc, args ...string) (string, error) {
+	t.Helper()
 	var buf bytes.Buffer
 	cfg := &globalConfig{}
-	root := newRootCmd(cfg, &buf)
+	root := newRootCmd(cfg, &buf, poller)
 	root.SetArgs(args)
 	err := root.Execute()
 	return buf.String(), err

--- a/internal/cli/polling.go
+++ b/internal/cli/polling.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"time"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+	"github.com/a2aproject/a2a-go/v2/a2aevent"
+)
+
+func handlePolling(ctx context.Context, client *a2aclient.Client, original *a2a.SendMessageRequest, interval time.Duration) iter.Seq2[a2a.Event, error] {
+	return func(yield func(a2a.Event, error) bool) {
+		req := *original
+		if req.Config == nil {
+			req.Config = &a2a.SendMessageConfig{ReturnImmediately: true}
+		} else if !req.Config.ReturnImmediately {
+			config := *original.Config
+			req.Config = &config
+			req.Config.ReturnImmediately = true
+		}
+
+		result, err := client.SendMessage(ctx, &req)
+		if err != nil {
+			yield(nil, fmt.Errorf("failed to send a message: %w", err))
+			return
+		}
+		if !yield(result, nil) {
+			return
+		}
+		if _, ok := result.(*a2a.Message); ok {
+			return
+		}
+		prevState, ok := result.(*a2a.Task)
+		if !ok {
+			yield(nil, fmt.Errorf("unexpected type: %T", result))
+			return
+		}
+		tid := prevState.ID
+
+		successiveFailures := 0
+		for !prevState.Status.State.Terminal() && prevState.Status.State != a2a.TaskStateInputRequired {
+			time.Sleep(interval)
+
+			task, err := client.GetTask(ctx, &a2a.GetTaskRequest{ID: tid})
+			if err != nil {
+				successiveFailures++
+				if successiveFailures == 3 {
+					yield(nil, fmt.Errorf("successive polling failure threshold exceeded for task %q", tid))
+					return
+				}
+				continue
+			}
+			successiveFailures = 0
+
+			var events []a2a.Event
+			if task.Status.State.Terminal() || task.Status.State == a2a.TaskStateInputRequired {
+				events = append(events, task)
+			} else {
+				events = a2aevent.Recover(prevState, task)
+			}
+
+			for _, event := range events {
+				if !yield(event, nil) {
+					return
+				}
+			}
+			prevState = task
+		}
+	}
+}

--- a/internal/cli/polling_test.go
+++ b/internal/cli/polling_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
+)
+
+func TestHandlePolling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		sendResult   a2a.SendMessageResult
+		sendErr      error
+		getResponses []getTaskResponse
+		wantEvents   []a2a.Event
+		wantErr      string
+	}{
+		{
+			name:       "direct message reply stops without polling",
+			sendResult: &a2a.Message{},
+			wantEvents: []a2a.Event{&a2a.Message{}},
+		},
+		{
+			name:    "send failure yields error",
+			sendErr: errors.New("network down"),
+			wantErr: "failed to send a message",
+		},
+		{
+			name:       "terminal task on send stops without polling",
+			sendResult: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
+			wantEvents: []a2a.Event{&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}}},
+		},
+		{
+			name:       "input-required task on send stops without polling",
+			sendResult: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateInputRequired}},
+			wantEvents: []a2a.Event{&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateInputRequired}}},
+		},
+		{
+			name:       "polls until completion recovering intermediate updates",
+			sendResult: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+			getResponses: []getTaskResponse{
+				{task: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}},
+				{task: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}}},
+			},
+			wantEvents: []a2a.Event{
+				&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+				&a2a.TaskStatusUpdateEvent{Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
+				&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
+			},
+		},
+		{
+			name:       "polls until input-required",
+			sendResult: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+			getResponses: []getTaskResponse{
+				{task: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}},
+				{task: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateInputRequired}}},
+			},
+			wantEvents: []a2a.Event{
+				&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+				&a2a.TaskStatusUpdateEvent{Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
+				&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateInputRequired}},
+			},
+		},
+		{
+			name:       "recovers artifact events during transition",
+			sendResult: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+			getResponses: []getTaskResponse{
+				{task: &a2a.Task{
+					Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+					Artifacts: []*a2a.Artifact{
+						{ID: "a-1", Parts: a2a.ContentParts{a2a.NewTextPart("foo")}},
+					},
+				}},
+				{task: &a2a.Task{
+					Status: a2a.TaskStatus{State: a2a.TaskStateWorking},
+					Artifacts: []*a2a.Artifact{
+						{ID: "a-1", Parts: a2a.ContentParts{a2a.NewTextPart("foo"), a2a.NewTextPart("bar")}},
+					},
+				}},
+				{task: &a2a.Task{
+					Status: a2a.TaskStatus{State: a2a.TaskStateCompleted},
+					Artifacts: []*a2a.Artifact{
+						{ID: "a-1", Parts: a2a.ContentParts{a2a.NewTextPart("foo"), a2a.NewTextPart("bar")}},
+					},
+				}},
+			},
+			wantEvents: []a2a.Event{
+				&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+				&a2a.TaskArtifactUpdateEvent{Artifact: &a2a.Artifact{ID: "a-1", Parts: a2a.ContentParts{a2a.NewTextPart("foo")}}},
+				&a2a.TaskArtifactUpdateEvent{
+					Append:   true,
+					Artifact: &a2a.Artifact{ID: "a-1", Parts: a2a.ContentParts{a2a.NewTextPart("bar")}},
+				},
+				&a2a.TaskStatusUpdateEvent{Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
+				&a2a.Task{
+					Status: a2a.TaskStatus{State: a2a.TaskStateCompleted},
+					Artifacts: []*a2a.Artifact{
+						{ID: "a-1", Parts: a2a.ContentParts{a2a.NewTextPart("foo"), a2a.NewTextPart("bar")}},
+					},
+				},
+			},
+		},
+		{
+			name:       "transient failures below threshold recover",
+			sendResult: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+			getResponses: []getTaskResponse{
+				{err: errors.New("temporary 1")},
+				{err: errors.New("temporary 2")},
+				{task: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateWorking}}},
+				{err: errors.New("temporary 3")},
+				{task: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}}},
+			},
+			wantEvents: []a2a.Event{
+				&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+				&a2a.TaskStatusUpdateEvent{Status: a2a.TaskStatus{State: a2a.TaskStateWorking}},
+				&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateCompleted}},
+			},
+		},
+		{
+			name:       "successive failures exceed threshold",
+			sendResult: &a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}},
+			getResponses: []getTaskResponse{
+				{err: errors.New("temporary 1")},
+				{err: errors.New("temporary 2")},
+				{err: errors.New("temporary 3")},
+			},
+			wantEvents: []a2a.Event{&a2a.Task{Status: a2a.TaskStatus{State: a2a.TaskStateSubmitted}}},
+			wantErr:    "successive polling failure threshold exceeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transport := &fakePollingTransport{
+				sendResult:   tt.sendResult,
+				sendErr:      tt.sendErr,
+				getResponses: tt.getResponses,
+			}
+			client := newPollingClient(t, transport)
+			req := &a2a.SendMessageRequest{Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("go"))}
+
+			gotEvents, err := drainAll(handlePolling(t.Context(), client, req, 0))
+
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("handlePolling() error = %v, want nil", err)
+			}
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("handlePolling() error = nil, want error containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("handlePolling() error = %v, want error containing %q", err, tt.wantErr)
+				}
+			}
+
+			if diff := cmp.Diff(tt.wantEvents, gotEvents); diff != "" {
+				t.Fatalf("handlePolling() events wrong result (-want +got) diff = %s", diff)
+			}
+		})
+	}
+}
+
+func TestHandlePolling_SetsReturnImmediately(t *testing.T) {
+	t.Parallel()
+
+	for _, config := range []*a2a.SendMessageConfig{nil, {}} {
+		transport := &fakePollingTransport{sendResult: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("hi"))}
+		client := newPollingClient(t, transport)
+		req := &a2a.SendMessageRequest{
+			Message: a2a.NewMessage(a2a.MessageRoleUser, a2a.NewTextPart("go")),
+			Config:  config,
+		}
+
+		if _, err := drainAll(handlePolling(t.Context(), client, req, 0)); err != nil {
+			t.Fatalf("handlePolling() error = %v, want nil", err)
+		}
+
+		if config == nil && req.Config != nil {
+			t.Error("handlePolling() changed input request")
+		}
+		if config != nil && config.ReturnImmediately {
+			t.Error("handlePolling() changed input config")
+		}
+		if transport.sendRequest.Config == nil || !transport.sendRequest.Config.ReturnImmediately {
+			t.Error("handlePolling() send request without ReturnImmediately = true")
+		}
+	}
+}
+
+type getTaskResponse struct {
+	task *a2a.Task
+	err  error
+}
+
+type fakePollingTransport struct {
+	a2aclient.Transport
+
+	sendResult a2a.SendMessageResult
+	sendErr    error
+
+	getResponses []getTaskResponse
+	getCalls     int
+
+	sendRequest *a2a.SendMessageRequest
+}
+
+func (f *fakePollingTransport) SendMessage(ctx context.Context, c a2aclient.ServiceParams, req *a2a.SendMessageRequest) (a2a.SendMessageResult, error) {
+	f.sendRequest = req
+	if f.sendErr != nil {
+		return nil, f.sendErr
+	}
+	return f.sendResult, nil
+}
+
+func (f *fakePollingTransport) GetTask(context.Context, a2aclient.ServiceParams, *a2a.GetTaskRequest) (*a2a.Task, error) {
+	i := f.getCalls
+	f.getCalls++
+	if i >= len(f.getResponses) {
+		return nil, fmt.Errorf("ran out of getResponses")
+	}
+	r := f.getResponses[i]
+	return r.task, r.err
+}
+
+func newPollingClient(t *testing.T, transport a2aclient.Transport) *a2aclient.Client {
+	t.Helper()
+	iface := a2a.NewAgentInterface("https://agent.test", a2a.TransportProtocolJSONRPC)
+	client, err := a2aclient.NewFromEndpoints(t.Context(),
+		[]*a2a.AgentInterface{iface},
+		a2aclient.WithTransport(a2a.TransportProtocolJSONRPC,
+			a2aclient.TransportFactoryFn(func(context.Context, *a2a.AgentCard, *a2a.AgentInterface) (a2aclient.Transport, error) {
+				return transport, nil
+			})),
+	)
+	if err != nil {
+		t.Fatalf("a2aclient.NewFromEndpoints() error = %v", err)
+	}
+	return client
+}
+
+func drainAll(seq iter.Seq2[a2a.Event, error]) ([]a2a.Event, error) {
+	var events []a2a.Event
+	var gotErr error
+	for e, err := range seq {
+		if err != nil {
+			gotErr = err
+			break
+		}
+		events = append(events, e)
+	}
+	return events, gotErr
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,7 +45,7 @@ func (g *globalConfig) logf(format string, args ...any) {
 // Execute runs the CLI and returns the exit code.
 func Execute() int {
 	cfg := &globalConfig{}
-	root := newRootCmd(cfg, os.Stdout)
+	root := newRootCmd(cfg, os.Stdout, handlePolling)
 	if err := root.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
@@ -53,7 +53,7 @@ func Execute() int {
 	return 0
 }
 
-func newRootCmd(cfg *globalConfig, out io.Writer) *cobra.Command {
+func newRootCmd(cfg *globalConfig, out io.Writer, poller pollerFunc) *cobra.Command {
 	cfg.out = out
 
 	cmd := &cobra.Command{
@@ -75,7 +75,7 @@ func newRootCmd(cfg *globalConfig, out io.Writer) *cobra.Command {
 
 	cmd.AddCommand(
 		newDiscoverCmd(cfg),
-		newSendCmd(cfg),
+		newSendCmd(cfg, poller),
 		newGetCmd(cfg),
 		newListCmd(cfg),
 		newCancelCmd(cfg),

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -17,25 +17,32 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"iter"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2aclient"
 )
 
-func newSendCmd(cfg *globalConfig) *cobra.Command {
+type pollerFunc func(ctx context.Context, client *a2aclient.Client, req *a2a.SendMessageRequest, interval time.Duration) iter.Seq2[a2a.Event, error]
+
+func newSendCmd(cfg *globalConfig, poller pollerFunc) *cobra.Command {
 	var (
-		stream    bool
-		immediate bool
-		jsonBody  string
-		partsJSON string
-		file      string
-		taskID    string
-		contextID string
-		history   int
+		stream          bool
+		immediate       bool
+		jsonBody        string
+		partsJSON       string
+		file            string
+		taskID          string
+		contextID       string
+		history         int
+		pollingInterval time.Duration
 	)
 
 	cmd := &cobra.Command{
@@ -43,6 +50,10 @@ func newSendCmd(cfg *globalConfig) *cobra.Command {
 		Short: "Send a message to an agent",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if stream && immediate {
+				return fmt.Errorf("--stream is incomaptible with --immediate")
+			}
+
 			msg, err := buildMessage(args[1:], jsonBody, partsJSON, file)
 			if err != nil {
 				return err
@@ -80,12 +91,15 @@ func newSendCmd(cfg *globalConfig) *cobra.Command {
 			}
 
 			if stream {
-				for event, err := range client.SendStreamingMessage(ctx, req) {
-					if err != nil {
-						return fmt.Errorf("streaming error: %w", err)
+				if err := handleStreaming(ctx, cfg, client, req); err != nil {
+					if !errors.Is(err, a2a.ErrUnsupportedOperation) {
+						return err
 					}
-					if err := cfg.printEvent(event); err != nil {
-						return fmt.Errorf("failed to print event: %w", err)
+					cfg.logf("falling back to polling (%v): %v", pollingInterval, err)
+					for event, err := range poller(ctx, client, req, pollingInterval) {
+						if err := handleStreamEntry(cfg, event, err); err != nil {
+							return err
+						}
 					}
 				}
 				return nil
@@ -103,7 +117,7 @@ func newSendCmd(cfg *globalConfig) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&stream, "stream", false, "Use streaming response")
+	f.BoolVar(&stream, "stream", false, "Use streaming response. Falls back to polling and synthetic events if a server does not support streaming.")
 	f.BoolVar(&immediate, "immediate", false, "Return immediately (fire-and-forget)")
 	f.StringVar(&jsonBody, "json", "", "Raw JSON Message object")
 	f.StringVar(&partsJSON, "parts", "", "Raw JSON parts array")
@@ -111,8 +125,31 @@ func newSendCmd(cfg *globalConfig) *cobra.Command {
 	f.StringVar(&taskID, "task", "", "Task ID to continue an existing task")
 	f.StringVar(&contextID, "context", "", "Context ID")
 	f.IntVar(&history, "history", 0, "Request n history messages in the response")
+	f.DurationVar(&pollingInterval, "polling-interval", 5*time.Second, "Duration between GetTask requests in polling fallback mode.")
 
 	return cmd
+}
+
+func handleStreaming(ctx context.Context, cfg *globalConfig, client *a2aclient.Client, req *a2a.SendMessageRequest) error {
+	if card := client.Card(); card != nil && !card.Capabilities.Streaming {
+		return fmt.Errorf("streaming not listed in agent capabilities: %w", a2a.ErrUnsupportedOperation)
+	}
+	for event, err := range client.SendStreamingMessage(ctx, req) {
+		if err := handleStreamEntry(cfg, event, err); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func handleStreamEntry(cfg *globalConfig, event a2a.Event, err error) error {
+	if err != nil {
+		return fmt.Errorf("streaming error: %w", err)
+	}
+	if err := cfg.printEvent(event); err != nil {
+		return fmt.Errorf("failed to print event: %w", err)
+	}
+	return nil
 }
 
 func buildMessage(positional []string, jsonBody, partsJSON, file string) (*a2a.Message, error) {


### PR DESCRIPTION
When cli is invoked in `a2a send --stream` for a server which doesn't support streaming we fallback to polling busy loop which emits synthetic events based on task state diff. 