### PR TITLE
feat: make agentcard resolver handler file://

### DIFF
--- a/a2aclient/agentcard/doc.go
+++ b/a2aclient/agentcard/doc.go
@@ -31,5 +31,9 @@ By default the request is sent for a well-known card location, but this can be c
 		a2aclient.WithPath(customPath),
 		a2aclient.WithHeader(key, value),
 	)
+
+A file:// URL can be used to load the card from the local file system instead of over HTTP.
+
+	card, err := resolver.Resolve(ctx, "file:///path/to/agent-card.json")
 */
 package agentcard

--- a/a2aclient/agentcard/resolver.go
+++ b/a2aclient/agentcard/resolver.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -80,6 +81,8 @@ type resolveRequest struct {
 // Resolve fetches an [a2a.AgentCard] from the provided URL (base URL or complete agent card URL).
 // By default, if the provided URL has no path or a root path, the request is sent for the /.well-known/agent-card.json path.
 // If the provided URL contains a non-root path, it is fetched directly as the complete agent card URL.
+// A file:// URL is supported to load the card from the local file system, in which case
+// the card is read directly from the referenced path and request headers are ignored.
 func (r *Resolver) Resolve(ctx context.Context, baseURL string, opts ...ResolveOption) (*a2a.AgentCard, error) {
 	reqSpec := &resolveRequest{headers: make(map[string]string)}
 	for _, o := range opts {
@@ -89,6 +92,19 @@ func (r *Resolver) Resolve(ctx context.Context, baseURL string, opts ...ResolveO
 	reqURL, err := buildURL(baseURL, reqSpec.path)
 	if err != nil {
 		return nil, err
+	}
+
+	u, err := url.Parse(reqURL)
+	if err != nil {
+		return nil, fmt.Errorf("url parsing failed: %w", err)
+	}
+
+	if u.Scheme == "file" {
+		body, err := readCardFile(u)
+		if err != nil {
+			return nil, err
+		}
+		return r.parseCard(body)
 	}
 
 	client := r.Client
@@ -153,6 +169,26 @@ func fetchCard(ctx context.Context, client *http.Client, reqURL string, headers 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read card response: %w", err)
+	}
+	return body, nil
+}
+
+func readCardFile(u *url.URL) ([]byte, error) {
+	if u.Host != "" && u.Host != "localhost" {
+		return nil, fmt.Errorf("unsupported file URL host %q, only an empty host or localhost is allowed", u.Host)
+	}
+
+	path := u.Path
+	if path == "" {
+		path = u.Opaque
+	}
+	if path == "" {
+		return nil, fmt.Errorf("file URL %q has no path", u)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read card file: %w", err)
 	}
 	return body, nil
 }

--- a/a2aclient/agentcard/resolver_test.go
+++ b/a2aclient/agentcard/resolver_test.go
@@ -19,6 +19,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -183,6 +186,71 @@ func TestResolver_MalformedJSON(t *testing.T) {
 	got, err := resolver.Resolve(t.Context(), url)
 	if err == nil {
 		t.Fatalf("expected Resolve() to fail on malformed response, got: %v", got)
+	}
+}
+
+func TestResolver_FileURL(t *testing.T) {
+	t.Parallel()
+	want := &a2a.AgentCard{Name: "TestResolver_FileURL"}
+	dir := t.TempDir()
+	cardPath := filepath.Join(dir, "agent-card.json")
+	if err := os.WriteFile(cardPath, mustMarshal(t, want), 0o600); err != nil {
+		t.Fatalf("failed to write card file: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		url       *url.URL
+		opts      []ResolveOption
+		wantErr   bool
+		wantErrIs error
+	}{
+		{
+			name:      "missing file",
+			url:       &url.URL{Scheme: "file", Path: filepath.Join(dir, "missing.json")},
+			wantErr:   true,
+			wantErrIs: os.ErrNotExist,
+		},
+		{
+			name:    "unsupported host",
+			url:     &url.URL{Scheme: "file", Host: "remotehost", Path: "/agent-card.json"},
+			wantErr: true,
+		},
+		{
+			name: "empty host",
+			url:  &url.URL{Scheme: "file", Path: cardPath},
+		},
+		{
+			name: "localhost",
+			url:  &url.URL{Scheme: "file", Host: "localhost", Path: cardPath},
+		},
+		{
+			name: "path as option",
+			url:  &url.URL{Scheme: "file", Host: "localhost", Path: dir},
+			opts: []ResolveOption{WithPath("agent-card.json")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := DefaultResolver.Resolve(t.Context(), tt.url.String(), tt.opts...)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Resolve(%s) = %v, want error", tt.url, got)
+				}
+				if tt.wantErrIs != nil && !errors.Is(err, tt.wantErrIs) {
+					t.Errorf("Resolve(%s) error = %v, want error matching %v", tt.url, err, tt.wantErrIs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve(%s) error = %v, want nil", tt.url, err)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("Resolve(%s) wrong result (-want +got) diff = %s", tt.url, diff)
+			}
+		})
 	}
 }
 

--- a/a2aclient/agentcard/resolver_test.go
+++ b/a2aclient/agentcard/resolver_test.go
@@ -61,10 +61,10 @@ func mustServe(t *testing.T, path string, body []byte, callback func(r *http.Req
 
 func TestResolver_DefaultPath(t *testing.T) {
 	want := &a2a.AgentCard{Name: "TestResolver_DefaultPath"}
-	url := mustServe(t, defaultAgentCardPath, mustMarshal(t, want), nil)
+	cardURL := mustServe(t, defaultAgentCardPath, mustMarshal(t, want), nil)
 	resolver := Resolver{}
 
-	for _, u := range []string{url, url + "/"} {
+	for _, u := range []string{cardURL, cardURL + "/"} {
 		got, err := resolver.Resolve(t.Context(), u)
 		if err != nil {
 			t.Fatalf("Resolve(%s) failed with: %v", u, err)
@@ -136,10 +136,10 @@ func TestResolver_CustomPath(t *testing.T) {
 	ctx := t.Context()
 	path := "/custom/agent.json"
 	want := &a2a.AgentCard{Name: "TestResolver_DefaultPath"}
-	url := mustServe(t, path, mustMarshal(t, want), nil)
+	cardURL := mustServe(t, path, mustMarshal(t, want), nil)
 
 	resolver := Resolver{}
-	got, err := resolver.Resolve(ctx, url)
+	got, err := resolver.Resolve(ctx, cardURL)
 	var httpErr *ErrStatusNotOK
 	if err == nil || !errors.As(err, &httpErr) {
 		t.Fatalf("expected Resolve() to fail with ErrStatusNotOK, got %v, %v", got, err)
@@ -149,7 +149,7 @@ func TestResolver_CustomPath(t *testing.T) {
 	}
 
 	for _, p := range []string{path, strings.TrimPrefix(path, "/")} {
-		got, err = resolver.Resolve(ctx, url, WithPath(p))
+		got, err = resolver.Resolve(ctx, cardURL, WithPath(p))
 		if err != nil {
 			t.Fatalf("Resolve(%s) failed with %v", p, err)
 		}
@@ -164,12 +164,12 @@ func TestResolver_CustomHeader(t *testing.T) {
 
 	capturedHeader := []string{}
 	card := &a2a.AgentCard{Name: "TestResolver_CustomHeader"}
-	url := mustServe(t, defaultAgentCardPath, mustMarshal(t, card), func(req *http.Request) {
+	cardURL := mustServe(t, defaultAgentCardPath, mustMarshal(t, card), func(req *http.Request) {
 		capturedHeader = req.Header[h]
 	})
 
 	resolver := NewResolver(nil)
-	_, err := resolver.Resolve(t.Context(), url, WithRequestHeader(h, hval))
+	_, err := resolver.Resolve(t.Context(), cardURL, WithRequestHeader(h, hval))
 	if err != nil {
 		t.Fatalf("Resolve() failed with: %v", err)
 	}
@@ -180,10 +180,10 @@ func TestResolver_CustomHeader(t *testing.T) {
 }
 
 func TestResolver_MalformedJSON(t *testing.T) {
-	url := mustServe(t, defaultAgentCardPath, []byte(`}{`), nil)
+	cardURL := mustServe(t, defaultAgentCardPath, []byte(`}{`), nil)
 
 	resolver := NewResolver(nil)
-	got, err := resolver.Resolve(t.Context(), url)
+	got, err := resolver.Resolve(t.Context(), cardURL)
 	if err == nil {
 		t.Fatalf("expected Resolve() to fail on malformed response, got: %v", got)
 	}


### PR DESCRIPTION
This can be useful for CLI cases with agent card present locally. 