### PR TITLE
fix: align ListTasks timestamp query parameter

### DIFF
--- a/a2aclient/rest.go
+++ b/a2aclient/rest.go
@@ -200,7 +200,7 @@ func (t *RESTTransport) GetTask(ctx context.Context, params ServiceParams, req *
 	path := rest.MakeGetTaskPath(string(req.ID))
 	q := url.Values{}
 	if req.HistoryLength != nil {
-		q.Add("historyLength", strconv.Itoa(*req.HistoryLength))
+		q.Add(rest.QueryHistoryLength, strconv.Itoa(*req.HistoryLength))
 	}
 	if encoded := q.Encode(); encoded != "" {
 		path += "?" + encoded
@@ -225,25 +225,25 @@ func (t *RESTTransport) ListTasks(ctx context.Context, params ServiceParams, req
 
 	query := url.Values{}
 	if req.ContextID != "" {
-		query.Add("contextId", string(req.ContextID))
+		query.Add(rest.QueryContextID, string(req.ContextID))
 	}
 	if req.Status != "" {
-		query.Add("status", string(req.Status))
+		query.Add(rest.QueryStatus, string(req.Status))
 	}
 	if req.PageSize != 0 {
-		query.Add("pageSize", strconv.Itoa(req.PageSize))
+		query.Add(rest.QueryPageSize, strconv.Itoa(req.PageSize))
 	}
 	if req.PageToken != "" {
-		query.Add("pageToken", string(req.PageToken))
+		query.Add(rest.QueryPageToken, string(req.PageToken))
 	}
 	if req.HistoryLength != nil {
-		query.Add("historyLength", strconv.Itoa(*req.HistoryLength))
+		query.Add(rest.QueryHistoryLength, strconv.Itoa(*req.HistoryLength))
 	}
 	if req.StatusTimestampAfter != nil {
-		query.Add("lastUpdatedAfter", req.StatusTimestampAfter.Format(time.RFC3339))
+		query.Add(rest.QueryStatusTimestampAfter, req.StatusTimestampAfter.Format(time.RFC3339))
 	}
 	if req.IncludeArtifacts {
-		query.Add("includeArtifacts", "true")
+		query.Add(rest.QueryIncludeArtifacts, "true")
 	}
 
 	if encoded := query.Encode(); encoded != "" {

--- a/a2aclient/rest_test.go
+++ b/a2aclient/rest_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/google/go-cmp/cmp"
@@ -115,6 +116,57 @@ func TestRESTTransport_ListTasks(t *testing.T) {
 
 	if diff := cmp.Diff(listTasksResult, wantResult); diff != "" {
 		t.Errorf("ListTasks() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRESTTransport_ListTasks_QueryParams(t *testing.T) {
+	t.Parallel()
+
+	cutoff := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	historyLength := 7
+	var gotQuery url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected method GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/tasks" {
+			t.Errorf("expected path /tasks, got %s", r.URL.Path)
+		}
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tasks":[]}`))
+	}))
+	defer server.Close()
+
+	transport := newRESTTransport(t, server)
+	_, err := transport.ListTasks(t.Context(), ServiceParams{}, &a2a.ListTasksRequest{
+		ContextID:            "ctx-999",
+		Status:               a2a.TaskStateWorking,
+		PageSize:             25,
+		PageToken:            "next-page",
+		HistoryLength:        &historyLength,
+		StatusTimestampAfter: &cutoff,
+		IncludeArtifacts:     true,
+	})
+	if err != nil {
+		t.Fatalf("ListTasks() error = %v, want nil", err)
+	}
+
+	want := url.Values{
+		"contextId":            []string{"ctx-999"},
+		"status":               []string{string(a2a.TaskStateWorking)},
+		"pageSize":             []string{"25"},
+		"pageToken":            []string{"next-page"},
+		"historyLength":        []string{"7"},
+		"statusTimestampAfter": []string{cutoff.Format(time.RFC3339)},
+		"includeArtifacts":     []string{"true"},
+	}
+	if diff := cmp.Diff(want, gotQuery); diff != "" {
+		t.Fatalf("ListTasks() wrong result (-want +got) diff = %s", diff)
+	}
+	if got := gotQuery.Get("lastUpdatedAfter"); got != "" {
+		t.Fatalf("ListTasks() lastUpdatedAfter = %q, want empty", got)
 	}
 }
 

--- a/a2asrv/rest.go
+++ b/a2asrv/rest.go
@@ -136,7 +136,7 @@ func (h *restHandler) handleGetTask(taskID string, rw http.ResponseWriter, req *
 		return
 	}
 
-	historyLength, err := parseIntOpt(req.URL.Query(), "historyLength")
+	historyLength, err := parseIntOpt(req.URL.Query(), rest.QueryHistoryLength)
 	if err != nil {
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(taskID))
 		return
@@ -163,35 +163,35 @@ func (h *restHandler) handleListTasks(rw http.ResponseWriter, req *http.Request)
 	ctx := req.Context()
 	query := req.URL.Query()
 
-	pageSize, err := parseInt(query, "pageSize")
+	pageSize, err := parseInt(query, rest.QueryPageSize)
 	if err != nil {
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
 		return
 	}
 
-	includeArtifacts, err := parseBool(query, "includeArtifacts")
+	includeArtifacts, err := parseBool(query, rest.QueryIncludeArtifacts)
 	if err != nil {
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
 		return
 	}
 
-	historyLength, err := parseIntOpt(query, "historyLength")
+	historyLength, err := parseIntOpt(query, rest.QueryHistoryLength)
 	if err != nil {
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
 		return
 	}
 
-	statusTimestampAfter, err := parseTimeOpt(query, "statusTimestampAfter")
+	statusTimestampAfter, err := parseTimeOpt(query, rest.QueryStatusTimestampAfter)
 	if err != nil {
 		writeRESTError(ctx, rw, a2a.ErrInvalidRequest, a2a.TaskID(""))
 		return
 	}
 
 	request := &a2a.ListTasksRequest{
-		ContextID:            query.Get("contextId"),
-		Status:               a2a.TaskState(query.Get("status")),
+		ContextID:            query.Get(rest.QueryContextID),
+		Status:               a2a.TaskState(query.Get(rest.QueryStatus)),
 		PageSize:             pageSize,
-		PageToken:            query.Get("pageToken"),
+		PageToken:            query.Get(rest.QueryPageToken),
 		HistoryLength:        historyLength,
 		StatusTimestampAfter: statusTimestampAfter,
 		IncludeArtifacts:     includeArtifacts,

--- a/a2asrv/rest_test.go
+++ b/a2asrv/rest_test.go
@@ -652,6 +652,47 @@ func TestREST_ListTasks_Success(t *testing.T) {
 	}
 }
 
+func TestREST_ListTasks_ClientRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	var capturedReq *a2a.ListTasksRequest
+	mock := &mockRequestHandler{
+		listTasksFunc: func(ctx context.Context, req *a2a.ListTasksRequest) (*a2a.ListTasksResponse, error) {
+			capturedReq = req
+			return &a2a.ListTasksResponse{}, nil
+		},
+	}
+	server := httptest.NewServer(NewRESTHandler(mock))
+	t.Cleanup(server.Close)
+
+	iface := a2a.NewAgentInterface(server.URL, a2a.TransportProtocolHTTPJSON)
+	client, err := a2aclient.NewFromEndpoints(t.Context(), []*a2a.AgentInterface{iface})
+	if err != nil {
+		t.Fatalf("a2aclient.NewFromEndpoints() error = %v, want nil", err)
+	}
+
+	cutoff := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	historyLength := 100
+	req := &a2a.ListTasksRequest{
+		ContextID:            "ctx-999",
+		Status:               a2a.TaskStateWorking,
+		PageSize:             50,
+		PageToken:            "next-page-token",
+		HistoryLength:        &historyLength,
+		StatusTimestampAfter: &cutoff,
+		IncludeArtifacts:     true,
+	}
+	if _, err := client.ListTasks(t.Context(), req); err != nil {
+		t.Fatalf("client.ListTasks() error = %v, want nil", err)
+	}
+	if capturedReq == nil {
+		t.Fatal("expected request to be captured, but got nil")
+	}
+	if diff := cmp.Diff(req, capturedReq); diff != "" {
+		t.Fatalf("ListTasks() wrong result (-want +got) diff = %s", diff)
+	}
+}
+
 func TestREST_GetTask_Success(t *testing.T) {
 	var capturedReq *a2a.GetTaskRequest
 

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -30,6 +30,17 @@ import (
 	"github.com/a2aproject/a2a-go/v2/internal/utils"
 )
 
+// Query parameter names for the v1 HTTP+JSON binding.
+const (
+	QueryContextID            = "contextId"
+	QueryStatus               = "status"
+	QueryPageSize             = "pageSize"
+	QueryPageToken            = "pageToken"
+	QueryHistoryLength        = "historyLength"
+	QueryStatusTimestampAfter = "statusTimestampAfter"
+	QueryIncludeArtifacts     = "includeArtifacts"
+)
+
 // PathBuilder constructs REST paths for A2A endpoints, optionally rooted
 // under a version prefix. The zero value builds v1.0 paths (no prefix); the
 // v0.3 compat binding uses NewPathBuilder("/v1") to prepend "/v1" to every


### PR DESCRIPTION
# Description

The v1 REST `ListTasks` client was sending the cutoff as `lastUpdatedAfter`. That is the v0 name. The v1 server reads `statusTimestampAfter`, which matches `ListTasksRequest` (`json:"statusTimestampAfter"`) and the proto field `status_timestamp_after`.

So a caller that passed `StatusTimestampAfter` got a query string the handler ignored. The cutoff came through as unset. JSON-RPC and gRPC were fine because they use the struct/proto field. The v0 compat path still uses `lastUpdatedAfter` on purpose and is unchanged.

## What changed

- `a2aclient/rest.go` now emits `statusTimestampAfter`.
- `a2asrv/rest.go` reads the same names.
- `internal/rest/rest.go` holds shared query-parameter constants (`QueryStatusTimestampAfter`, `QueryPageSize`, and the rest) so client and server cannot drift again.
- `a2aclient/rest_test.go` checks the serialized query, including `statusTimestampAfter`.
- `a2asrv/rest_test.go` runs a client-to-`NewRESTHandler` round trip and asserts the captured request got the cutoff.

## How I tested

```
go test -race -count=1 -shuffle=on ./a2aclient -run 'TestRESTTransport_ListTasks'
go test -race -count=1 -shuffle=on ./a2asrv -run 'TestREST_ListTasks'
```
