### PR TITLE
fix: compare recovery timestamps by value

### DIFF
--- a/a2aevent/diff.go
+++ b/a2aevent/diff.go
@@ -17,6 +17,7 @@ package a2aevent
 import (
 	"reflect"
 	"slices"
+	"time"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 )
@@ -97,7 +98,14 @@ func hasStatusChanged(prevState *a2a.Task, state *a2a.Task) bool {
 	return s1.State != s2.State ||
 		((s1.Message != nil) != (s2.Message != nil)) ||
 		(s1.Message != nil && s1.Message.ID != s2.Message.ID) ||
-		s1.Timestamp != s2.Timestamp
+		!timestampsEqual(s1.Timestamp, s2.Timestamp)
+}
+
+func timestampsEqual(t1, t2 *time.Time) bool {
+	if t1 == nil || t2 == nil {
+		return t1 == t2
+	}
+	return t1.Equal(*t2)
 }
 
 type partsDiff struct {

--- a/a2aevent/diff_test.go
+++ b/a2aevent/diff_test.go
@@ -29,7 +29,17 @@ func TestRecover(t *testing.T) {
 
 	tip, ti := newTestTaskInfo()
 	ts := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	tsCopy := ts
 	m1 := &a2a.Message{ID: "m1", Role: a2a.MessageRoleAgent, Parts: makeTextParts("first")}
+
+	timestamped := &a2a.Task{
+		ContextID: ti.ContextID, ID: ti.TaskID,
+		Status: a2a.TaskStatus{State: a2a.TaskStateWorking, Timestamp: &ts},
+	}
+	timestampedCopy, err := utils.DeepCopy(timestamped)
+	if err != nil {
+		t.Fatalf("utils.DeepCopy() error = %v, want nil", err)
+	}
 
 	testCases := []struct {
 		name string
@@ -159,6 +169,38 @@ func TestRecover(t *testing.T) {
 			},
 		},
 		{
+			name: "equal timestamp values, different pointers",
+			prev: &a2a.Task{
+				ContextID: ti.ContextID, ID: ti.TaskID,
+				Status: a2a.TaskStatus{State: a2a.TaskStateWorking, Timestamp: &ts},
+			},
+			curr: &a2a.Task{
+				ContextID: ti.ContextID, ID: ti.TaskID,
+				Status: a2a.TaskStatus{State: a2a.TaskStateWorking, Timestamp: &tsCopy},
+			},
+			want: nil,
+		},
+		{
+			name: "nil vs set timestamp",
+			prev: newTask(tip, a2a.TaskStateWorking),
+			curr: &a2a.Task{
+				ContextID: ti.ContextID, ID: ti.TaskID,
+				Status: a2a.TaskStatus{State: a2a.TaskStateWorking, Timestamp: &ts},
+			},
+			want: []a2a.Event{
+				&a2a.TaskStatusUpdateEvent{
+					ContextID: ti.ContextID, TaskID: ti.TaskID,
+					Status: a2a.TaskStatus{State: a2a.TaskStateWorking, Timestamp: &ts},
+				},
+			},
+		},
+		{
+			name: "deep copy of timestamped task",
+			prev: timestamped,
+			curr: timestampedCopy,
+			want: nil,
+		},
+		{
 			name: "task metadata change",
 			prev: &a2a.Task{
 				ContextID: ti.ContextID, ID: ti.TaskID,
@@ -241,6 +283,8 @@ func TestRecover_ReappliedEventsReproduceState(t *testing.T) {
 	t.Parallel()
 
 	tip, ti := newTestTaskInfo()
+	ts := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	tsCopy := ts
 	m1 := &a2a.Message{ID: "m1", Role: a2a.MessageRoleAgent, Parts: makeTextParts("first")}
 	m2 := &a2a.Message{ID: "m2", Role: a2a.MessageRoleAgent, Parts: makeTextParts("second")}
 
@@ -253,6 +297,17 @@ func TestRecover_ReappliedEventsReproduceState(t *testing.T) {
 			name: "no changes",
 			prev: newTask(tip, a2a.TaskStateWorking, &a2a.Artifact{ID: "a1", Parts: makeTextParts("Hello")}),
 			curr: newTask(tip, a2a.TaskStateWorking, &a2a.Artifact{ID: "a1", Parts: makeTextParts("Hello")}),
+		},
+		{
+			name: "no changes with timestamps",
+			prev: &a2a.Task{
+				ID: ti.TaskID, ContextID: ti.ContextID,
+				Status: a2a.TaskStatus{State: a2a.TaskStateWorking, Message: m1, Timestamp: &ts},
+			},
+			curr: &a2a.Task{
+				ID: ti.TaskID, ContextID: ti.ContextID,
+				Status: a2a.TaskStatus{State: a2a.TaskStateWorking, Message: m1, Timestamp: &tsCopy},
+			},
 		},
 		{
 			name: "all possible changes",


### PR DESCRIPTION
## Summary

`a2aevent.Recover` compared `TaskStatus.Timestamp` pointers by identity in `hasStatusChanged`. Separately allocated timestamps representing the same instant were therefore treated as a status change, causing duplicate `TaskStatusUpdateEvent` values during polling and replay.

This changes `a2aevent/diff.go` to compare non-nil timestamps with `time.Time.Equal` while preserving nil handling. The cases in `a2aevent/diff_test.go` cover equal values with different pointers, nil versus set timestamps, deep-copied tasks, and replay of an unchanged timestamped task.

## Testing

- `go test -race -count=1 -shuffle=on ./a2aevent -run 'TestRecover'`
- `go test -race -count=1 -shuffle=on ./internal/cli -run 'TestPolling'`
