### PR TITLE
fix(a2a): decode ProtoJSON security scopes

### DIFF
--- a/a2a/auth.go
+++ b/a2a/auth.go
@@ -79,6 +79,30 @@ type SecuritySchemeName string
 // SecuritySchemeScopes is a list of scopes a security credential must be covering.
 type SecuritySchemeScopes []string
 
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *SecuritySchemeScopes) UnmarshalJSON(b []byte) error {
+	var scopes []string
+	if err := json.Unmarshal(b, &scopes); err == nil {
+		*s = scopes
+		return nil
+	}
+
+	var wrapped struct {
+		List json.RawMessage `json:"list"`
+	}
+	if err := json.Unmarshal(b, &wrapped); err != nil {
+		return err
+	}
+	if wrapped.List == nil {
+		return fmt.Errorf("security scheme scopes object is missing the list field")
+	}
+	if err := json.Unmarshal(wrapped.List, &scopes); err != nil {
+		return err
+	}
+	*s = scopes
+	return nil
+}
+
 // NamedSecuritySchemes is a declaration of the security schemes available to authorize requests.
 // The key is the scheme name. Follows the OpenAPI 3.0 Security Scheme Object.
 type NamedSecuritySchemes map[SecuritySchemeName]SecurityScheme

--- a/a2a/auth.go
+++ b/a2a/auth.go
@@ -88,18 +88,12 @@ func (s *SecuritySchemeScopes) UnmarshalJSON(b []byte) error {
 	}
 
 	var wrapped struct {
-		List json.RawMessage `json:"list"`
+		List []string `json:"list"`
 	}
 	if err := json.Unmarshal(b, &wrapped); err != nil {
 		return err
 	}
-	if wrapped.List == nil {
-		return fmt.Errorf("security scheme scopes object is missing the list field")
-	}
-	if err := json.Unmarshal(wrapped.List, &scopes); err != nil {
-		return err
-	}
-	*s = scopes
+	*s = wrapped.List
 	return nil
 }
 

--- a/a2a/auth_test.go
+++ b/a2a/auth_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 The A2A Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package a2a
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSecurityRequirementsOptionsUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		json string
+		want SecurityRequirementsOptions
+	}{
+		{
+			name: "protojson scopes wrapper",
+			json: `[{"schemes":{"oauth2":{"list":["openid","profile"]}}}]`,
+			want: SecurityRequirementsOptions{
+				{"oauth2": {"openid", "profile"}},
+			},
+		},
+		{
+			name: "legacy scopes array",
+			json: `[{"schemes":{"oauth2":["openid","profile"]}}]`,
+			want: SecurityRequirementsOptions{
+				{"oauth2": {"openid", "profile"}},
+			},
+		},
+		{
+			name: "empty protojson scopes wrapper",
+			json: `[{"schemes":{"apiKey":{"list":[]}}}]`,
+			want: SecurityRequirementsOptions{
+				{"apiKey": {}},
+			},
+		},
+		{
+			name: "mixed protojson and legacy scopes",
+			json: `[{"schemes":{"oauth2":{"list":["openid"]},"apiKey":[]}}]`,
+			want: SecurityRequirementsOptions{
+				{"oauth2": {"openid"}, "apiKey": {}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got SecurityRequirementsOptions
+			if err := json.Unmarshal([]byte(tc.json), &got); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v, want nil", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("json.Unmarshal() wrong result (-want +got) diff = %s", diff)
+			}
+		})
+	}
+}
+
+func TestSecurityRequirementsOptionsUnmarshalJSONRejectsInvalidScopesWrapper(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "missing list field",
+			json: `[{"schemes":{"oauth2":{}}}]`,
+		},
+		{
+			name: "list is not an array",
+			json: `[{"schemes":{"oauth2":{"list":"openid"}}}]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got SecurityRequirementsOptions
+			if err := json.Unmarshal([]byte(tc.json), &got); err == nil {
+				t.Fatal("json.Unmarshal() error = nil, want non-nil")
+			}
+		})
+	}
+}

--- a/a2a/auth_test.go
+++ b/a2a/auth_test.go
@@ -51,6 +51,13 @@ func TestSecurityRequirementsOptionsUnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "protojson empty message",
+			json: `[{"schemes":{"apiKey":{}}}]`,
+			want: SecurityRequirementsOptions{
+				{"apiKey": nil},
+			},
+		},
+		{
 			name: "mixed protojson and legacy scopes",
 			json: `[{"schemes":{"oauth2":{"list":["openid"]},"apiKey":[]}}]`,
 			want: SecurityRequirementsOptions{
@@ -81,10 +88,6 @@ func TestSecurityRequirementsOptionsUnmarshalJSONRejectsInvalidScopesWrapper(t *
 		name string
 		json string
 	}{
-		{
-			name: "missing list field",
-			json: `[{"schemes":{"oauth2":{}}}]`,
-		},
 		{
 			name: "list is not an array",
 			json: `[{"schemes":{"oauth2":{"list":"openid"}}}]`,


### PR DESCRIPTION
## Summary

This fixes Agent Card decoding when a security requirement uses the A2A v1.0 ProtoJSON representation for `StringList`:

```json
{"schemes":{"oauth2":{"list":["openid","profile"]}}}
```

`SecuritySchemeScopes` was previously decoded only as a bare JSON array, so a spec-compliant `{"list": [...]}` value failed before `SecurityRequirementsOptions.UnmarshalJSON` could construct the requirement map.

The new `SecuritySchemeScopes.UnmarshalJSON` accepts both representations:

- the ProtoJSON wrapper required by the v1.0 `StringList` message; and
- the existing bare-array representation, preserving compatibility with cards produced by older SDK behavior.

This is intentionally a decode-only compatibility change. It does not change the SDK's current marshal shape or any public Go type.

## Tests

- Added table-driven regressions for the ProtoJSON wrapper, the legacy array, an explicit empty list, a ProtoJSON zero-value message with the repeated field omitted, and mixed wrapper/array schemes in one requirement.
- Added a negative case proving a non-array `list` value still returns a decoding error.
- Confirmed the ProtoJSON case fails before the implementation and passes afterward.
- Ran `go test ./a2a -count=1`.
- Ran `go vet ./a2a`.
- Ran the full repository suite with `go test ./... -count=1`.
- Ran `git diff --check`.

Fixes #430
